### PR TITLE
More packaging readiness: Remove pyramid_tm

### DIFF
--- a/conf/console.default.ini
+++ b/conf/console.default.ini
@@ -33,10 +33,8 @@ pyramid.default_locale_name = en
 pyramid.includes =
     pyramid_beaker
     pyramid_chameleon
-#    pyramid_debugtoolbar
     pyramid_layout
-    pyramid_mailer
-    pyramid_tm
+#    pyramid_debugtoolbar
 
 ## Session config ##
 # See http://beaker.readthedocs.org/en/latest/configuration.html

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ requires = [
     # 'pyramid_debugtoolbar',  # Optional -- helpful for development/debugging
     'pyramid_layout >= 0.8',
     # 'pyramid_mailer >= 0.13',
-    'pyramid_tm >= 0.7',
+    # 'pyramid_tm >= 0.7',
     'python-dateutil <= 1.5',  # Don't use 2.x series unless on Python 3
     'simplejson >= 2.0.9',
     # 'SQLAlchemy == 0.8.3',


### PR DESCRIPTION
Remove pyramid_mailer from setup.py and remove pyramid_mailer and pyramid_tm from pyramid.includes in default console.ini
