### PR TITLE
GUI-197: Misc fixes for IP Address pages

### DIFF
--- a/koala/forms/__init__.py
+++ b/koala/forms/__init__.py
@@ -5,12 +5,11 @@ Base Forms
 IMPORTANT: All forms needing CSRF protection should inherit from BaseSecureForm
 
 """
-import logging
+from boto.ec2.vmtype import VmType
 from pyramid.i18n import TranslationString as _
 from wtforms.ext.csrf import SecureForm
 
 from ..constants.instances import AWS_INSTANCE_TYPE_CHOICES
-from boto.ec2.vmtype import VmType
 
 BLANK_CHOICE = ('', _(u'select...'))
 
@@ -53,6 +52,19 @@ class ChoicesManager(object):
         for zone in zones:
             choices.append((zone.name, zone.name))
         return sorted(choices)
+
+    def instances(self, instances=None):
+        from ..views import TaggedItemView
+        choices = [('', _(u'Select instance...'))]
+        instances = instances or []
+        if not instances and self.conn is not None:
+            instances = self.conn.get_only_instances()
+            if self.conn:
+                for instance in instances:
+                    value = instance.id
+                    label = TaggedItemView.get_display_name(instance)
+                    choices.append((value, label))
+        return choices
 
     def instance_types(self, cloud_type='euca', add_blank=True):
         """Get instance type (e.g. m1.small) choices

--- a/koala/forms/ipaddresses.py
+++ b/koala/forms/ipaddresses.py
@@ -8,7 +8,7 @@ from wtforms import validators, widgets
 
 from pyramid.i18n import TranslationString as _
 
-from . import BaseSecureForm
+from . import BaseSecureForm, ChoicesManager
 
 
 class AllocateIPsForm(BaseSecureForm):
@@ -36,19 +36,9 @@ class AssociateIPForm(BaseSecureForm):
     def __init__(self, request, conn=None, **kwargs):
         super(AssociateIPForm, self).__init__(request, **kwargs)
         self.conn = conn
-        self.instance_id.choices = self.get_instance_choices()
+        self.choices_manager = ChoicesManager(conn=self.conn)
+        self.instance_id.choices = self.choices_manager.instances()
         self.instance_id.error_msg = self.instance_error_msg
-
-    def get_instance_choices(self):
-        choices = [('', _(u'Select instance...'))]
-        if self.conn:
-            for instance in self.conn.get_only_instances():
-                value = instance.id
-                inst_name_tag = instance.tags.get('Name', '')
-                label = '{0}{1}'.format(
-                    inst_name_tag if inst_name_tag else instance.id, ' ({0})'.format(instance.id) if inst_name_tag else '')
-                choices.append((value, label))
-        return choices
 
 
 class DisassociateIPForm(BaseSecureForm):

--- a/koala/templates/ipaddresses/ipaddress_view.pt
+++ b/koala/templates/ipaddresses/ipaddress_view.pt
@@ -50,13 +50,7 @@
     <script src="${request.static_url('koala:static/js/thirdparty/jquery/chosen.jquery.min.js')}"></script>
     <script>
         $(document).ready(function() {
-            $('#associate-ip-modal').foundation({
-                'reveal': {
-                    'opened': function() {
-                        $('#instance_id').chosen();
-                    }
-                }
-            });
+            $('#instance_id').chosen({'width': '80%'});
         });
     </script>
 </div>


### PR DESCRIPTION
Add instances to form ChoicesManager class and leverage canonical instance choices for Associate IP Address with Instance dialog.  Fix broken Chosen selector on associate IP dialog.  GUI-197
