### PR TITLE
Remove blue title bars everywhere

### DIFF
--- a/koala/static/css/pages/instance_launch.css
+++ b/koala/static/css/pages/instance_launch.css
@@ -1,5 +1,5 @@
 /* @section Wizard styles */
-.wizard { position: relative; background-color: #eeeeee; }
+.wizard { position: relative; background-color: #eeeeee; padding-top: 16px; }
 .wizard.has-title { position: relative; padding-top: 42px; }
 .wizard.has-title h6.title { position: absolute; text-transform: uppercase; letter-spacing: 1px; top: 0; left: 0; right: 0; line-height: 2.5rem; padding-left: 12px; background-color: #00415e; color: white; overflow: hidden; white-space: nowrap; text-overflow: ellipsis; }
 .wizard .row.controls-wrapper.readonly { margin-bottom: 0.5rem; }
@@ -10,7 +10,7 @@
 .wizard .tabs-content { min-height: 400px; margin: 0 0 0 0; padding: 1rem; background-color: white; border-right: 16px solid #eeeeee; border-left: 16px solid #eeeeee; }
 .wizard .tabs-content .content { width: 100%; }
 
-.summary { position: relative; padding-bottom: 2rem; top: 2px; background-color: #eeeeee; border-top: 8px solid #00415e; }
+.summary { position: relative; top: 2px; padding-top: 8px; padding-bottom: 2rem; background-color: #eeeeee; }
 .summary label { position: relative; right: -1rem; color: #00415e; font-weight: bold; }
 .summary .value { word-break: break-all; }
 .summary .row { margin-bottom: 5px; }

--- a/koala/static/css/pages/launchconfig_wizard.css
+++ b/koala/static/css/pages/launchconfig_wizard.css
@@ -1,5 +1,5 @@
 /* @section Wizard styles */
-.wizard { position: relative; background-color: #eeeeee; }
+.wizard { position: relative; background-color: #eeeeee; padding-top: 16px; }
 .wizard.has-title { position: relative; padding-top: 42px; }
 .wizard.has-title h6.title { position: absolute; text-transform: uppercase; letter-spacing: 1px; top: 0; left: 0; right: 0; line-height: 2.5rem; padding-left: 12px; background-color: #00415e; color: white; overflow: hidden; white-space: nowrap; text-overflow: ellipsis; }
 .wizard .row.controls-wrapper.readonly { margin-bottom: 0.5rem; }
@@ -10,7 +10,7 @@
 .wizard .tabs-content { min-height: 400px; margin: 0 0 0 0; padding: 1rem; background-color: white; border-right: 16px solid #eeeeee; border-left: 16px solid #eeeeee; }
 .wizard .tabs-content .content { width: 100%; }
 
-.summary { position: relative; padding-bottom: 2rem; top: 2px; background-color: #eeeeee; border-top: 8px solid #00415e; }
+.summary { position: relative; top: 2px; padding-top: 8px; padding-bottom: 2rem; background-color: #eeeeee; }
 .summary label { position: relative; right: -1rem; color: #00415e; font-weight: bold; }
 .summary .value { word-break: break-all; }
 .summary .row { margin-bottom: 5px; }

--- a/koala/static/css/pages/login.css
+++ b/koala/static/css/pages/login.css
@@ -1,7 +1,7 @@
 /* @fileOverview Login page CSS */
 #notifications-wrapper { margin-top: 2rem; }
 
-#login-wrapper { position: relative; margin-top: 3rem; background-color: #f6f6f6; padding: 10px; padding-top: 44px; box-shadow: 0 3px 6px #999999; }
+#login-wrapper { position: relative; margin-top: 3rem; background-color: #eeeeee; padding: 10px; box-shadow: 0 3px 6px #999999; }
 #login-wrapper label { font-weight: bold; white-space: nowrap; vertical-align: middle; position: relative; top: 0px; left: 0px; bottom: 10px; }
 #login-wrapper input { background-color: #eeeeee; }
 #login-wrapper .hide-aws { max-width: 480px; margin: 0 auto; }

--- a/koala/static/css/pages/scalinggroup_wizard.css
+++ b/koala/static/css/pages/scalinggroup_wizard.css
@@ -1,5 +1,5 @@
 /* @section Wizard styles */
-.wizard { position: relative; background-color: #eeeeee; }
+.wizard { position: relative; background-color: #eeeeee; padding-top: 16px; }
 .wizard.has-title { position: relative; padding-top: 42px; }
 .wizard.has-title h6.title { position: absolute; text-transform: uppercase; letter-spacing: 1px; top: 0; left: 0; right: 0; line-height: 2.5rem; padding-left: 12px; background-color: #00415e; color: white; overflow: hidden; white-space: nowrap; text-overflow: ellipsis; }
 .wizard .row.controls-wrapper.readonly { margin-bottom: 0.5rem; }
@@ -10,7 +10,7 @@
 .wizard .tabs-content { min-height: 400px; margin: 0 0 0 0; padding: 1rem; background-color: white; border-right: 16px solid #eeeeee; border-left: 16px solid #eeeeee; }
 .wizard .tabs-content .content { width: 100%; }
 
-.summary { position: relative; padding-bottom: 2rem; top: 2px; background-color: #eeeeee; border-top: 8px solid #00415e; }
+.summary { position: relative; top: 2px; padding-top: 8px; padding-bottom: 2rem; background-color: #eeeeee; }
 .summary label { position: relative; right: -1rem; color: #00415e; font-weight: bold; }
 .summary .value { word-break: break-all; }
 .summary .row { margin-bottom: 5px; }

--- a/koala/static/sass/includes/_wizard.scss
+++ b/koala/static/sass/includes/_wizard.scss
@@ -8,6 +8,7 @@ $wizard-border-width: 16px;
 .wizard {
     position: relative;
     background-color: $euca-extralightgrey;
+    padding-top: $wizard-border-width;
     &.has-title {
         position: relative;
         padding-top: 42px;
@@ -69,10 +70,10 @@ $wizard-border-width: 16px;
 
 .summary {
     position: relative;
-    padding-bottom: 2rem;
     top: 2px;
+    padding-top: 8px;
+    padding-bottom: 2rem;
     background-color: $euca-extralightgrey;
-    border-top: 8px solid $euca-darkblue;
     label {
         position: relative;
         right: -1rem;

--- a/koala/static/sass/pages/login.scss
+++ b/koala/static/sass/pages/login.scss
@@ -8,9 +8,8 @@
 #login-wrapper {
     position: relative;
     margin-top: 3rem;
-    background-color: lighten($euca-extralightgrey, 3%);
+    background-color: $euca-extralightgrey;
     padding: 10px;
-    padding-top: 44px;
     box-shadow: 0 3px 6px $euca-grey;
     label {
         font-weight: bold;

--- a/koala/templates/images/image_view.pt
+++ b/koala/templates/images/image_view.pt
@@ -3,9 +3,12 @@
 <div metal:fill-slot="main_content">
     <div class="row" id="contentwrap">
         <h3 class="header" id="pagetitle">
-            <a class="back-arrow" href="${request.route_url('images')}"
-               data-tooltip="" title="Back to images" i18n:attributes="title">&lt;</a>
-            <span i18n:translate="">Image</span> ${image.id if image else ''}
+            <metal:breadcrumbs metal:use-macro="layout.global_macros['breadcrumbs']">
+                <metal:crumbs metal:fill-slot="crumbs">
+                    <li><a href="${request.route_url('images')}" i18n:translate="">Images</a></li>
+                    <li class="current"><a href="#">${image.id}</a></li>
+                </metal:crumbs>
+            </metal:breadcrumbs>
         </h3>
         <!-- Notifications -->
         <metal:block metal:use-macro="layout.global_macros['notifications']" />
@@ -13,17 +16,8 @@
         <div class="large-7 columns"
             tal:define="image_tags image.tags if image else {};
                         readonly True if image else False;">
-            <div class="panel has-title">
-                <h6 class="title">
-                    <span tal:condition="image">
-                        <span i18n:translate="">Properties of image</span>
-                        <strong>${image.id }</strong>
-                    </span>
-                    <span tal:condition="not image" i18n:translate="">
-                        Error 
-                    </span>
-                </h6>
-                <form action="${request.route_url('image_update', id=image.id)}" method="post" data-abide="abide"> 
+            <div class="panel no-title">
+                <form action="${request.route_url('image_update', id=image.id)}" method="post" data-abide="abide">
                     ${structure:image_form['csrf_token']}
                     <div tal:condition="image">
                         <div class="section">
@@ -141,8 +135,7 @@
             </div>
         </div>
         <div class="large-5 columns">
-            <div class="panel has-title" tal:condition="image">
-                <h6 class="title" i18n:translate="">Other image actions</h6>
+            <div class="panel no-title" tal:condition="image">
                 <div class="row">
                     <div class="large-12 columns">
                         <a href="${request.route_url('instance_create')}?image_id=${image.id}"

--- a/koala/templates/instances/instance_launch.pt
+++ b/koala/templates/instances/instance_launch.pt
@@ -19,8 +19,7 @@
         <!-- Notifications -->
         <metal:block metal:use-macro="layout.global_macros['notifications']" />
         <div class="large-8 columns" tal:define="_ import: pyramid.i18n.TranslationString">
-            <div class="wizard has-title">
-                <h6 class="title" i18n:translate="">Launch instance</h6>
+            <div class="wizard no-title">
                 <form action="${request.route_url('instance_launch')}" id="launch-instance-form"
                       method="post" data-abide="abide" enctype="multipart/form-data">
                     ${structure:launch_form['csrf_token']}

--- a/koala/templates/instances/instance_volumes.pt
+++ b/koala/templates/instances/instance_volumes.pt
@@ -26,11 +26,7 @@
         <metal:block metal:use-macro="layout.global_macros['notifications']" />
 
         <div class="large-8 columns" tal:define="parse_date import: dateutil.parser.parse">
-            <div class="panel gridwrapper has-title">
-                <h6 class="title">
-                    <span i18n:translate="">Volumes for instance</span>
-                    <strong>${instance_name}</strong>
-                </h6>
+            <div class="panel gridwrapper no-title">
                 <div class="tile add" id="attach-volume">
                     <a href="#" data-reveal-id="attach-volume-modal">
                         <div class="plus">+</div>

--- a/koala/templates/ipaddresses/ipaddress_view.pt
+++ b/koala/templates/ipaddresses/ipaddress_view.pt
@@ -19,11 +19,7 @@
             </metal:breadcrumbs>
         </h3>
         <div class="large-7 columns">
-            <div class="panel has-title">
-                <h6 class="title">
-                    <span i18n:translate="">Elastic IP</span>
-                    ${eip.public_ip}
-                </h6>
+            <div class="no-title">
                 <div tal:condition="not eip.instance_id">
                     <p i18n:translate="">The IP address is not associated with any instances.</p>
                     <a class="button secondary" data-reveal-id="associate-ip-modal" id="associate-btn" i18n:translate="">

--- a/koala/templates/keypairs/keypair_view.pt
+++ b/koala/templates/keypairs/keypair_view.pt
@@ -1,12 +1,17 @@
 <metal:block use-macro="main_template">
 
 <div metal:fill-slot="main_content">
-    <div class="row" id="contentwrap">
+    <div class="row" id="contentwrap"
+            tal:define="html_attrs {'disabled': 'disabled'} if keypair else {};">
         <h3 class="header" id="pagetitle">
             <metal:breadcrumbs metal:use-macro="layout.global_macros['breadcrumbs']">
                 <metal:crumbs metal:fill-slot="crumbs">
                     <li><a href="${request.route_url('keypairs')}" i18n:translate="">Key Pairs</a></li>
-                    <li class="current"><a href="#">${keypair.name if keypair else 'Create key pair'}</a></li>
+                    <li class="current">
+                        <a tal:condition="keypair">${keypair.name }</a>
+                        <a tal:condition="not keypair and keypair_route_id == 'new'" i18n:translate="">Create new keypair</a>
+                        <a tal:condition="not keypair and keypair_route_id == 'new2'" i18n:translate="">Import public key</a>
+                    </li>
                 </metal:crumbs>
             </metal:breadcrumbs>
         </h3>
@@ -26,22 +31,8 @@
            </script>
         </div>
 
-        <div class="large-7 columns"
-            tal:define="html_attrs {'disabled': 'disabled'} if keypair else {};
-                        route_id keypair_route_id if keypair_route_id else '';">
-            <div class="panel has-title">
-                <h6 class="title">
-                    <span tal:condition="keypair">
-                        <span i18n:translate="">Properties of keypair</span>
-                        <strong>${keypair.name }</strong>
-                    </span>
-                    <span tal:condition="not keypair and route_id == 'new'" i18n:translate="">
-                        Create new keypair 
-                    </span>
-                    <span tal:condition="not keypair and route_id == 'new2'" i18n:translate="">
-                        Import public key 
-                    </span>
-                </h6>
+        <div class="large-7 columns">
+            <div class="panel no-title">
                 <div tal:condition="keypair">
                     <div class="row controls-wrapper readonly">
                         <div class="small-3 columns"><label i18n:translate="">Name</label></div>
@@ -52,7 +43,7 @@
                         <div class="small-9 columns value">${keypair.fingerprint if keypair.fingerprint else ''}</div>
                     </div>
                 </div>
-                <div tal:condition="not keypair and route_id == 'new'" i18n:translate="">
+                <div tal:condition="not keypair and keypair_route_id == 'new'" i18n:translate="">
                     <div>
                         <span i18n:translate="">
                             You can use this key pair to launch more than one instance.
@@ -88,7 +79,7 @@
                     </div>
                      </form>
                  </div>
-                <div tal:condition="not keypair and route_id == 'new2'" i18n:translate="">
+                <div tal:condition="not keypair and keypair_route_id == 'new2'" i18n:translate="">
                     <div>
                         <span i18n:translate="">
                             Importing a public key allows you to use an existing SSH key to access your Eucalyptus instances.
@@ -133,8 +124,7 @@
             </div>
         </div>
         <div class="large-5 columns">
-            <div class="panel has-title" tal:condition="keypair">
-                <h6 class="title" i18n:translate="">Other keypair actions</h6>
+            <div class="panel no-title" tal:condition="keypair">
                 <div class="row">
                     <div class="large-3 columns">&nbsp;</div>
                     <div class="large-9 columns">

--- a/koala/templates/keypairs/keypairs.pt
+++ b/koala/templates/keypairs/keypairs.pt
@@ -23,6 +23,7 @@
             <div metal:fill-slot="new_button">
                 <a class="button small" i18n:translate="" id="create-keypair-btn"
                     href="${request.route_url('keypair_view', id='new')}">Create new key pair</a>
+                &nbsp;&nbsp;
                 <a class="button small" i18n:translate=""
                     href="${request.route_url('keypair_view', id='new2')}">Import public key</a>
             </div>

--- a/koala/templates/launchconfigs/launchconfig_view.pt
+++ b/koala/templates/launchconfigs/launchconfig_view.pt
@@ -105,8 +105,7 @@
             </div>
         </div>
         <div class="large-5 columns">
-            <div class="panel has-title">
-                <h6 class="title" i18n:translate="">Other launch configuration actions</h6>
+            <div class="panel no-title">
                 <div class="row">
                     <div class="large-1 columns">&nbsp;</div>
                     <div class="large-11 columns">

--- a/koala/templates/launchconfigs/launchconfig_wizard.pt
+++ b/koala/templates/launchconfigs/launchconfig_wizard.pt
@@ -20,8 +20,7 @@
         <!-- Notifications -->
         <metal:block metal:use-macro="layout.global_macros['notifications']" />
         <div class="large-8 columns" tal:define="_ import: pyramid.i18n.TranslationString">
-            <div class="wizard has-title">
-                <h6 class="title" i18n:translate="">Create Launch Configuration</h6>
+            <div class="wizard no-title">
                 <form action="${request.route_url('launchconfig_create')}" id="launch-config-form"
                       method="post" data-abide="abide" enctype="multipart/form-data">
                     ${structure:create_form['csrf_token']}

--- a/koala/templates/login.pt
+++ b/koala/templates/login.pt
@@ -26,17 +26,13 @@
         </div>
     </div>
 
-    <div class="row panel has-title large-8 columns large-centered" id="login-wrapper"
+    <div class="row panel no-title large-8 columns large-centered" id="login-wrapper"
          ng-app="LoginPage" ng-controller="LoginPageCtrl" ng-init="initController()">
-        <h6 class="title" i18n:translate="">
-            <span i18n:translate="">Log in to Eucalyptus</span>
-            <span tal:condition="layout.aws_enabled" i18n:translate="">or AWS</span>
-        </h6>
         <div class="large-12 large-centered columns">
             <div class="row" id="login-forms">
                 <dl class="tabs" id="login-tabs" data-tab="">
-                    <dd id="euca-tab" class="active"><a href="#eucalyptus" i18n:translate="">Eucalyptus</a></dd>
-                    <dd id="aws-tab" tal:condition="layout.aws_enabled"><a href="#aws" i18n:translate="">AWS</a></dd>
+                    <dd id="euca-tab" class="active"><a href="#eucalyptus" i18n:translate="">Log in to Eucalyptus</a></dd>
+                    <dd id="aws-tab" tal:condition="layout.aws_enabled"><a href="#aws" i18n:translate="">Log in to AWS</a></dd>
                 </dl>
                 <div class="tabs-content">
                     <div class="content active large-8 medium-8 columns large-centered medium-centered" id="eucalyptus">

--- a/koala/templates/scalinggroups/scalinggroup_instances.pt
+++ b/koala/templates/scalinggroups/scalinggroup_instances.pt
@@ -17,7 +17,7 @@
             </metal:breadcrumbs>
         </h3>
         <dl class="sub-nav" id="scalinggroup-subnav">
-            <dd><a href="${request.route_url('scalinggroup_view', id=scaling_group.name)}" i18n:translate="">Scaling Group</a></dd>
+            <dd><a href="${request.route_url('scalinggroup_view', id=scaling_group.name)}" i18n:translate="">General</a></dd>
             <dd><a href="${request.route_url('scalinggroup_policies', id=scaling_group.name)}" i18n:translate="">Policies</a></dd>
             <dd class="active"><a href="#">Instances</a></dd>
         </dl>
@@ -25,11 +25,7 @@
         <metal:block metal:use-macro="layout.global_macros['notifications']" />
 
         <div class="large-8 columns">
-            <div class="panel gridwrapper has-title">
-                <h6 class="title">
-                    <span i18n:translate="">Instances in scaling group</span>
-                    <strong>${scaling_group.name}</strong>
-                </h6>
+            <div class="panel gridwrapper no-title">
                 <div ng-show="initialLoading">
                     <span class="dots">&nbsp;</span>
                 </div>

--- a/koala/templates/scalinggroups/scalinggroup_policies.pt
+++ b/koala/templates/scalinggroups/scalinggroup_policies.pt
@@ -17,7 +17,7 @@
             </metal:breadcrumbs>
         </h3>
         <dl class="sub-nav" id="scalinggroup-subnav">
-            <dd><a href="${request.route_url('scalinggroup_view', id=scaling_group.name)}" i18n:translate="">Scaling Group</a></dd>
+            <dd><a href="${request.route_url('scalinggroup_view', id=scaling_group.name)}" i18n:translate="">General</a></dd>
             <dd class="active"><a href="#" i18n:translate="">Policies</a></dd>
             <dd><a href="${request.route_url('scalinggroup_instances', id=scaling_group.name)}">Instances</a></dd>
         </dl>
@@ -25,11 +25,7 @@
         <metal:block metal:use-macro="layout.global_macros['notifications']" />
 
         <div class="large-8 columns">
-            <div class="panel gridwrapper has-title">
-                <h6 class="title">
-                    <span i18n:translate="">Policies for scaling group</span>
-                    <strong>${scaling_group.name}</strong>
-                </h6>
+            <div class="panel gridwrapper no-title">
                 <div class="tile add" id="add-policy">
                     <a href="${request.route_url('scalinggroup_policy_new', id=scaling_group.name)}">
                         <div class="plus">+</div>

--- a/koala/templates/scalinggroups/scalinggroup_policy.pt
+++ b/koala/templates/scalinggroups/scalinggroup_policy.pt
@@ -12,12 +12,12 @@
                     <li><a href="${request.route_url('scalinggroups')}" i18n:translate="">Scaling groups</a></li>
                     <li><a href="${request.route_url('scalinggroup_view', id=scaling_group.name)}">${scaling_group.name}</a></li>
                     <li><a href="${request.route_url('scalinggroup_policies', id=scaling_group.name)}" i18n:translate="">Policies</a></li>
-                    <li class="current"><a href="#">Add policy</a></li>
+                    <li class="current"><a href="#">Create policy</a></li>
                 </metal:crumbs>
             </metal:breadcrumbs>
         </h3>
         <dl class="sub-nav" id="scalinggroup-subnav">
-            <dd><a href="${request.route_url('scalinggroup_view', id=scaling_group.name)}" i18n:translate="">Scaling Group</a></dd>
+            <dd><a href="${request.route_url('scalinggroup_view', id=scaling_group.name)}" i18n:translate="">General</a></dd>
             <dd class="active"><a href="${request.route_url('scalinggroup_policies', id=scaling_group.name)}" i18n:translate="">Policies</a></dd>
             <dd><a href="${request.route_url('scalinggroup_instances', id=scaling_group.name)}" i18n:translate="">Instances</a></dd>
         </dl>
@@ -25,11 +25,7 @@
         <metal:block metal:use-macro="layout.global_macros['notifications']" />
 
         <div class="large-7 columns">
-            <div class="panel has-title">
-                <h6 class="title">
-                    <span i18n:translate="">Create new policy for </span>
-                    <strong>${scaling_group.name}</strong>
-                </h6>
+            <div class="panel no-title">
                 <form action="${request.route_url('scalinggroup_policy_create', id=scaling_group.name)}" method="post" data-abide="">
                     ${structure:policy_form['csrf_token']}
                     ${panel('form_field', field=policy_form['name'])}

--- a/koala/templates/scalinggroups/scalinggroup_view.pt
+++ b/koala/templates/scalinggroups/scalinggroup_view.pt
@@ -17,7 +17,7 @@
             </metal:breadcrumbs>
         </h3>
         <dl class="sub-nav" id="scalinggroup-subnav">
-            <dd class="active"><a href="#" i18n:translate="">Scaling Group</a></dd>
+            <dd class="active"><a href="#" i18n:translate="">General</a></dd>
             <dd><a href="${request.route_url('scalinggroup_policies', id=scaling_group.name)}" i18n:translate="">Policies</a></dd>
             <dd><a href="${request.route_url('scalinggroup_instances', id=scaling_group.name)}" i18n:translate="">Instances</a></dd>
         </dl>
@@ -25,11 +25,7 @@
         <metal:block metal:use-macro="layout.global_macros['notifications']" />
 
         <div class="large-7 columns">
-            <div class="panel has-title">
-                <h6 class="title">
-                    <span i18n:translate="">Properties of scaling group</span>
-                    <strong>${scaling_group.name}</strong>
-                </h6>
+            <div class="panel no-title">
                 <form action="${request.route_url('scalinggroup_update', id=scaling_group.name)}" method="post" data-abide=""
                       tal:define="avail_zone_html_attrs {'data-placeholder': avail_zone_placeholder_text};
                                   load_balancers_html_attrs {'data-placeholder': ' '};
@@ -76,8 +72,7 @@
             </div>
         </div>
         <div class="large-5 columns">
-            <div class="panel has-title" tal:condition="scaling_group">
-                <h6 class="title" i18n:translate="">Other scaling group actions</h6>
+            <div class="panel no-title" tal:condition="scaling_group">
                 <div class="row">
                     <div class="small-2 columns">&nbsp;</div>
                     <div class="small-10 columns">

--- a/koala/templates/scalinggroups/scalinggroup_wizard.pt
+++ b/koala/templates/scalinggroups/scalinggroup_wizard.pt
@@ -19,8 +19,7 @@
         <!-- Notifications -->
         <metal:block metal:use-macro="layout.global_macros['notifications']" />
         <div class="large-8 columns" tal:define="_ import: pyramid.i18n.TranslationString">
-            <div class="wizard has-title">
-                <h6 class="title" i18n:translate="">Create Scaling Group</h6>
+            <div class="wizard no-title">
                 <form action="${request.route_url('scalinggroup_create')}" id="scalinggroup-wizard-form"
                       method="post" data-abide="abide">
                     ${structure:create_form['csrf_token']}

--- a/koala/templates/volumes/volume_snapshots.pt
+++ b/koala/templates/volumes/volume_snapshots.pt
@@ -25,11 +25,7 @@
         <metal:block metal:use-macro="layout.global_macros['notifications']" />
 
         <div class="large-8 columns" tal:define="parse_date import: dateutil.parser.parse">
-            <div class="panel gridwrapper has-title">
-                <h6 class="title">
-                    <span i18n:translate="">Snapshots for volume</span>
-                    <strong>${volume_name}</strong>
-                </h6>
+            <div class="panel gridwrapper no-title">
                 <div class="tile add" id="create-snapshot">
                     <a href="#" data-reveal-id="create-snapshot-modal">
                         <div class="plus">+</div>

--- a/koala/views/keypairs.py
+++ b/koala/views/keypairs.py
@@ -12,6 +12,7 @@ from ..forms.keypairs import KeyPairForm, KeyPairImportForm, KeyPairDeleteForm
 from ..models import Notification
 from ..views import BaseView, LandingPageView
 
+
 class KeyPairsView(LandingPageView):
     def __init__(self, request):
         super(KeyPairsView, self).__init__(request)
@@ -19,7 +20,6 @@ class KeyPairsView(LandingPageView):
         self.prefix = '/keypairs'
         self.display_type = self.request.params.get('display', 'tableview')  # Set tableview as default
         self.delete_form = KeyPairDeleteForm(self.request, formdata=self.request.params or None)
-
 
     def get_items(self):
         conn = self.get_connection()


### PR DESCRIPTION
We’re assuming the title in the breadcrumbs is adequate (for now).

Also fixes the tab titles on the login page
