### PR TITLE
Refactor display of security group rules in Launch Instance and Launch Config wizards.

### DIFF
--- a/koala/templates/instances/instance_launch.pt
+++ b/koala/templates/instances/instance_launch.pt
@@ -118,35 +118,7 @@
                                     ng_attrs={'model': 'keyPair'})}
                             ${panel('form_field', field=launch_form['securitygroup'], leftcol_width=3, rightcol_width=9,
                                 ng_attrs={'model': 'securityGroup', 'change': 'updateSelectedSecurityGroupRules()'})}
-                            <div class="row">
-                                <div class="small-3 columns">&nbsp;</div>
-                                <div class="small-9 columns rules-title" ng-show="selectedGroupRules.length > 0">
-                                    <span i18n:translate="">Incoming rules for security group</span>
-                                    <b>{{ securityGroup }}</b>:
-                                </div>
-                                <div class="small-9 columns rules-title" ng-show="selectedGroupRules.length === 0">
-                                    <p>
-                                        <span i18n:translate="">WARNING, NO RULES DEFINED!</span>
-                                        Your instance(s) will not be accessible until you add rules to this security group
-                                        (commonly, open port 22 for SSH access to Linux instances and port 3389 for RDP access to Windows instances).
-                                        You can add rules to security group
-                                        <a ng-href="/securitygroups/{{ securityGroup }}" target="_blank">{{ securityGroup }}</a>
-                                        after you launch the instance(s) if you select security group {{ securityGroup }}.
-                                    </p>
-                                </div>
-                            </div>
-                            <div class="row controls-wrapper" ng-repeat="rule in selectedGroupRules ">
-                                <div class="small-3 columns">&nbsp;</div>
-                                <div class="small-9 columns">
-                                    <strong i18n:translate="">Rule</strong>:
-                                    {{ rule.ip_protocol.toUpperCase() }}
-                                    ({{ rule.from_port }}<span ng-show="rule.to_port != rule.from_port"> - {{ rule.to_port }}</span>)
-                                    <span ng-repeat="grant in rule.grants">
-                                        <span ng-show="grant.cidr_ip">{{ grant.cidr_ip }}</span>
-                                        <span ng-show="grant.name">{{ grant.owner_id }}/{{ grant.name }}</span>
-                                    </span>
-                                </div>
-                            </div>
+                            ${panel('securitygroup_rules_preview')}
                             <hr />
                             <div class="row">
                                 <div class="small-3 columns">&nbsp;</div>

--- a/koala/templates/launchconfigs/launchconfig_wizard.pt
+++ b/koala/templates/launchconfigs/launchconfig_wizard.pt
@@ -82,12 +82,13 @@
                             <p class="description" i18n:translate="">
                                 Specify the launch configuration name and the instance size/type.
                             </p>
-                            ${panel('form_field', field=create_form['name'])}
-                            ${panel('form_field', field=create_form['instance_type'], ng_attrs={'model': 'instanceType'})}
+                            ${panel('form_field', field=create_form['name'], leftcol_width=3, rightcol_width=9)}
+                            ${panel('form_field', field=create_form['instance_type'], leftcol_width=3, rightcol_width=9,
+                                    ng_attrs={'model': 'instanceType'})}
                             <hr />
                             <div class="row">
-                                <div class="small-4 columns">&nbsp;</div>
-                                <div class="small-8 columns field inline">
+                                <div class="small-3 columns">&nbsp;</div>
+                                <div class="small-9 columns field inline">
                                     <a id="visit-step-3" class="button small round" ng-click="visitNextStep(3, $event)">
                                         <span i18n:translate="">Next</span>
                                     </a>
@@ -99,42 +100,15 @@
                             <p class="description" i18n:translate="">
                                 Specify the key pair and security group.
                             </p>
-                            ${panel('form_field', field=create_form['keypair'], ng_attrs={'model': 'keyPair'})}
-                            ${panel('form_field', field=create_form['securitygroup'],
+                            ${panel('form_field', field=create_form['keypair'], leftcol_width=3, rightcol_width=9,
+                                    ng_attrs={'model': 'keyPair'})}
+                            ${panel('form_field', field=create_form['securitygroup'], leftcol_width=3, rightcol_width=9,
                                 ng_attrs={'model': 'securityGroup', 'change': 'updateSelectedSecurityGroupRules()'})}
-                            <div class="row">
-                                <div class="small-4 columns">&nbsp;</div>
-                                <div class="small-8 columns rules-title" ng-show="selectedGroupRules.length > 0">
-                                    <span i18n:translate="">Incoming rules for security group</span>
-                                    <b>{{ securityGroup }}</b>:
-                                </div>
-                                <div class="small-8 columns rules-title" ng-show="selectedGroupRules.length === 0">
-                                    <p>
-                                        <span i18n:translate="">WARNING, NO RULES DEFINED!</span>
-                                        Your instance(s) will not be accessible until you add rules to this security group
-                                        (commonly, open port 22 for SSH access to Linux instances and port 3389 for RDP access to Windows instances).
-                                        You can add rules to security group
-                                        <a ng-href="/securitygroups/{{ securityGroup }}" target="_blank">{{ securityGroup }}</a>
-                                        after you launch the instance(s) if you select security group {{ securityGroup }}.
-                                    </p>
-                                </div>
-                            </div>
-                            <div class="row controls-wrapper" ng-repeat="rule in selectedGroupRules ">
-                                <div class="small-4 columns">&nbsp;</div>
-                                <div class="small-8 columns">
-                                    <strong i18n:translate="">Rule</strong>:
-                                    {{ rule.ip_protocol.toUpperCase() }}
-                                    ({{ rule.from_port }}<span ng-show="rule.to_port != rule.from_port"> - {{ rule.to_port }}</span>)
-                                    <span ng-repeat="grant in rule.grants">
-                                        <span ng-show="grant.cidr_ip">{{ grant.cidr_ip }}</span>
-                                        <span ng-show="grant.name">{{ grant.owner_id }}/{{ grant.name }}</span>
-                                    </span>
-                                </div>
-                            </div>
+                            ${panel('securitygroup_rules_preview')}
                             <hr />
                             <div class="row">
-                                <div class="small-4 columns">&nbsp;</div>
-                                <div class="small-8 columns field inline">
+                                <div class="small-3 columns">&nbsp;</div>
+                                <div class="small-9 columns field inline">
                                     <button type="submit" class="button" id="create-launchconfig-btn-step3">
                                         <span i18n:translate="">Create Launch Configuration</span>
                                     </button><br />

--- a/koala/templates/panels/securitygroup_rules_preview.pt
+++ b/koala/templates/panels/securitygroup_rules_preview.pt
@@ -1,0 +1,32 @@
+<!--! Security group rules preview (used in Launch Instance and Create Launch Configuration wizards) -->
+<div tal:omit-tag="">
+    <div class="row">
+        <div class="small-${leftcol_width} columns">&nbsp;</div>
+        <div class="small-${rightcol_width} columns rules-title" ng-show="selectedGroupRules.length > 0">
+            <span i18n:translate="">Incoming rules for security group</span>
+            <b>{{ securityGroup }}</b>:
+        </div>
+        <div class="small-${rightcol_width} columns rules-title" ng-show="selectedGroupRules.length === 0">
+            <p>
+                <span i18n:translate="">WARNING, NO RULES DEFINED!</span>
+                Your instance(s) will not be accessible until you add rules to this security group
+                (commonly, open port 22 for SSH access to Linux instances and port 3389 for RDP access to Windows instances).
+                You can add rules to security group
+                <a ng-href="/securitygroups/{{ securityGroup }}" target="_blank">{{ securityGroup }}</a>
+                after you launch the instance(s) if you select security group {{ securityGroup }}.
+            </p>
+        </div>
+    </div>
+    <div class="row controls-wrapper" ng-repeat="rule in selectedGroupRules ">
+        <div class="small-${leftcol_width} columns">&nbsp;</div>
+        <div class="small-${rightcol_width} columns">
+            <strong i18n:translate="">Rule</strong>:
+            {{ rule.ip_protocol.toUpperCase() }}
+            ({{ rule.from_port }}<span ng-show="rule.to_port != rule.from_port"> - {{ rule.to_port }}</span>)
+            <span ng-repeat="grant in rule.grants">
+                <span ng-show="grant.cidr_ip">{{ grant.cidr_ip }}</span>
+                <span ng-show="grant.name">{{ grant.owner_id }}/{{ grant.name }}</span>
+            </span>
+        </div>
+    </div>
+</div>

--- a/koala/views/launchconfigs.py
+++ b/koala/views/launchconfigs.py
@@ -208,6 +208,7 @@ class CreateLaunchConfigView(BlockDeviceMappingItemView):
             images_json_endpoint=self.images_json_endpoint,
             owner_choices=self.owner_choices,
             snapshot_choices=self.get_snapshot_choices(),
+            securitygroups_rules_json=self.securitygroups_rules_json,
         )
 
     @view_config(route_name='launchconfig_new', renderer=TEMPLATE, request_method='GET')

--- a/koala/views/panels.py
+++ b/koala/views/panels.py
@@ -129,6 +129,16 @@ def securitygroup_rules(context, request, rules=None, groupnames=None, leftcol_w
     )
 
 
+@panel_config('securitygroup_rules_preview', renderer='../templates/panels/securitygroup_rules_preview.pt')
+def securitygroup_rules_preview(context, request, leftcol_width=3, rightcol_width=9):
+    """ Security group rules preview, used in Launch Instance and Create Launch Configuration wizards.
+    """
+    return dict(
+        leftcol_width=leftcol_width,
+        rightcol_width=rightcol_width,
+    )
+
+
 @panel_config('bdmapping_editor', renderer='../templates/panels/bdmapping_editor.pt')
 def bdmapping_editor(context, request, image=None, snapshot_choices=None):
     """ Block device mapping editor (e.g. for Launch Instance page).


### PR DESCRIPTION
Refactor Launch Instance and Create Launch Configuration wizards to keep things DRY.  
Fix issue passing security group rules to Launch Config wizard.
