### PR TITLE
GUI-56: Various UX fixes to wrap up Images landing page.

### DIFF
--- a/koala/static/css/pages/images.css
+++ b/koala/static/css/pages/images.css
@@ -80,4 +80,11 @@
 .tile .footer .action { display: block; position: absolute; left: 0; right: 0; bottom: 0; line-height: 1.5rem; text-align: center; background-color: #76b800; color: white; }
 .tile .footer .action:hover { background-color: #558500; }
 
+.table td .label { padding: 4px 6px; }
+.table td .label.i386 { background-color: #999999; }
+.table td .label.x86_64 { background-color: #40a8c6; }
+.table td .label.ebs { background-color: #468400; }
+.table td .label.instance-store { background-color: #737373; }
+.table td .emi-name { display: inline-block; width: 12rem; word-break: break-all; }
+
 .row.sort-search { margin-top: 20px; }

--- a/koala/static/sass/pages/images.scss
+++ b/koala/static/sass/pages/images.scss
@@ -4,6 +4,7 @@
 @import "../includes/landingpage";
 
 
+// Tile/grid view
 .tile {
     .header a {
         padding-right: 4px;
@@ -24,6 +25,25 @@
         color: white;
         &:hover {
             background-color: darken($euca-green, 10%);
+        }
+    }
+}
+
+
+// Table view
+.table {
+    td {
+        .label {
+            padding: 4px 6px;
+            &.i386 { background-color: $euca-grey; }
+            &.x86_64 { background-color: $euca-notificationblue; }
+            &.ebs { background-color: $euca-darkgreen; }
+            &.instance-store { background-color: darken($euca-grey, 15%); }
+        }
+        .emi-name {
+            display: inline-block;
+            width: 12rem;
+            word-break: break-all;
         }
     }
 }

--- a/koala/templates/images/images.pt
+++ b/koala/templates/images/images.pt
@@ -55,7 +55,10 @@
                 <a class="tiny secondary button dropdown right"><i class="fi-widget"></i></a>
                 <ul id="item-dropdown_{{ item.id }}" class="f-dropdown">
                     <li><a i18n:translate="" ng-href="${prefix}/{{ item.id }}">View properties</a></li>
-                    <li><a i18n:translate="" href="/instances/new?image_id={{ item.id }}">Launch instance</a></li>
+                    <li><a i18n:translate="" ng-href="${request.route_url('instance_create')}?image_id={{ item.id }}">Launch instance</a></li>
+                    <li><a ng-href="${request.route_url('launchconfig_new')}?image_id={{ item.id }}"
+                           i18n:translate="">Create scaling group launch configuration</a>
+                    </li>
                 </ul>
             </div>
             <div metal:fill-slot="tile_header">
@@ -67,7 +70,7 @@
                     {{ item.id }}
                 </div>
                 <div>
-                    <span class="label" title="NAME" i18n:attributes="title" data-tooltip="">NM</span>
+                    <span class="label" title="Machine Image Name" i18n:attributes="title" data-tooltip="">NM</span>
                     {{ item.name }}
                 </div>
                 <div ng-show="item.platform_name">
@@ -85,10 +88,6 @@
                     <span class="label" title="Architecture" i18n:attributes="title" data-tooltip="">AR</span>
                     {{ item.architecture }}
                 </div>
-                <div ng-show="item.kernel_id">
-                    <span class="label" title="kernel id" i18n:attributes="title" data-tooltip="">KN</span>
-                    {{ item.kernel_id }}
-                </div>
                 <div ng-show="item.owner_alias">
                     <span class="label" title="Owner Alias" i18n:attributes="title" data-tooltip="">OW</span>
                     {{ item.owner_alias }}
@@ -98,15 +97,10 @@
                     {{ item.root_device_type }}
                 </div>
             </div>
-            <div metal:fill-slot="tile_footer">
-                <div class="footer">
-                    <a href="/instances/new?image_id={{ item.id }}" class="action"
-                            i18n:translate="">Launch instance</a>
-                </div>
-            </div>
+            <div metal:fill-slot="tile_footer"></div>
             <metal:block metal:fill-slot="tableview_headers">
-                <th>IMAGE</th>
-                <th i18n:translate="">Name</th>
+                <th i18n:translate="">Name (ID)</th>
+                <th i18n:translate="">EMI Name</th>
                 <th i18n:translate="">Description</th>
                 <th i18n:translate="">Arch</th>
                 <th i18n:translate="">Root Device</th>
@@ -115,17 +109,22 @@
             </metal:block>
             <metal:block metal:fill-slot="tableview_columns">
                 <td class="id"><a ng-href="${prefix}/{{ item.id }}">{{ item.tagged_name || item.id }}</a></td>
-                <td>{{ item.name }}</td>
+                <td><span class="emi-name">{{ item.name }}</span></td>
                 <td>{{ item.description }}</td>
-                <td>{{ item.architecture }}</td>
-                <td>{{ item.root_device_type }}</td>
+                <td><span class="label radius {{ item.architecture }}">{{ item.architecture }}</span></td>
+                <td><span class="label radius {{ item.root_device_type }}">{{ item.root_device_type }}</span></td>
                 <td>{{ item.platform_name }}</td>
                 <td>
-                <a class="tiny secondary button dropdown round"><i class="fi-widget"></i></a>
-                <ul id="item-dropdown_{{ item.id }}" class="f-dropdown">
-                    <li><a i18n:translate="" ng-href="${prefix}/{{ item.id }}">View properties</a></li>
-                    <li><a i18n:translate="" href="/instances/new?image_id={{ item.id }}">Launch instance</a></li>
-                </ul>
+                    <span class="actions">
+                        <a class="tiny secondary button dropdown round"><i class="fi-widget"></i></a>
+                        <ul id="item-dropdown_{{ item.id }}" class="f-dropdown">
+                            <li><a i18n:translate="" ng-href="${prefix}/{{ item.id }}">View properties</a></li>
+                            <li><a i18n:translate="" ng-href="${request.route_url('instance_create')}?image_id={{ item.id }}">Launch instance</a></li>
+                            <li><a ng-href="${request.route_url('launchconfig_new')}?image_id={{ item.id }}"
+                                   i18n:translate="">Create scaling group launch configuration</a>
+                            </li>
+                        </ul>
+                    </span>
                 </td>
             </metal:block>
         </div>

--- a/koala/views/images.py
+++ b/koala/views/images.py
@@ -42,7 +42,9 @@ class ImagesView(LandingPageView):
             LandingPageFilter(key='owner_alias', name='Images owned by', choices=owner_choices),
         ]
         # filter_keys are passed to client-side filtering in search box
-        self.filter_keys = ['architecture', 'description', 'id', 'name', 'owner_alias']
+        self.filter_keys = [
+            'architecture', 'description', 'id', 'name', 'owner_alias',
+            'platform_name', 'root_device_type', 'tagged_name']
         # sort_keys are passed to sorting drop-down
         self.sort_keys = [
             dict(key='id', name='ID'),
@@ -70,19 +72,15 @@ class ImagesJsonView(BaseView):
         images = []
         for image in self.get_items():
             platform = ImageView.get_platform(image)
-            tagged_name = image.tags.get('Name', '') if image.tags.get('Name', '') else ''
             images.append(dict(
                 architecture=image.architecture,
                 description=image.description,
                 id=image.id,
-                kernel_id=image.kernel_id,
                 name=image.name,
-                tagged_name=tagged_name,
+                tagged_name=TaggedItemView.get_display_name(image),
                 owner_alias=image.owner_alias,
                 platform_name=ImageView.get_platform_name(platform),
-                platform_key=ImageView.get_platform_key(platform),
                 root_device_type=image.root_device_type,
-                ramdisk_id=image.ramdisk_id,
             ))
         return dict(results=images)
 


### PR DESCRIPTION
Implemented in this pull request…
- Table view first column header changed to Name (ID) and uses the tagged name if there is one.
- Modified the other name column header to be EMI Name
- Removed Kernel ID from tile view
- Added Create Scaling Group Launch Configuration under actions menu (tile and table views)

Also implemented…
- Styled architecture and root device types to use Foundation label classes.  Let me know if the styles/colors should be modified (assuming we're keeping them) or if they should be removed.
