### PR TITLE
Fixes the indentation for the ini file example in README.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -95,6 +95,9 @@ The `--reload` flag instructs Pyramid to automatically watch for changes in the 
 
 The Pyramid Debug Toolbar can be enabled by adding pyramid_debugtoolbar to the app:main section of console.ini
 
+
+::
+
     [app:main]
     # ...
     pyramid.includes =


### PR DESCRIPTION
Creates proper indentation for the ini file example within README.rst
