### PR TITLE
GUI-70: Launch configurations

### DIFF
--- a/koala/routes.py
+++ b/koala/routes.py
@@ -86,6 +86,7 @@ urls = [
     # Landing page
     Route(name='launchconfigs', pattern='/launchconfigs'),
     Route(name='launchconfigs_json', pattern='/launchconfigs/json'),
+    Route(name='launchconfigs_delete', pattern='/launchconfigs/delete'),
     # Detail page
     Route(name='launchconfig_new', pattern='/launchconfigs/new'),
     Route(name='launchconfig_create', pattern='/launchconfigs/create'),

--- a/koala/static/css/pages/alarms.css
+++ b/koala/static/css/pages/alarms.css
@@ -13,7 +13,7 @@
 .tile .header a { overflow: hidden; white-space: nowrap; text-overflow: ellipsis; display: block; padding: 6px 30px 4px 10px; color: white; }
 .tile .header a:hover { color: #76b800; }
 .tile .header strong { font-weight: normal; }
-.tile .header .f-dropdown a { overflow: visible; }
+.tile .header .f-dropdown a { white-space: pre-wrap; overflow: visible; }
 .tile .content { padding: 8px; font-size: 0.9em; }
 .tile .content a:hover { text-decoration: underline; }
 .tile .content div { margin-bottom: 2px; margin-left: 28px; word-break: break-all; }

--- a/koala/static/css/pages/images.css
+++ b/koala/static/css/pages/images.css
@@ -13,7 +13,7 @@
 .tile .header a { overflow: hidden; white-space: nowrap; text-overflow: ellipsis; display: block; padding: 6px 30px 4px 10px; color: white; }
 .tile .header a:hover { color: #76b800; }
 .tile .header strong { font-weight: normal; }
-.tile .header .f-dropdown a { overflow: visible; }
+.tile .header .f-dropdown a { white-space: pre-wrap; overflow: visible; }
 .tile .content { padding: 8px; font-size: 0.9em; }
 .tile .content a:hover { text-decoration: underline; }
 .tile .content div { margin-bottom: 2px; margin-left: 28px; word-break: break-all; }

--- a/koala/static/css/pages/instance.css
+++ b/koala/static/css/pages/instance.css
@@ -13,7 +13,7 @@
 .tile .header a { overflow: hidden; white-space: nowrap; text-overflow: ellipsis; display: block; padding: 6px 30px 4px 10px; color: white; }
 .tile .header a:hover { color: #76b800; }
 .tile .header strong { font-weight: normal; }
-.tile .header .f-dropdown a { overflow: visible; }
+.tile .header .f-dropdown a { white-space: pre-wrap; overflow: visible; }
 .tile .content { padding: 8px; font-size: 0.9em; }
 .tile .content a:hover { text-decoration: underline; }
 .tile .content div { margin-bottom: 2px; margin-left: 28px; word-break: break-all; }

--- a/koala/static/css/pages/instances.css
+++ b/koala/static/css/pages/instances.css
@@ -13,7 +13,7 @@
 .tile .header a { overflow: hidden; white-space: nowrap; text-overflow: ellipsis; display: block; padding: 6px 30px 4px 10px; color: white; }
 .tile .header a:hover { color: #76b800; }
 .tile .header strong { font-weight: normal; }
-.tile .header .f-dropdown a { overflow: visible; }
+.tile .header .f-dropdown a { white-space: pre-wrap; overflow: visible; }
 .tile .content { padding: 8px; font-size: 0.9em; }
 .tile .content a:hover { text-decoration: underline; }
 .tile .content div { margin-bottom: 2px; margin-left: 28px; word-break: break-all; }

--- a/koala/static/css/pages/ipaddresses.css
+++ b/koala/static/css/pages/ipaddresses.css
@@ -13,7 +13,7 @@
 .tile .header a { overflow: hidden; white-space: nowrap; text-overflow: ellipsis; display: block; padding: 6px 30px 4px 10px; color: white; }
 .tile .header a:hover { color: #76b800; }
 .tile .header strong { font-weight: normal; }
-.tile .header .f-dropdown a { overflow: visible; }
+.tile .header .f-dropdown a { white-space: pre-wrap; overflow: visible; }
 .tile .content { padding: 8px; font-size: 0.9em; }
 .tile .content a:hover { text-decoration: underline; }
 .tile .content div { margin-bottom: 2px; margin-left: 28px; word-break: break-all; }

--- a/koala/static/css/pages/keypairs.css
+++ b/koala/static/css/pages/keypairs.css
@@ -13,7 +13,7 @@
 .tile .header a { overflow: hidden; white-space: nowrap; text-overflow: ellipsis; display: block; padding: 6px 30px 4px 10px; color: white; }
 .tile .header a:hover { color: #76b800; }
 .tile .header strong { font-weight: normal; }
-.tile .header .f-dropdown a { overflow: visible; }
+.tile .header .f-dropdown a { white-space: pre-wrap; overflow: visible; }
 .tile .content { padding: 8px; font-size: 0.9em; }
 .tile .content a:hover { text-decoration: underline; }
 .tile .content div { margin-bottom: 2px; margin-left: 28px; word-break: break-all; }

--- a/koala/static/css/pages/launchconfigs.css
+++ b/koala/static/css/pages/launchconfigs.css
@@ -13,7 +13,7 @@
 .tile .header a { overflow: hidden; white-space: nowrap; text-overflow: ellipsis; display: block; padding: 6px 30px 4px 10px; color: white; }
 .tile .header a:hover { color: #76b800; }
 .tile .header strong { font-weight: normal; }
-.tile .header .f-dropdown a { overflow: visible; }
+.tile .header .f-dropdown a { white-space: pre-wrap; overflow: visible; }
 .tile .content { padding: 8px; font-size: 0.9em; }
 .tile .content a:hover { text-decoration: underline; }
 .tile .content div { margin-bottom: 2px; margin-left: 28px; word-break: break-all; }

--- a/koala/static/css/pages/scalinggroup.css
+++ b/koala/static/css/pages/scalinggroup.css
@@ -13,7 +13,7 @@
 .tile .header a { overflow: hidden; white-space: nowrap; text-overflow: ellipsis; display: block; padding: 6px 30px 4px 10px; color: white; }
 .tile .header a:hover { color: #76b800; }
 .tile .header strong { font-weight: normal; }
-.tile .header .f-dropdown a { overflow: visible; }
+.tile .header .f-dropdown a { white-space: pre-wrap; overflow: visible; }
 .tile .content { padding: 8px; font-size: 0.9em; }
 .tile .content a:hover { text-decoration: underline; }
 .tile .content div { margin-bottom: 2px; margin-left: 28px; word-break: break-all; }

--- a/koala/static/css/pages/scalinggroups.css
+++ b/koala/static/css/pages/scalinggroups.css
@@ -13,7 +13,7 @@
 .tile .header a { overflow: hidden; white-space: nowrap; text-overflow: ellipsis; display: block; padding: 6px 30px 4px 10px; color: white; }
 .tile .header a:hover { color: #76b800; }
 .tile .header strong { font-weight: normal; }
-.tile .header .f-dropdown a { overflow: visible; }
+.tile .header .f-dropdown a { white-space: pre-wrap; overflow: visible; }
 .tile .content { padding: 8px; font-size: 0.9em; }
 .tile .content a:hover { text-decoration: underline; }
 .tile .content div { margin-bottom: 2px; margin-left: 28px; word-break: break-all; }

--- a/koala/static/css/pages/securitygroups.css
+++ b/koala/static/css/pages/securitygroups.css
@@ -13,7 +13,7 @@
 .tile .header a { overflow: hidden; white-space: nowrap; text-overflow: ellipsis; display: block; padding: 6px 30px 4px 10px; color: white; }
 .tile .header a:hover { color: #76b800; }
 .tile .header strong { font-weight: normal; }
-.tile .header .f-dropdown a { overflow: visible; }
+.tile .header .f-dropdown a { white-space: pre-wrap; overflow: visible; }
 .tile .content { padding: 8px; font-size: 0.9em; }
 .tile .content a:hover { text-decoration: underline; }
 .tile .content div { margin-bottom: 2px; margin-left: 28px; word-break: break-all; }

--- a/koala/static/css/pages/snapshots.css
+++ b/koala/static/css/pages/snapshots.css
@@ -13,7 +13,7 @@
 .tile .header a { overflow: hidden; white-space: nowrap; text-overflow: ellipsis; display: block; padding: 6px 30px 4px 10px; color: white; }
 .tile .header a:hover { color: #76b800; }
 .tile .header strong { font-weight: normal; }
-.tile .header .f-dropdown a { overflow: visible; }
+.tile .header .f-dropdown a { white-space: pre-wrap; overflow: visible; }
 .tile .content { padding: 8px; font-size: 0.9em; }
 .tile .content a:hover { text-decoration: underline; }
 .tile .content div { margin-bottom: 2px; margin-left: 28px; word-break: break-all; }

--- a/koala/static/css/pages/volume.css
+++ b/koala/static/css/pages/volume.css
@@ -13,7 +13,7 @@
 .tile .header a { overflow: hidden; white-space: nowrap; text-overflow: ellipsis; display: block; padding: 6px 30px 4px 10px; color: white; }
 .tile .header a:hover { color: #76b800; }
 .tile .header strong { font-weight: normal; }
-.tile .header .f-dropdown a { overflow: visible; }
+.tile .header .f-dropdown a { white-space: pre-wrap; overflow: visible; }
 .tile .content { padding: 8px; font-size: 0.9em; }
 .tile .content a:hover { text-decoration: underline; }
 .tile .content div { margin-bottom: 2px; margin-left: 28px; word-break: break-all; }

--- a/koala/static/css/pages/volumes.css
+++ b/koala/static/css/pages/volumes.css
@@ -13,7 +13,7 @@
 .tile .header a { overflow: hidden; white-space: nowrap; text-overflow: ellipsis; display: block; padding: 6px 30px 4px 10px; color: white; }
 .tile .header a:hover { color: #76b800; }
 .tile .header strong { font-weight: normal; }
-.tile .header .f-dropdown a { overflow: visible; }
+.tile .header .f-dropdown a { white-space: pre-wrap; overflow: visible; }
 .tile .content { padding: 8px; font-size: 0.9em; }
 .tile .content a:hover { text-decoration: underline; }
 .tile .content div { margin-bottom: 2px; margin-left: 28px; word-break: break-all; }

--- a/koala/static/js/pages/keypairs.js
+++ b/koala/static/js/pages/keypairs.js
@@ -1,5 +1,5 @@
 /**
- * @fileOverview Elastic IPs landing page JS
+ * @fileOverview Key pairs landing page JS
  * @requires AngularJS, jQuery
  *
  */
@@ -11,7 +11,6 @@ angular.module('KeypairsPage', ['LandingPage'])
         $scope.urlParams = $.url().param();
         $scope.displayType = $scope.urlParams['display'] || 'tableview';
         $scope.revealModal = function (action, keypair_name) {
-            console.log("hello " + keypair_name)
             keypair_name = keypair_name || '';
             var modal = $('#' + action + '-keypair-modal');
             $scope.keypairName = keypair_name;

--- a/koala/static/js/pages/launchconfigs.js
+++ b/koala/static/js/pages/launchconfigs.js
@@ -1,0 +1,21 @@
+/**
+ * @fileOverview Launch configurations landing page JS
+ * @requires AngularJS, jQuery
+ *
+ */
+
+// Pull in common landing page module
+angular.module('LaunchConfigsPage', ['LandingPage'])
+    .controller('LaunchConfigsPageCtrl', function ($scope) {
+        $scope.launchConfigName= '';
+        $scope.launchConfigInUse = false;
+        $scope.urlParams = $.url().param();
+        $scope.displayType = $scope.urlParams['display'] || 'tableview';
+        $scope.revealModal = function (action, launchConfig) {
+            $scope.launchConfigName = launchConfig['name'];
+            $scope.launchConfigInUse = launchConfig['in_use'];
+            var modal = $('#' + action + '-launchconfig-modal');
+            modal.foundation('reveal', 'open');
+        };
+    });
+

--- a/koala/static/sass/includes/_landingpage.scss
+++ b/koala/static/sass/includes/_landingpage.scss
@@ -75,6 +75,7 @@ $gridwrapper-table-width: 98%;
             font-weight: normal;
         }
         .f-dropdown a {
+            white-space: pre-wrap;
             overflow: visible;
         }
     }

--- a/koala/templates/dialogs/launchconfig_dialogs.pt
+++ b/koala/templates/dialogs/launchconfig_dialogs.pt
@@ -1,0 +1,34 @@
+<!--! Modal dialogs for Launch configurations on landing and detail page -->
+<div tal:omit-tag="" xmlns="http://www.w3.org/1999/html">
+    <div id="delete-launchconfig-modal" class="reveal-modal small" data-reveal=""
+         tal:define="landingpage_action request.route_url('launchconfigs_delete');
+                     detailpage_action request.route_url('launchconfig_delete', id=launch_config.name) if launch_config else '';
+                     action landingpage_action if landingpage else detailpage_action;">
+        <h3 i18n:translate="">Delete launch configuration</h3>
+        <div ng-show="!!launchConfigInUse" tal:condition="in_use if launch_config else True">
+            <p>
+                <span i18n:translate="">Launch configuration</span>
+                <b>${launch_config.name if launch_config else '{{ launchConfigName }}'}</b>
+                <span i18n:translate="">is in use and may not be deleted.</span>
+            </p>
+            <p i18n:translate="">
+                Change the launch configuration from each scaling group's detail page,
+                and then try to delete this launch configuration again.
+            </p>
+        </div>
+        <p ng-show="!launchConfigInUse" tal:condition="not in_use if launch_config else True">
+            <span i18n:translate="">Are you sure you want to delete the launch configuration</span>
+            <b>${launch_config.name if launch_config else '{{ launchConfigName }}'}</b>?
+        </p>
+        <form action="${action}" method="post" ng-show="!launchConfigInUse"
+              tal:condition="not in_use if launch_config else True">
+            ${structure:delete_form['csrf_token']}
+            <div tal:condition="landingpage" tal:omit-tag="">
+                <input type="hidden" name="display" value="{{ displayType }}" />
+                <input type="hidden" name="name" value="{{ launchConfigName }}">
+            </div>
+            <button type="submit" class="button" i18n:translate="">Yes, delete</button>
+        </form>
+        <a class="close-reveal-modal">&#215;</a>
+    </div>
+</div>

--- a/koala/templates/images/image_view.pt
+++ b/koala/templates/images/image_view.pt
@@ -48,7 +48,7 @@
                             </div>
                             <div class="row controls-wrapper readonly">
                                 <div class="small-4 columns"><label i18n:translate="">Manifest Path</label></div>
-                                <div class="small-8 columns value">${image.location if image.location else ''}</div>
+                                <div class="small-8 columns value breakword">${image.location if image.location else ''}</div>
                             </div>
                             <div class="row controls-wrapper readonly">
                                 <div class="small-4 columns"><label i18n:translate="">Description</label></div>

--- a/koala/templates/keypairs/keypair_view.pt
+++ b/koala/templates/keypairs/keypair_view.pt
@@ -167,7 +167,7 @@
             </div>
         </div>
         <!--! Modal dialogs reused across landing and detail page -->
-        ${panel('keypair_dialogs', keypair=keypair, delete_form=delete_form, landingpage=False)}
+        ${panel('keypair_dialogs', keypair=keypair, delete_form=delete_form)}
     </div>
 </div>
 

--- a/koala/templates/launchconfigs/launchconfig_view.pt
+++ b/koala/templates/launchconfigs/launchconfig_view.pt
@@ -22,6 +22,10 @@
                 </h6>
                 <form>
                     <div class="row controls-wrapper readonly">
+                        <div class="small-3 columns"><label i18n:translate="">In use?</label></div>
+                        <div class="small-9 columns value">${'yes' if in_use else 'no'}</div>
+                    </div>
+                    <div class="row controls-wrapper readonly">
                         <div class="small-3 columns"><label i18n:translate="">Key pair</label></div>
                         <div class="small-9 columns value">
                             <a href="${request.route_url('keypair_view', id=launch_config.key_name)}">${launch_config.key_name}</a>
@@ -86,7 +90,7 @@
                     </div>
                     <div class="row controls-wrapper readonly">
                         <div class="small-3 columns"><label i18n:translate="">Image manifest</label></div>
-                        <div class="small-9 columns value">${image.location}</div>
+                        <div class="small-9 columns value breakword">${image.location}</div>
                     </div>
                     <hr />
                     <div class="row">
@@ -117,17 +121,7 @@
             </div>
         </div>
         <!--! Modal dialogs -->
-        <div id="delete-launchconfig-modal" class="reveal-modal small" data-reveal="">
-            <h3 i18n:translate="">Delete launchconfig</h3>
-            <p><span i18n:translate="">Are you sure you want to delete the launch configuration</span>
-            <b>${launch_config.name}</b>?</p>
-            <form action="${request.route_url('launchconfig_delete', id=launch_config.name)}" method="post">
-                ${structure:delete_form['csrf_token']}
-                <input type="hidden" name="name" value="${launch_config.name}">
-                <button type="submit" class="button" i18n:translate="">Yes, delete</button>
-            </form>
-            <a class="close-reveal-modal">&#215;</a>
-        </div>
+        ${panel('launchconfig_dialogs', launch_config=launch_config, in_use=in_use, delete_form=delete_form)}
     </div>
 </div>
 

--- a/koala/templates/launchconfigs/launchconfigs.pt
+++ b/koala/templates/launchconfigs/launchconfigs.pt
@@ -5,7 +5,7 @@
 </head>
 
 <div metal:fill-slot="main_content">
-    <div class="row" id="contentwrap" ng-app="LandingPage">
+    <div class="row" id="contentwrap" ng-app="LaunchConfigsPage" ng-controller="LaunchConfigsPageCtrl">
         <h3 class="header" id="pagetitle">
             <metal:breadcrumbs metal:use-macro="layout.global_macros['breadcrumbs']">
                 <metal:crumbs metal:fill-slot="crumbs">
@@ -35,13 +35,14 @@
                 <ul id="item-dropdown_{{ item.name }}" class="f-dropdown">
                     <li><a i18n:translate="" ng-href="${prefix}/{{ item.name }}">View properties</a></li>
                     <li><a i18n:translate=""
-                           ng-href="/scalinggroups/new?launch_config={{ item.name }}">Create scaling group</a></li>
+                           ng-href="/scalinggroups/new?launch_config={{ item.name }}">Use to create scaling group</a></li>
+                    <li><a i18n:translate="" ng-click="revealModal('delete', item)">Delete launch configuration</a></li>
                 </ul>
             </div>
             <div metal:fill-slot="tile_content" tal:omit-tag="">
                 <div ng-show="item.image_id">
                     <span class="label" title="Image ID" i18n:attributes="title" data-tooltip="">IM</span>
-                    <a ng-href="/images/{{ item.image_id }}">{{ item.image_id }}</a>
+                    <a ng-href="/images/{{ item.image_id }}">{{ item.image_name || item.image_id }}</a>
                 </div>
                 <div ng-show="item.key_name">
                     <span class="label" title="Key Pair" i18n:attributes="title" data-tooltip="">KP</span>
@@ -51,18 +52,6 @@
                     <span class="label" title="Security Groups" i18n:attributes="title" data-tooltip="">SG</span>
                     <a ng-repeat="sgroup_id in item.security_groups"
                        ng-href="/securitygroups/{{ sgroup_id }}">{{ sgroup_id }}</a>
-                </div>
-                <div ng-show="item.instance_monitoring">
-                    <span class="label" title="Instance Monitoring" i18n:attributes="title" data-tooltip="">MO</span>
-                    {{ item.instance_monitoring }}
-                </div>
-                <div ng-show="item.kernel_id">
-                    <span class="label" title="Kernel ID" i18n:attributes="title" data-tooltip="">KI</span>
-                    {{ item.kernel_id }}
-                </div>
-                <div ng-show="item.ramdisk_id">
-                    <span class="label" title="Ramdisk ID" i18n:attributes="title" data-tooltip="">RM</span>
-                    {{ item.ramdisk_id }}
                 </div>
                 <div ng-show="item.created_time">
                     <span class="label" title="Created Time" i18n:attributes="title" data-tooltip="">CT</span>
@@ -74,12 +63,12 @@
                 <th i18n:translate="">Image</th>
                 <th i18n:translate="">Key</th>
                 <th i18n:translate="">Security Group</th>
-                <th i18n:translate="">Create time</th>
+                <th i18n:translate="">Creation time</th>
                 <th i18n:translate="" class="actions">Actions</th>
             </metal:block>
             <metal:block metal:fill-slot="tableview_columns">
                 <td><a ng-href="${prefix}/{{ item.id || item.name | escapeURL }}">{{ item.name }}</a></td>
-                <td><a ng-href="/images/{{ item.image_id }}">{{ item.image_id }}</a></td>
+                <td><a ng-href="/images/{{ item.image_id }}">{{ item.image_name || item.image_id }}</a></td>
                 <td><a ng-href="/keypairs/{{ item.key_name }}">{{ item.key_name }}</a></td>
                 <td>
                     <a ng-repeat="sgroup_id in item.security_groups"
@@ -92,12 +81,15 @@
                         <ul id="item-dropdown_{{ item.name }}" class="f-dropdown">
                             <li><a i18n:translate="" ng-href="${prefix}/{{ item.name }}">View properties</a></li>
                             <li><a i18n:translate=""
-                                   ng-href="/scalinggroups/new?launch_config={{ item.name }}">Create scaling group</a></li>
+                                   ng-href="/scalinggroups/new?launch_config={{ item.name }}">Use to create scaling group</a></li>
+                            <li><a i18n:translate="" ng-click="revealModal('delete', item)">Delete launch configuration</a></li>
                         </ul>
                     </span>
                 </td>
             </metal:block>
         </div>
+        <!--! Modal dialogs -->
+        ${panel('launchconfig_dialogs', delete_form=delete_form, landingpage=True)}
     </div>
 </div>
 
@@ -105,6 +97,7 @@
     <script src="${request.static_url('koala:static/js/thirdparty/utils/purl.js')}"></script>
     <script src="${request.static_url('koala:static/js/pages/custom_filters.js')}"></script>
     <script src="${request.static_url('koala:static/js/pages/landingpage.js')}"></script>
+    <script src="${request.static_url('koala:static/js/pages/launchconfigs.js')}"></script>
 </div>
 
 </metal:block>

--- a/koala/views/dialogs.py
+++ b/koala/views/dialogs.py
@@ -93,3 +93,14 @@ def keypair_dialogs(context, request, keypair=None, landingpage=False, delete_fo
         delete_form=delete_form,
     )
 
+
+@panel_config('launchconfig_dialogs', renderer='../templates/dialogs/launchconfig_dialogs.pt')
+def launchconfig_dialogs(context, request, launch_config=None, in_use=False, landingpage=False, delete_form=None):
+    """ Modal dialogs for Launch configurations landing and detail page."""
+    return dict(
+        launch_config=launch_config,
+        in_use=in_use,
+        landingpage=landingpage,
+        delete_form=delete_form,
+    )
+

--- a/koala/views/keypairs.py
+++ b/koala/views/keypairs.py
@@ -3,7 +3,8 @@
 Pyramid views for Eucalyptus and AWS key pairs
 
 """
-from pyramid.httpexceptions import HTTPFound, HTTPNotFound
+from boto.exception import EC2ResponseError
+from pyramid.httpexceptions import HTTPFound
 from pyramid.i18n import TranslationString as _
 from pyramid.view import view_config
 from pyramid.response import Response
@@ -124,7 +125,6 @@ class KeyPairView(BaseView):
         if self.keypair_form.validate():
             name = self.request.params.get('name')
             session = self.request.session
-            msg = ""
             try:
                 new_keypair = self.conn.create_key_pair(name)
                 # Store the new keypair material information in the session            


### PR DESCRIPTION
 Whole slew of changes based on UX feedback for launch configuration pages.
- Implement launch config delete on landing page.
- Show appropriate feedback when attempting to delete a launch config that's in use.
- Minor visual fixes for wrapping of manifest info on launch config and image detail pages.
