### PR TITLE
GUI-200

### DIFF
--- a/koala/forms/snapshots.py
+++ b/koala/forms/snapshots.py
@@ -25,7 +25,6 @@ class SnapshotForm(BaseSecureForm):
     description = wtforms.TextAreaField(
         label=_(u'Description'),
         validators=[
-            validators.Required(message=desc_error_msg),
             validators.Length(max=255, message=_(u'Description must be less than 255 characters'))
         ],
     )

--- a/koala/forms/volumes.py
+++ b/koala/forms/volumes.py
@@ -44,7 +44,11 @@ class VolumeForm(BaseSecureForm):
 
         if conn is not None:
             self.set_volume_snapshot_choices()
-            self.set_availability_zone_choices()
+            zones = self.conn.get_all_zones()
+            self.set_availability_zone_choices(zones)
+            # default to first zone if new volume, and at least one zone in list
+            if volume is None and len(zones) > 0:
+                self.zone.data = zones[0].name
 
     def set_volume_snapshot_choices(self):
         choices = [('', _(u'None'))]
@@ -55,9 +59,9 @@ class VolumeForm(BaseSecureForm):
             choices.append((value, label))
         self.snapshot_id.choices = sorted(choices)
 
-    def set_availability_zone_choices(self):
+    def set_availability_zone_choices(self, zones):
         choices = [('', _(u'select...'))]
-        for zone in self.conn.get_all_zones():
+        for zone in zones:
             choices.append((zone.name, zone.name))
         self.zone.choices = sorted(choices)
 
@@ -127,7 +131,6 @@ class AttachForm(BaseSecureForm):
         if len(choices) == 1:
             choices = [('', _(u'No available volumes in the availability zone'))]
         self.instance_id.choices = choices
-
 
 class DetachForm(BaseSecureForm):
     """CSRF-protected form to detach a volume from an instance"""

--- a/koala/templates/instances/instance_volumes.pt
+++ b/koala/templates/instances/instance_volumes.pt
@@ -6,7 +6,7 @@
 </head>
 
 <div metal:fill-slot="main_content">
-    <div class="row" id="contentwrap" ng-app="InstanceVolumes" tal:define="instance_name instance.tags.get('Name', instance.id)"
+    <div class="row" id="contentwrap" ng-app="InstanceVolumes"
          ng-controller="InstanceVolumesCtrl"
          ng-init="initController('${request.route_url('instance_volumes_json', id=instance.id)}')">
         <h3 class="header" id="pagetitle">
@@ -115,7 +115,7 @@
             <div id="detach-volume-modal" class="reveal-modal small" data-reveal="">
                 <h3 i18n:translate="">Detach volume</h3>
                 <p>
-                    <span i18n:translate="">Are you sure you want to detach the volume from instance</span>
+                    <span i18n:translate="">Are you sure you want to detach the volume from instance</span><br/>
                     <strong>${instance_name}</strong>?
                 </p>
                 <form method="post" id="detach-form" data-abide="" action="{{ detachFormAction }}">

--- a/koala/templates/volumes/volume_view.pt
+++ b/koala/templates/volumes/volume_view.pt
@@ -11,7 +11,7 @@
 </head>
 
 <div metal:fill-slot="main_content">
-    <div class="row" id="contentwrap" tal:define="volume_name volume.tags.get('Name', volume.id) if volume else ''"
+    <div class="row" id="contentwrap"
          ng-app="VolumePage" ng-controller="VolumePageCtrl"
          ng-init="initController('${request.route_url(
                  'volume_state_json', id=volume.id) if volume else ''}',
@@ -79,7 +79,7 @@
                          tal:condition="instance_id">
                         <div class="small-4 columns"><label i18n:translate="">Attached to instance</label></div>
                         <div class="small-8 columns value">
-                            <a href="${request.route_url('instance_view', id=instance_id)}">${instance_id}</a>
+                            <a href="${request.route_url('instance_view', id=instance_id)}">${instance_name}</a>
                         </div>
                     </div>
                     ${panel('form_field', field=volume_form['name'], **html_attrs)}
@@ -196,7 +196,10 @@
         </div>
         <div id="detach-modal" class="reveal-modal small" tal:condition="volume" data-reveal="">
             <h3 i18n:translate="">Detach volume</h3>
-            <p><span i18n:translate="">Are you sure you want to detach the volume from the instance</span>?</p>
+            <p>
+              <span i18n:translate="">Are you sure you want to detach the volume from the instance</span><br/>
+              <strong>${instance_name}</strong>?
+            </p>
             <form method="post" id="detach-form" data-abide="" action="${request.route_url('volume_detach', id=volume.id)}">
                 ${structure:detach_form['csrf_token']}
                 <div>&nbsp;</div>

--- a/koala/views/instances.py
+++ b/koala/views/instances.py
@@ -266,9 +266,13 @@ class InstanceVolumesView(BaseView):
         self.instance = self.get_instance()
         self.attach_form = AttachVolumeForm(
             self.request, conn=self.conn, instance=self.instance, formdata=self.request.params or None)
+        self.inst_name_tag = self.instance.tags.get('Name', '') if self.instance else None
+        self.instance_name = '{}{}'.format(
+            self.instance.id, ' ({})'.format(self.inst_name_tag) if self.inst_name_tag else '') if self.instance else ''
         self.detach_form = DetachVolumeForm(self.request, formdata=self.request.params or None)
         self.render_dict = dict(
             instance=self.instance,
+            instance_name=self.instance_name,
             attach_form=self.attach_form,
             detach_form=self.detach_form,
         )


### PR DESCRIPTION
implemented changes from UI review, detailed in issue
- default to first AZ
- don't require description on snapshot
- suggested device name should be default. Only works when instance known, no client side updates for attach to arbitrary instance from volume page
- should list instance and volume on dialog (fixed on instance and volume detail pages)
- It would be great to list volume ID as well as the name (which is listed) (also fixed on vol detail page)
