### PR TITLE
GUI-353: Enable inline Create Security Group operation in Launch Instance wizard

### DIFF
--- a/koala/static/css/pages/instance_launch.css
+++ b/koala/static/css/pages/instance_launch.css
@@ -38,7 +38,7 @@
 #launch-instance-form #image-id-input { width: 10rem; display: inline; }
 #launch-instance-form #controls_userdata_file { position: relative; top: -0.5rem; }
 #launch-instance-form #controls_userdata_file #userdata_file { width: 80%; display: inline-block; }
-#launch-instance-form #create-keypair-link { position: relative; top: -6px; margin-bottom: 10px; }
+#launch-instance-form #create-keypair-link, #launch-instance-form #create-securitygroup-link { position: relative; top: -6px; margin-bottom: 10px; }
 #launch-instance-form .rules-title { margin-bottom: 3px; }
 
 #create-keypair-modal #keypair-material { height: 16rem; color: white; background-color: black; font-weight: bold; font-family: Courier, "courier New", monospace, sans-serif; }

--- a/koala/static/js/widgets/securitygroup_rules.js
+++ b/koala/static/js/widgets/securitygroup_rules.js
@@ -9,6 +9,7 @@ angular.module('SecurityGroupRules', [])
         $scope.rulesEditor = $('#rules-editor');
         $scope.rulesTextarea = $scope.rulesEditor.find('textarea#rules');
         $scope.rulesArray = [];
+        $scope.selectedProtocol = '';
         $scope.resetValues = function () {
             $scope.trafficType = 'ip';
             $scope.fromPort = '';
@@ -67,7 +68,7 @@ angular.module('SecurityGroupRules', [])
             $scope.syncRules();
         };
         $scope.setPorts = function (port) {
-            if (!isNaN(port)) {
+            if (!isNaN(parseInt(port, 10))) {
                 $scope.fromPort = port;
                 $scope.toPort = port;
             } else {
@@ -80,10 +81,3 @@ angular.module('SecurityGroupRules', [])
         };
     })
 ;
-
-
-// Avoid clobbering the tag editor, since we have multiple ng-app="" attributes on the page.
-angular.element(document).ready(function() {
-    angular.bootstrap(document.getElementById('tag-editor'), ['TagEditor']);
-});
-

--- a/koala/static/sass/pages/instance_launch.scss
+++ b/koala/static/sass/pages/instance_launch.scss
@@ -34,7 +34,7 @@
             display: inline-block;
         }
     }
-    #create-keypair-link {
+    #create-keypair-link, #create-securitygroup-link {
         position: relative;
         top: -6px;
         margin-bottom: 10px;

--- a/koala/templates/instances/instance_launch.pt
+++ b/koala/templates/instances/instance_launch.pt
@@ -7,7 +7,7 @@
 
 <div metal:fill-slot="main_content">
     <div class="row" id="contentwrap" ng-app="LaunchInstance" ng-controller="LaunchInstanceCtrl"
-         ng-init="initController('${securitygroups_rules_json}', '${keypair_names_json}')">
+         ng-init="initController('${securitygroups_rules_json}', '${keypair_choices_json}', '${securitygroup_choices_json}')">
         <h3 class="header" id="pagetitle">
             <metal:breadcrumbs metal:use-macro="layout.global_macros['breadcrumbs']">
                 <metal:crumbs metal:fill-slot="crumbs">
@@ -121,7 +121,14 @@
                                 </div>
                             </div>
                             ${panel('form_field', field=launch_form['securitygroup'], leftcol_width=3, rightcol_width=9,
-                                ng_attrs={'model': 'securityGroup', 'change': 'updateSelectedSecurityGroupRules()'})}
+                                ng_attrs={'model': 'securityGroup', 'change': 'updateSelectedSecurityGroupRules()',
+                                          'options': 'k as v for (k, v) in securityGroupChoices'})}
+                            <div class="row">
+                                <div class="small-9 columns right">
+                                    <a data-reveal-id="create-securitygroup-modal" i18n:translate=""
+                                       id="create-securitygroup-link">Create security group</a>
+                                </div>
+                            </div>
                             ${panel('securitygroup_rules_preview')}
                             <hr />
                             <div class="row">
@@ -245,7 +252,7 @@
                 Save the key pair the file in a place you will remember.
                 You will need to enter the path later to connect to your instances.
             </p>
-            <form method="post" data-abide="abide" ng-show="!showKeyPairMaterial"
+            <form method="post" data-abide="abide" ng-show="!showKeyPairMaterial" id="create-keypair-form"
                   ng-submit="handleKeyPairCreate($event, '${request.route_url('keypair_create')}')">
                 ${structure:keypair_form['csrf_token']}
                 ${panel('form_field', field=keypair_form['name'], ng_attrs={'model': 'newKeyPairName'},
@@ -266,6 +273,31 @@
                 <button type="submit" class="button" id="confirm-keypair-btn" i18n:translate="">
                     Got it!
                 </button>
+            </form>
+            <a class="close-reveal-modal">&#215;</a>
+        </div>
+        <div id="create-securitygroup-modal" class="reveal-modal medium" data-reveal="" ng-cloak="">
+            <h3 i18n:translate="">Create security group</h3>
+            <p i18n:translate=""></p>
+            <form method="post" data-abide="abide" id="create-securitygroup-form"
+                  ng-submit="handleSecurityGroupCreate($event, '${request.route_url('securitygroup_create')}')">
+                ${structure:securitygroup_form['csrf_token']}
+                ${panel('form_field', field=securitygroup_form['name'], ng_attrs={'model': 'newSecurityGroupName'},
+                        leftcol_width=3, rightcol_width=9)}
+                ${panel('form_field', field=securitygroup_form['description'], ng_attrs={'model': 'newSecurityGroupDesc'},
+                        leftcol_width=3, rightcol_width=9)}
+                <hr />
+                ${panel('securitygroup_rules', groupnames=security_group_names)}
+                <hr />
+                <div class="row">
+                    <div class="small-3 columns">&nbsp;</div>
+                    <div class="small-9 columns field inline">
+                        <button type="submit" class="button" id="create-securitygroup-btn"
+                                i18n:translate="" ng-disabled="isLoadingSecurityGroup">
+                            Create security group
+                        </button>
+                    </div>
+                </div>
             </form>
             <a class="close-reveal-modal">&#215;</a>
         </div>

--- a/koala/views/instances.py
+++ b/koala/views/instances.py
@@ -18,6 +18,7 @@ from ..forms.instances import (
     InstanceForm, AttachVolumeForm, DetachVolumeForm, LaunchInstanceForm, LaunchMoreInstancesForm,
     RebootInstanceForm, StartInstanceForm, StopInstanceForm, TerminateInstanceForm)
 from ..forms.keypairs import KeyPairForm
+from ..forms.securitygroups import SecurityGroupForm
 from ..models import LandingPageFilter, Notification
 from ..views import BaseView, LandingPageView, TaggedItemView, BlockDeviceMappingItemView
 from ..views.images import ImageView
@@ -551,19 +552,24 @@ class InstanceLaunchView(BlockDeviceMappingItemView):
             self.request, image=self.image, securitygroups=self.securitygroups,
             conn=self.conn, formdata=self.request.params or None)
         self.keypair_form = KeyPairForm(self.request, formdata=self.request.params or None)
+        self.securitygroup_form = SecurityGroupForm(self.request, formdata=self.request.params or None)
         self.securitygroups_rules_json = json.dumps(self.get_securitygroups_rules())
         self.images_json_endpoint = self.request.route_url('images_json')
         self.owner_choices = self.get_owner_choices()
-        self.keypair_names_json = json.dumps(dict(self.launch_form.keypair.choices))
+        self.keypair_choices_json = json.dumps(dict(self.launch_form.keypair.choices))
+        self.securitygroup_choices_json = json.dumps(dict(self.launch_form.securitygroup.choices))
         self.render_dict = dict(
             image=self.image,
             launch_form=self.launch_form,
             keypair_form=self.keypair_form,
+            securitygroup_form=self.securitygroup_form,
             images_json_endpoint=self.images_json_endpoint,
             owner_choices=self.owner_choices,
             snapshot_choices=self.get_snapshot_choices(),
             securitygroups_rules_json=self.securitygroups_rules_json,
-            keypair_names_json=self.keypair_names_json,
+            keypair_choices_json=self.keypair_choices_json,
+            securitygroup_choices_json=self.securitygroup_choices_json,
+            security_group_names=[name for name, label in self.launch_form.securitygroup.choices],
         )
 
     @view_config(route_name='instance_create', renderer=TEMPLATE, request_method='GET')

--- a/koala/views/keypairs.py
+++ b/koala/views/keypairs.py
@@ -154,7 +154,7 @@ class KeyPairView(BaseView):
                 return HTTPFound(location=location)
         if self.request.is_xhr:
             form_errors = ', '.join(self.keypair_form.get_errors_list())
-            Response(status=400, resp_body=dict(message=form_errors))  # Validation failure = bad request
+            Response(status=400, body=dict(message=form_errors))  # Validation failure = bad request
         else:
             self.request.error_messages = self.keypair_form.get_errors_list()
             return self.render_dict


### PR DESCRIPTION
Also includes a fix to properly parse the selected port ranges in the security group rules editor.

Note: We aren't able to display the tag editor in the Create Security Group dialog since it conflicts with the tag editor for the instance in the wizard.
