### PR TITLE
GUI-294: Various fixes based on UX feedback for Create Scaling Group wizard

### DIFF
--- a/koala/forms/scalinggroups.py
+++ b/koala/forms/scalinggroups.py
@@ -165,6 +165,9 @@ class ScalingGroupCreateForm(BaseScalingGroupForm):
         # Set error messages
         self.name.error_msg = self.name_error_msg
 
+        # Set initial data
+        self.availability_zones.data = [value for value, label in self.availability_zones.choices]
+
 
 class ScalingGroupEditForm(BaseScalingGroupForm):
     """Edit Scaling Group form"""

--- a/koala/static/css/pages/instance_launch.css
+++ b/koala/static/css/pages/instance_launch.css
@@ -12,7 +12,7 @@
 .wizard .tabs-content .content { width: 100%; }
 
 .summary { position: relative; top: 2px; padding-top: 8px; padding-bottom: 2rem; background-color: #eeeeee; }
-.summary label { position: relative; right: -1rem; color: #00415e; font-weight: bold; margin-bottom: 2px; }
+.summary label { position: relative; right: -1rem; color: #00415e; font-weight: bold; margin-bottom: 4px; }
 .summary .value { word-break: break-all; }
 .summary .row { margin-bottom: 5px; }
 .summary .title { font-weight: bold; border-bottom: 1px solid #00415e; margin-top: 7px; margin-bottom: 1rem; }

--- a/koala/static/css/pages/launchconfig_wizard.css
+++ b/koala/static/css/pages/launchconfig_wizard.css
@@ -12,7 +12,7 @@
 .wizard .tabs-content .content { width: 100%; }
 
 .summary { position: relative; top: 2px; padding-top: 8px; padding-bottom: 2rem; background-color: #eeeeee; }
-.summary label { position: relative; right: -1rem; color: #00415e; font-weight: bold; margin-bottom: 2px; }
+.summary label { position: relative; right: -1rem; color: #00415e; font-weight: bold; margin-bottom: 4px; }
 .summary .value { word-break: break-all; }
 .summary .row { margin-bottom: 5px; }
 .summary .title { font-weight: bold; border-bottom: 1px solid #00415e; margin-top: 7px; margin-bottom: 1rem; }

--- a/koala/static/css/pages/scalinggroup_wizard.css
+++ b/koala/static/css/pages/scalinggroup_wizard.css
@@ -12,7 +12,7 @@
 .wizard .tabs-content .content { width: 100%; }
 
 .summary { position: relative; top: 2px; padding-top: 8px; padding-bottom: 2rem; background-color: #eeeeee; }
-.summary label { position: relative; right: -1rem; color: #00415e; font-weight: bold; margin-bottom: 2px; }
+.summary label { position: relative; right: -1rem; color: #00415e; font-weight: bold; margin-bottom: 4px; }
 .summary .value { word-break: break-all; }
 .summary .row { margin-bottom: 5px; }
 .summary .title { font-weight: bold; border-bottom: 1px solid #00415e; margin-top: 7px; margin-bottom: 1rem; }

--- a/koala/static/js/pages/scalinggroup_wizard.js
+++ b/koala/static/js/pages/scalinggroup_wizard.js
@@ -15,6 +15,7 @@ angular.module('ScalingGroupWizard', ['AutoScaleTagEditor'])
         $scope.maxSize = 2;
         $scope.urlParams = $.url().param();
         $scope.launchConfig = '';
+        $scope.summarySection = $('.summary');
         $scope.initChosenSelectors = function () {
             $('#launch_config').chosen({'width': '80%', search_contains: true});
             $('#availability_zones').chosen({'width': '100%', search_contains: true});
@@ -22,11 +23,19 @@ angular.module('ScalingGroupWizard', ['AutoScaleTagEditor'])
         $scope.setLaunchConfig = function () {
             $scope.launchConfig = $scope.urlParams['launch_config'] || '';
         };
+        $scope.setInitialValues = function () {
+            $scope.availZones = $('#availability_zones').val();
+        };
         $scope.initController = function () {
             $scope.initChosenSelectors();
             $scope.setLaunchConfig();
+            $scope.setInitialValues();
         };
         $scope.visitNextStep = function (nextStep, $event) {
+            // Unhide step 2 of summary
+            if (nextStep === 2) {
+                $scope.summarySection.find('.step2').removeClass('hide');
+            }
             // Trigger form validation before proceeding to next step
             $scope.form.trigger('validate');
             var currentStep = nextStep - 1,

--- a/koala/static/sass/includes/_wizard.scss
+++ b/koala/static/sass/includes/_wizard.scss
@@ -82,7 +82,7 @@ $wizard-border-width: 16px;
         right: -1rem;
         color: $euca-darkblue;
         font-weight: bold;
-        margin-bottom: 2px;
+        margin-bottom: 4px;
     }
     .value {
         word-break: break-all;

--- a/koala/templates/panels/autoscale_tag_editor.pt
+++ b/koala/templates/panels/autoscale_tag_editor.pt
@@ -32,7 +32,8 @@
                 <div class="small-3 columns">
                     <input id="propagate-checkbox" class="taginput propagate" type="checkbox" ng-model="newTagPropagate" />
                     <span class="label secondary" i18n:translate="" ng-click="togglePropagateCheckbox()"
-                          data-tooltip="" title="Propagate to instances" i18n:attributes="title">Propagate</span>
+                          data-tooltip="" title="Propagate to instances launched by this scaling group"
+                          i18n:attributes="title">Propagate</span>
                 </div>
                 <div class="small-4 columns">
                     <input class="taginput key" placeholder="name..." ng-model="newTagKey" pattern="${layout.tag_pattern}" />

--- a/koala/templates/scalinggroups/scalinggroup_wizard.pt
+++ b/koala/templates/scalinggroups/scalinggroup_wizard.pt
@@ -30,13 +30,8 @@
                             </a>
                         </dd>
                         <dd>
-                            <a id="tabStep2" href="#step2">
+                            <a id="tabStep2" href="#step2" ng-click="visitNextStep(2, $event)">
                                 <span class="cir">2</span> <b>Membership</b>
-                            </a>
-                        </dd>
-                        <dd>
-                            <a id="tabStep3" href="#step3">
-                                <span class="cir">3</span> <b>Tags</b>
                             </a>
                         </dd>
                     </dl>
@@ -47,10 +42,10 @@
                             ${panel('form_field', field=create_form['launch_config'], ng_attrs={'model': 'launchConfig'})}
                             <hr />
                             <div class="row controls-wrapper" id="capacity-section">
-                                <div class="medium-4 columns">
-                                    <h6 class="right" i18n:translate="">Capacity</h6>
+                                <div class="medium-2 columns">
+                                    <h6 i18n:translate="">Capacity</h6>
                                 </div>
-                                <div class="medium-8 columns">
+                                <div class="medium-10 columns">
                                     ${panel('form_field', field=create_form['min_size'], maxlength=2,
                                             ng_attrs={'model': 'minSize', 'change': 'handleSizeChange()'})}
                                     ${panel('form_field', field=create_form['desired_capacity'], maxlength=2,
@@ -60,12 +55,14 @@
                                 </div>
                             </div>
                             <hr />
+                            ${panel('autoscale_tag_editor', tags=[])}
+                            <hr />
                             <div>&nbsp;</div>
                             <div class="row">
                                 <div class="small-4 columns">&nbsp;</div>
                                 <div class="small-8 columns field inline">
                                     <a id="visit-step-2" class="button small round" ng-click="visitNextStep(2, $event)">
-                                        <span i18n:translate="">Next: Membership</span>
+                                        <span i18n:translate="">Next</span>
                                     </a>
                                 </div>
                             </div>
@@ -77,27 +74,13 @@
                             ${panel('form_field', field=create_form['availability_zones'],
                                     ng_attrs={'model': 'availZones'}, **avail_zones_attrs)}
                             <div>&nbsp;</div>
+                            <hr />
                             <div class="row">
                                 <div class="small-4 columns">&nbsp;</div>
                                 <div class="small-8 columns field inline">
-                                    <a id="visit-step-3" class="button small round" ng-click="visitNextStep(3, $event)">
-                                        <span i18n:translate="">Next: Tags</span>
-                                    </a>
-                                </div>
-                            </div>
-                        </div>
-                        <!--! Step 3: Tags tab content -->
-                        <div class="content" id="step3">
-                            ${panel('autoscale_tag_editor', tags=[])}
-                            <div>&nbsp;</div>
-                            <div class="row">
-                                <div class="small-2 columns">&nbsp;</div>
-                                <div class="small-10 columns field inline">
                                     <button type="submit" class="button" id="create-scalinggroup-btn">
                                         <span i18n:translate="">Create scaling group</span>
                                     </button>
-                                    <a href="${request.route_url('scalinggroups')}"
-                                       class="cancel-link" i18n:translate="">Cancel</a>
                                 </div>
                             </div>
                         </div>
@@ -108,34 +91,34 @@
         </div>
         <div class="large-4 columns summary" ng-cloak="">
             <h5 i18n:translate="" class="title">Summary</h5>
-            <div class="section">
+            <div class="section step1">
                 <div class="row">
-                    <div class="small-4 columns"><label i18n:translate="" class="right">Name:</label></div>
-                    <div class="small-8 columns value">{{ scalingGroupName }}</div>
+                    <label i18n:translate="">Name:</label>
+                    <div class="columns value">{{ scalingGroupName }}</div>
                 </div>
                 <div class="row">
-                    <div class="small-4 columns"><label i18n:translate="" class="right">Launch configuration:</label></div>
-                    <div class="small-8 columns value">{{ launchConfig }}</div>
+                    <label i18n:translate="">Launch configuration:</label>
+                    <div class="columns value">{{ launchConfig }}</div>
                 </div>
                 <div class="row">
-                    <div class="small-4 columns"><label i18n:translate="" class="right">Instances:</label></div>
-                    <div class="small-8 columns value">
+                    <label i18n:translate="">Instances:</label>
+                    <div class="columns value">
                         Min: {{ minSize }}, Desired: {{ desiredCapacity }}, Max: {{ maxSize }}
                     </div>
                 </div>
             </div>
-            <div class="section">
+            <div class="section step2 hide">
                 <div class="row">
-                    <div class="small-4 columns"><label i18n:translate="" class="right">Health check:</label></div>
-                    <div class="small-8 columns value">{{ healthCheckType }}</div>
+                    <label i18n:translate="">Health check:</label>
+                    <div class="columns value">{{ healthCheckType }}</div>
                 </div>
                 <div class="row">
-                    <div class="small-4 columns"><label i18n:translate="" class="right">Grace period:</label></div>
-                    <div class="small-8 columns value">{{ healthCheckPeriod }}</div>
+                    <label i18n:translate="">Grace period:</label>
+                    <div class="columns value">{{ healthCheckPeriod }}</div>
                 </div>
                 <div class="row">
-                    <div class="small-4 columns"><label i18n:translate="" class="right">Availability zones:</label></div>
-                    <div class="small-8 columns value">
+                    <label i18n:translate="">Availability zones:</label>
+                    <div class="columns value">
                         <span ng-repeat="zone in availZones">{{ zone }}<span ng-show="!$last">, </span></span>
                     </div>
                 </div>


### PR DESCRIPTION
Implemented in this pull request…
- Pushed the capacity label over so that the widgets all fit in a line.
- Fixed immediate validation error on membership page as soon as next is clicked.
- Merge the tags on to the general step and got rid of the tag step.
- Summary does not populate before visiting the associated step.
- Propagate mouseover now reads "Propagate to instances launched by this scaling group"

Notes w.r.t. validation error:
The immediate validation error is due to how Foundation validation works, which is form-based rather than step-based.  The workaround for the availability zones input is to pre-populate those, which isn't ideal but may work well for us here since it's trivial to remove an unwanted zone in a multi-select Chosen widget (--in fact it's easier to remove a zone than to add it, and it seems safe to include them all by default since there probably won't be more than a few, right?  Let's discuss if this is a concern.
