### PR TITLE
Only display block device mapping editor for EBS-backed images in wizards

### DIFF
--- a/koala/templates/panels/bdmapping_editor.pt
+++ b/koala/templates/panels/bdmapping_editor.pt
@@ -1,7 +1,7 @@
 <!--! Block Device Mapping editor -->
 <div id="bdmapping-editor" class="row controls-wrapper" ng-app="BlockDeviceMappingEditor"
      ng-controller="BlockDeviceMappingEditorCtrl" ng-init="initBlockDeviceMappingEditor('${bdm_json}')">
-    <div class="columns">
+    <div class="columns" tal:condition="image.root_device_type == 'ebs'">
         <label i18n:translate="" class="storage-label">Storage</label>
         <table class="table">
             <thead>

--- a/koala/templates/panels/image_picker.pt
+++ b/koala/templates/panels/image_picker.pt
@@ -17,16 +17,14 @@
                         <div class="small-7 columns">
                             <div class="row sort-search" ng-cloak="cloak">
                                 <div class="small-9 columns search-filter">
-                                    <form ng-submit="searchImages()">
-                                        <div class="row collapse">
-                                            <div class="small-10 columns">
-                                                <input type="search" ng-model="searchFilter" id="search-filter" />
-                                            </div>
-                                            <div class="small-2 columns">
-                                                <button class="button secondary postfix go"><i class="fi-magnifying-glass"></i></button>
-                                            </div>
+                                    <div class="row collapse">
+                                        <div class="small-10 columns">
+                                            <input type="search" ng-model="searchFilter" id="search-filter" ng-keyup="searchImages()" />
                                         </div>
-                                    </form>
+                                        <div class="small-2 columns">
+                                            <button class="button secondary postfix go"><i class="fi-magnifying-glass"></i></button>
+                                        </div>
+                                    </div>
                                 </div>
                                 <div class="small-3 columns right" id="results-count" ng-show="!itemsLoading">
                                     {{ items.length }} <span class="hide-for-small" i18n:translate="">images</span>


### PR DESCRIPTION
Selectively display the block device mapping editor in the Launch Instance and Create Launch Configuration wizards only for EBS-backed images.  Fix image picker filter input for the two wizards.
