### PR TITLE
Deployment readiness: Avoid HTTP/HTTPS mixed content and CORS access control warnings

### DIFF
--- a/eucaconsole/templates/changepassword.pt
+++ b/eucaconsole/templates/changepassword.pt
@@ -1,8 +1,8 @@
 <metal:block use-macro="main_template">
 
 <div metal:fill-slot="head_css">
-    <link rel="stylesheet" href="${request.static_url('eucaconsole:static/css/pages/login.css')}" />
-    <link rel="stylesheet" href="${request.static_url('eucaconsole:static/css/pages/changepassword.css')}" />
+    <link rel="stylesheet" href="${request.static_path('eucaconsole:static/css/pages/login.css')}" />
+    <link rel="stylesheet" href="${request.static_path('eucaconsole:static/css/pages/changepassword.css')}" />
 </div>
 
 <div metal:fill-slot="main_content">
@@ -26,7 +26,7 @@
                     </div>
                     </div>
                     <div class="large-8 small-12 columns large-centered">
-                        <form class="custom" id="euca-changepassword-form" method="post" action="${request.route_url('changepassword')}">
+                        <form class="custom" id="euca-changepassword-form" method="post" action="${request.route_path('changepassword')}">
                             ${structure:changepassword_form['csrf_token']}
                             <input type="hidden" name="came_from" value="${came_from}" />
                             <input type="hidden" name="account" value="${account}" />
@@ -68,7 +68,7 @@
 </div>
 
 <div metal:fill-slot="tail_js">
-    <script src="${request.static_url('eucaconsole:static/js/thirdparty/utils/zxcvbn-async.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/thirdparty/utils/zxcvbn-async.js')}"></script>
     <script type="text/javascript">
         $(document).ready(function () {
             var newPasswordForm = $('#new_password');

--- a/eucaconsole/templates/cloudwatch/alarms.pt
+++ b/eucaconsole/templates/cloudwatch/alarms.pt
@@ -1,7 +1,7 @@
 <metal:block use-macro="main_template">
 
 <head metal:fill-slot="head_css">
-    <link rel="stylesheet" type="text/css" href="${request.static_url('eucaconsole:static/css/pages/alarms.css')}" />
+    <link rel="stylesheet" type="text/css" href="${request.static_path('eucaconsole:static/css/pages/alarms.css')}" />
 </head>
 
 <div metal:fill-slot="main_content" ng-app="AlarmsPage" ng-controller="AlarmsCtrl">
@@ -75,10 +75,10 @@
 </div>
 
 <div metal:fill-slot="tail_js">
-    <script src="${request.static_url('eucaconsole:static/js/thirdparty/utils/purl.js')}"></script>
-    <script src="${request.static_url('eucaconsole:static/js/pages/custom_filters.js')}"></script>
-    <script src="${request.static_url('eucaconsole:static/js/pages/landingpage.js')}"></script>
-    <script src="${request.static_url('eucaconsole:static/js/pages/alarms.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/thirdparty/utils/purl.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/pages/custom_filters.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/pages/landingpage.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/pages/alarms.js')}"></script>
 </div>
 
 </metal:block>

--- a/eucaconsole/templates/dashboard.pt
+++ b/eucaconsole/templates/dashboard.pt
@@ -1,12 +1,12 @@
 <metal:block use-macro="main_template">
 
 <head metal:fill-slot="head_css">
-    <link rel="stylesheet" type="text/css" href="${request.static_url('eucaconsole:static/css/pages/dashboard.css')}" />
+    <link rel="stylesheet" type="text/css" href="${request.static_path('eucaconsole:static/css/pages/dashboard.css')}" />
 </head>
 
 <div metal:fill-slot="main_content">
     <div class="row" id="dashboard" ng-app="Dashboard" ng-controller="DashboardCtrl"
-         ng-init="initController('${request.route_url('dashboard_json')}')">
+         ng-init="initController('${request.route_path('dashboard_json')}')">
         <div id="pagetitle">
             <h3 i18n:translate="">Dashboard</h3>
             <div id="zone-selector">
@@ -30,14 +30,14 @@
                 <div class="tile" id="running">
                     <h5 class="subheader" i18n:translate="">Running instances</h5>
                     <div class="content">
-                        <a href="${request.route_url('instances')}?state=running">
+                        <a href="${request.route_path('instances')}?state=running">
                             <i class="icon"><em><span class="dots" ng-show="itemsLoading">&nbsp;</span>
                                 <span ng-show="!itemsLoading" id="running-instances-count" ng-cloak="">{{ totals.instances_running }}</span></em>
                             </i>
                         </a>
                     </div>
                     <div class="footer">
-                        <a class="button small round primary" href="${request.route_url('instance_create')}" i18n:translate="">Launch Instance</a>
+                        <a class="button small round primary" href="${request.route_path('instance_create')}" i18n:translate="">Launch Instance</a>
                     </div>
                 </div>
             </li>
@@ -45,7 +45,7 @@
                 <div class="tile">
                     <h5 class="subheader" i18n:translate="">Stopped instances</h5>
                     <div class="content">
-                        <a href="${request.route_url('instances')}?state=stopped">
+                        <a href="${request.route_path('instances')}?state=stopped">
                             <i class="icon"><em><span class="dots" ng-show="itemsLoading">&nbsp;</span>
                                 <span ng-show="!itemsLoading" id="stopped-instances-count" ng-cloak="">{{ totals.instances_stopped }}</span></em>
                             </i>
@@ -60,14 +60,14 @@
                         <span i18n:translate=""> Instances in scaling groups</span>
                     </h5>
                     <div class="content">
-                        <a href="${request.route_url('scalinggroups')}">
+                        <a href="${request.route_path('scalinggroups')}">
                             <i class="icon"><em><span class="dots" ng-show="itemsLoading">&nbsp;</span>
                                 <span ng-show="!itemsLoading" id="scalinggroup-instances-count" ng-cloak="">{{ totals.instances_scaling }}</span></em>
                             </i>
                         </a>
                     </div>
                     <div class="footer">
-                        <a href="${request.route_url('scalinggroup_new')}" i18n:translate="">Create scaling group</a>
+                        <a href="${request.route_path('scalinggroup_new')}" i18n:translate="">Create scaling group</a>
                     </div>
                 </div>
             </li>
@@ -75,7 +75,7 @@
                 <div class="tile">
                     <h5 class="subheader" i18n:translate="">Elastic IPs</h5>
                     <div class="content">
-                        <a href="${request.route_url('ipaddresses')}">
+                        <a href="${request.route_path('ipaddresses')}">
                             <i class="icon"><em><span class="dots" ng-show="itemsLoading">&nbsp;</span>
                                 <span ng-show="!itemsLoading" id="ipaddresses-count" ng-cloak="">{{ totals.eips }}</span></em>
                             </i>
@@ -88,14 +88,14 @@
                 <div class="tile">
                     <h5 class="subheader" i18n:translate="">Volumes</h5>
                     <div class="content">
-                        <a href="${request.route_url('volumes')}">
+                        <a href="${request.route_path('volumes')}">
                             <i class="icon"><em><span class="dots" ng-show="itemsLoading">&nbsp;</span>
                                 <span ng-show="!itemsLoading" id="volumes-count" ng-cloak="">{{ totals.volumes }}</span></em>
                             </i>
                         </a>
                     </div>
                     <div class="footer">
-                        <a href="${request.route_url('volume_view', id='new')}" i18n:translate="">Create volume</a>
+                        <a href="${request.route_path('volume_view', id='new')}" i18n:translate="">Create volume</a>
                     </div>
                 </div>
             </li>
@@ -103,14 +103,14 @@
                 <div class="tile">
                     <h5 class="subheader" i18n:translate="">Snapshots</h5>
                     <div class="content">
-                        <a href="${request.route_url('snapshots')}">
+                        <a href="${request.route_path('snapshots')}">
                             <i class="icon"><em><span class="dots" ng-show="itemsLoading">&nbsp;</span>
                                 <span ng-show="!itemsLoading" id="snapshots-count" ng-cloak="">{{ totals.snapshots }}</span></em>
                             </i>
                         </a>
                     </div>
                     <div class="footer">
-                        <a href="${request.route_url('snapshot_view', id='new')}" i18n:translate="">Create snapshot</a>
+                        <a href="${request.route_path('snapshot_view', id='new')}" i18n:translate="">Create snapshot</a>
                     </div>
                 </div>
             </li>
@@ -118,14 +118,14 @@
                 <div class="tile">
                     <h5 class="subheader" i18n:translate="">Security groups</h5>
                     <div class="content">
-                        <a href="${request.route_url('securitygroups')}">
+                        <a href="${request.route_path('securitygroups')}">
                             <i class="icon"><em><span class="dots" ng-show="itemsLoading">&nbsp;</span>
                                 <span ng-show="!itemsLoading" id="securitygroups-count" ng-cloak="">{{ totals.securitygroups }}</span></em>
                             </i>
                         </a>
                     </div>
                     <div class="footer">
-                        <a href="${request.route_url('securitygroup_view', id='new')}" i18n:translate="">Create security group</a>
+                        <a href="${request.route_path('securitygroup_view', id='new')}" i18n:translate="">Create security group</a>
                     </div>
                 </div>
             </li>
@@ -133,14 +133,14 @@
                 <div class="tile">
                     <h5 class="subheader" i18n:translate="">Key pairs</h5>
                     <div class="content">
-                        <a href="${request.route_url('keypairs')}">
+                        <a href="${request.route_path('keypairs')}">
                             <i class="icon"><em><span class="dots" ng-show="itemsLoading">&nbsp;</span>
                                 <span ng-show="!itemsLoading" id="keypairs-count" ng-cloak="">{{ totals.keypairs }}</span></em>
                             </i>
                         </a>
                     </div>
                     <div class="footer">
-                        <a href="${request.route_url('keypair_view', id='new')}" i18n:translate="">Create key pair</a>
+                        <a href="${request.route_path('keypair_view', id='new')}" i18n:translate="">Create key pair</a>
                     </div>
                 </div>
             </li>
@@ -148,14 +148,14 @@
                 <div class="tile">
                     <h5 class="subheader" i18n:translate="">IAM users</h5>
                     <div class="content">
-                        <a href="${request.route_url('users')}">
+                        <a href="${request.route_path('users')}">
                             <i class="icon"><em><span class="dots" ng-show="itemsLoading">&nbsp;</span>
                                 <span ng-show="!itemsLoading" id="users-count" ng-cloak="">{{ totals.users }}</span></em>
                             </i>
                         </a>
                     </div>
                     <div class="footer">
-                        <a href="${request.route_url('user_view', name='new')}" i18n:translate="">Create users</a>
+                        <a href="${request.route_path('user_view', name='new')}" i18n:translate="">Create users</a>
                     </div>
                 </div>
             </li>
@@ -163,14 +163,14 @@
                 <div class="tile">
                     <h5 class="subheader" i18n:translate="">IAM groups</h5>
                     <div class="content">
-                        <a href="${request.route_url('groups')}">
+                        <a href="${request.route_path('groups')}">
                             <i class="icon"><em><span class="dots" ng-show="itemsLoading">&nbsp;</span>
                                 <span ng-show="!itemsLoading" id="groups-count" ng-cloak="">{{ totals.groups }}</span></em>
                             </i>
                         </a>
                     </div>
                     <div class="footer">
-                        <a href="${request.route_url('group_view', name='new')}" i18n:translate="">Create group</a>
+                        <a href="${request.route_path('group_view', name='new')}" i18n:translate="">Create group</a>
                     </div>
                 </div>
             </li>
@@ -179,7 +179,7 @@
 </div>
 
 <div metal:fill-slot="tail_js">
-    <script src="${request.static_url('eucaconsole:static/js/pages/dashboard.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/pages/dashboard.js')}"></script>
 </div>
 
 </metal:block>

--- a/eucaconsole/templates/dialogs/create_alarm_dialog.pt
+++ b/eucaconsole/templates/dialogs/create_alarm_dialog.pt
@@ -3,7 +3,7 @@
     <div id="create-alarm-modal" class="reveal-modal ${modal_size}" data-reveal="">
         <h3 i18n:translate="">Create alarm</h3>
         <p i18n:translate="">&nbsp;</p>
-        <form action="${request.route_url('cloudwatch_alarms_create')}" method="post" data-abide="">
+        <form action="${request.route_path('cloudwatch_alarms_create')}" method="post" data-abide="">
             ${structure:alarm_form['csrf_token']}
             <input type="hidden" name="redirect_location" value="${redirect_location}" />
             <input type="hidden" name="namespace" value="{{ namespace }}" />
@@ -120,6 +120,6 @@
             </div>
         </form>
         <a class="close-reveal-modal">&#215;</a>
-        <script src="${request.static_url('eucaconsole:static/js/pages/create_alarm.js')}"></script>
+        <script src="${request.static_path('eucaconsole:static/js/pages/create_alarm.js')}"></script>
     </div>
 </div>

--- a/eucaconsole/templates/dialogs/create_keypair_dialog.pt
+++ b/eucaconsole/templates/dialogs/create_keypair_dialog.pt
@@ -8,7 +8,7 @@
             You will need to enter the path later to connect to your instances.
         </p>
         <form method="post" data-abide="abide" ng-show="!showKeyPairMaterial" id="create-keypair-form"
-              ng-submit="handleKeyPairCreate($event, '${request.route_url('keypair_create')}')">
+              ng-submit="handleKeyPairCreate($event, '${request.route_path('keypair_create')}')">
             ${structure:keypair_form['csrf_token']}
             ${panel('form_field', field=keypair_form['name'], ng_attrs={'model': 'newKeyPairName'}, leftcol_width=3, rightcol_width=9)}
             <hr>
@@ -22,7 +22,7 @@
                 </div>
             </div>
         </form>
-        <form ng-show="showKeyPairMaterial" ng-submit="downloadKeyPair($event, '${request.route_url('file_download')}')">
+        <form ng-show="showKeyPairMaterial" ng-submit="downloadKeyPair($event, '${request.route_path('file_download')}')">
             ${structure:generate_file_form['csrf_token']}
             <textarea id="keypair-material" name="content"></textarea>
             <button type="submit" class="button" id="confirm-keypair-btn" i18n:translate="">

--- a/eucaconsole/templates/dialogs/create_securitygroup_dialog.pt
+++ b/eucaconsole/templates/dialogs/create_securitygroup_dialog.pt
@@ -4,7 +4,7 @@
         <h3 i18n:translate="">Create security group</h3>
         <p i18n:translate=""></p>
         <form method="post" data-abide="abide" id="create-securitygroup-form"
-              ng-submit="handleSecurityGroupCreate($event, '${request.route_url('securitygroup_create')}')">
+              ng-submit="handleSecurityGroupCreate($event, '${request.route_path('securitygroup_create')}')">
             ${structure:securitygroup_form['csrf_token']}
             ${panel('form_field', field=securitygroup_form['name'], ng_attrs={'model': 'newSecurityGroupName'}, leftcol_width=3, rightcol_width=9)}
             ${panel('form_field', field=securitygroup_form['description'], ng_attrs={'model': 'newSecurityGroupDesc'}, leftcol_width=3, rightcol_width=9)}

--- a/eucaconsole/templates/dialogs/instance_dialogs.pt
+++ b/eucaconsole/templates/dialogs/instance_dialogs.pt
@@ -2,8 +2,8 @@
 <div tal:omit-tag="">
     <div id="change-state-dialogs">
         <div id="reboot-instance-modal" class="reveal-modal small" data-reveal=""
-             tal:define="landingpage_action request.route_url('instances_reboot');
-                         detailpage_action request.route_url('instance_reboot', id=instance.id) if instance else '';
+             tal:define="landingpage_action request.route_path('instances_reboot');
+                         detailpage_action request.route_path('instance_reboot', id=instance.id) if instance else '';
                          action landingpage_action if landingpage else detailpage_action;">
             <h3 i18n:translate="">Reboot instance</h3>
             <p i18n:translate="">Rebooting preserves the root file system of your instance across restarts.</p>
@@ -25,8 +25,8 @@
             <a class="close-reveal-modal">&#215;</a>
         </div>
         <div id="start-instance-modal" class="reveal-modal small" data-reveal=""
-             tal:define="landingpage_action request.route_url('instances_start');
-                         detailpage_action request.route_url('instance_start', id=instance.id) if instance else '';
+             tal:define="landingpage_action request.route_path('instances_start');
+                         detailpage_action request.route_path('instance_start', id=instance.id) if instance else '';
                          action landingpage_action if landingpage else detailpage_action;">
             <h3 i18n:translate="">Start instance</h3>
             <p><span i18n:translate="">Are you sure you want to start instance</span>
@@ -47,8 +47,8 @@
             <a class="close-reveal-modal">&#215;</a>
         </div>
         <div id="stop-instance-modal" class="reveal-modal small" data-reveal=""
-             tal:define="landingpage_action request.route_url('instances_stop');
-                         detailpage_action request.route_url('instance_stop', id=instance.id) if instance else '';
+             tal:define="landingpage_action request.route_path('instances_stop');
+                         detailpage_action request.route_path('instance_stop', id=instance.id) if instance else '';
                          action landingpage_action if landingpage else detailpage_action;">
             <h3 i18n:translate="">Stop instance</h3>
             <p><span i18n:translate="">Are you sure you want to stop instance</span>
@@ -69,8 +69,8 @@
             <a class="close-reveal-modal">&#215;</a>
         </div>
         <div id="terminate-instance-modal" class="reveal-modal small" data-reveal=""
-             tal:define="landingpage_action request.route_url('instances_terminate');
-                         detailpage_action request.route_url('instance_terminate', id=instance.id) if instance else '';
+             tal:define="landingpage_action request.route_path('instances_terminate');
+                         detailpage_action request.route_path('instance_terminate', id=instance.id) if instance else '';
                          action landingpage_action if landingpage else detailpage_action;">
             <h3 i18n:translate="">Terminate instance</h3>
             <div ng-show="rootDevice == 'ebs'">
@@ -120,7 +120,7 @@
             <div ng-show="platform == 'windows'">
                 <p i18n:translate=""> To connect to your instance, be sure security group "{{ groupName }}" has TCP port 3389 open to inbound traffic and then perform the following steps (these instructions do not apply if you did not select a key pair when you launched this instance):</p>
                 <ol>
-                    <li><a ng-click="promptFile('${request.route_url('instance_get_password', id='_id_')}')" i18n:translate="">Browse to your key file "{{ keyName }}.pem" in your local file system and use it to retrieve your instance password. </a></li>
+                    <li><a ng-click="promptFile('${request.route_path('instance_get_password', id='_id_')}')" i18n:translate="">Browse to your key file "{{ keyName }}.pem" in your local file system and use it to retrieve your instance password. </a></li>
                     <li i18n:translate="">Open a remote desktop client. </li>
                     <li i18n:translate="">Use the following for your username and password: </li>
                 </ol>
@@ -129,7 +129,7 @@
                     <div class="small-6 columns connect-center"> <span i18n:translate="">PASSWORD</span> </div>
                     <div class="small-6 columns connect-center"> <span> {{ publicDNS }}\\Administrator </span> </div>
                     <div class="small-6 columns connect-center">
-                        <span id="the-password"> <a id="password-link" ng-click="promptFile('${request.route_url('instance_get_password', id='_id_')}')" i18n:translate="">get password for {{ keyName }}</a></span>
+                        <span id="the-password"> <a id="password-link" ng-click="promptFile('${request.route_path('instance_get_password', id='_id_')}')" i18n:translate="">get password for {{ keyName }}</a></span>
                     </div>
                     <input type="file" id="file" name="file" class="ng-hide"/>
                 </div>

--- a/eucaconsole/templates/dialogs/ipaddress_dialogs.pt
+++ b/eucaconsole/templates/dialogs/ipaddress_dialogs.pt
@@ -1,8 +1,8 @@
 <!--! Modal dialogs for Elastic IPs on landing and detail page -->
 <div tal:omit-tag="">
     <div id="associate-ip-modal" class="reveal-modal small" data-reveal=""
-         tal:define="landingpage_action request.route_url('ipaddresses_associate');
-                     detailpage_action request.route_url('ipaddress_associate', public_ip=eip.public_ip) if eip else '';
+         tal:define="landingpage_action request.route_path('ipaddresses_associate');
+                     detailpage_action request.route_path('ipaddress_associate', public_ip=eip.public_ip) if eip else '';
                      action landingpage_action if landingpage else detailpage_action;">
         <h3 i18n:translate="">Associate elastic IP Address to instance</h3>
         <p i18n:translate="">Associate <b>${eip.public_ip if eip else '{{ publicIP }}'}</b> with an instance</p>
@@ -23,8 +23,8 @@
         <a class="close-reveal-modal">&#215;</a>
     </div>
     <div id="disassociate-ip-modal" class="reveal-modal small" data-reveal=""
-         tal:define="landingpage_action request.route_url('ipaddresses_disassociate');
-                     detailpage_action request.route_url('ipaddress_disassociate', public_ip=eip.public_ip) if eip else '';
+         tal:define="landingpage_action request.route_path('ipaddresses_disassociate');
+                     detailpage_action request.route_path('ipaddress_disassociate', public_ip=eip.public_ip) if eip else '';
                      action landingpage_action if landingpage else detailpage_action;
                      instance_name eip.instance_name if eip else '';">
         <h3 i18n:translate="">Disassociate elastic IP address from instance</h3>
@@ -45,8 +45,8 @@
         <a class="close-reveal-modal">&#215;</a>
     </div>
     <div id="release-ip-modal" class="reveal-modal small" data-reveal=""
-         tal:define="landingpage_action request.route_url('ipaddresses_release');
-                     detailpage_action request.route_url('ipaddress_release', public_ip=eip.public_ip) if eip else '';
+         tal:define="landingpage_action request.route_path('ipaddresses_release');
+                     detailpage_action request.route_path('ipaddress_release', public_ip=eip.public_ip) if eip else '';
                      action landingpage_action if landingpage else detailpage_action;">
         <h3 i18n:translate="">Release IP address to cloud</h3>
         <p i18n:translate="">If you release an elastic IP address to the cloud, you can no longer associate

--- a/eucaconsole/templates/dialogs/keypair_dialogs.pt
+++ b/eucaconsole/templates/dialogs/keypair_dialogs.pt
@@ -1,8 +1,8 @@
 <!--! Modal dialogs for Keypairs on landing and detail page -->
 <div tal:omit-tag="">
     <div id="delete-keypair-modal" class="reveal-modal small" data-reveal=""
-         tal:define="landingpage_action request.route_url('keypair_delete');
-                     detailpage_action request.route_url('keypair_delete', id=keypair.name) if keypair else '';
+         tal:define="landingpage_action request.route_path('keypair_delete');
+                     detailpage_action request.route_path('keypair_delete', id=keypair.name) if keypair else '';
                      action landingpage_action if landingpage else detailpage_action;
                      keypair_name keypair.name if keypair else '';">
         <h3 i18n:translate="">Delete key</h3>

--- a/eucaconsole/templates/dialogs/launchconfig_dialogs.pt
+++ b/eucaconsole/templates/dialogs/launchconfig_dialogs.pt
@@ -1,8 +1,8 @@
 <!--! Modal dialogs for Launch configurations on landing and detail page -->
 <div tal:omit-tag="" xmlns="http://www.w3.org/1999/html">
     <div id="delete-launchconfig-modal" class="reveal-modal small" data-reveal=""
-         tal:define="landingpage_action request.route_url('launchconfigs_delete');
-                     detailpage_action request.route_url('launchconfig_delete', id=launch_config.name) if launch_config else '';
+         tal:define="landingpage_action request.route_path('launchconfigs_delete');
+                     detailpage_action request.route_path('launchconfig_delete', id=launch_config.name) if launch_config else '';
                      action landingpage_action if landingpage else detailpage_action;
                      launch_config_name launch_config.name if launch_config else '';">
         <h3 i18n:translate="">Delete launch configuration</h3>

--- a/eucaconsole/templates/dialogs/scalinggroup_dialogs.pt
+++ b/eucaconsole/templates/dialogs/scalinggroup_dialogs.pt
@@ -2,8 +2,8 @@
 <div tal:omit-tag="">
     <!--! Delete dialogs -->
     <div id="delete-scalinggroup-modal" class="reveal-modal small" data-reveal=""
-        tal:define="landingpage_action request.route_url('scalinggroups_delete');
-                    detailpage_action request.route_url('scalinggroup_delete', id=scaling_group.name) if scaling_group else '';
+        tal:define="landingpage_action request.route_path('scalinggroups_delete');
+                    detailpage_action request.route_path('scalinggroup_delete', id=scaling_group.name) if scaling_group else '';
                     action landingpage_action if landingpage else detailpage_action;
                     has_instances scaling_group.instances if scaling_group else '';">
         <h3 i18n:translate="">Delete scaling group</h3>

--- a/eucaconsole/templates/dialogs/securitygroup_dialogs.pt
+++ b/eucaconsole/templates/dialogs/securitygroup_dialogs.pt
@@ -1,8 +1,8 @@
 <!--! Modal dialogs for Security groups on landing and detail page -->
 <div tal:omit-tag="">
     <div id="delete-securitygroup-modal" class="reveal-modal small" data-reveal=""
-         tal:define="landingpage_action request.route_url('securitygroups_delete');
-                     detailpage_action request.route_url('securitygroup_delete', id=security_group.id) if security_group else '';
+         tal:define="landingpage_action request.route_path('securitygroups_delete');
+                     detailpage_action request.route_path('securitygroup_delete', id=security_group.id) if security_group else '';
                      action landingpage_action if landingpage else detailpage_action;
                      security_group_name security_group.name if security_group else '';">
         <h3 i18n:translate="">Delete security group</h3>

--- a/eucaconsole/templates/dialogs/snapshot_dialogs.pt
+++ b/eucaconsole/templates/dialogs/snapshot_dialogs.pt
@@ -1,8 +1,8 @@
 <!--! Modal dialogs for Snapshots on landing and detail page -->
 <div tal:omit-tag="">
     <div id="delete-snapshot-modal" class="reveal-modal small" data-reveal=""
-         tal:define="landingpage_action request.route_url('snapshots_delete');
-                     detailpage_action request.route_url('snapshot_delete', id=snapshot.id) if snapshot else '';
+         tal:define="landingpage_action request.route_path('snapshots_delete');
+                     detailpage_action request.route_path('snapshot_delete', id=snapshot.id) if snapshot else '';
                      action landingpage_action if landingpage else detailpage_action;">
         <h3 i18n:translate="">Delete snapshot</h3>
         <p><span i18n:translate="">Are you sure you want to delete snapshot</span><br />
@@ -22,8 +22,8 @@
         <a class="close-reveal-modal">&#215;</a>
     </div>
     <div id="register-snapshot-modal" class="reveal-modal small" data-reveal=""
-         tal:define="landingpage_action request.route_url('snapshots_register');
-                     detailpage_action request.route_url('snapshot_register', id=snapshot.id) if snapshot else '';
+         tal:define="landingpage_action request.route_path('snapshots_register');
+                     detailpage_action request.route_path('snapshot_register', id=snapshot.id) if snapshot else '';
                      action landingpage_action if landingpage else detailpage_action;
                      html_attrs {'pattern': '^[a-zA-Z0-9\-\_\(\)\.\/]{3,128}$',
                          'error_msg': 'AMI names must be between 3 and 128 characters long, and may contain letters, numbers, \'(\', \')\', \'.\', \'-\', \'/\' and \'_\''};">

--- a/eucaconsole/templates/dialogs/terminate_instances_dialog.pt
+++ b/eucaconsole/templates/dialogs/terminate_instances_dialog.pt
@@ -6,7 +6,7 @@
             Are you sure you want to terminate these instances?
             Remove any instances below that you do not wish to terminate.
         </p>
-        <form method="post" action="${request.route_url('instances_batch_terminate')}" id="batch-terminate-form">
+        <form method="post" action="${request.route_path('instances_batch_terminate')}" id="batch-terminate-form">
             ${structure:batch_terminate_form['csrf_token']}
             <div>
                 <select multiple="" name="instance_ids" id="instance-ids" ng-cloak="">

--- a/eucaconsole/templates/dialogs/volume_dialogs.pt
+++ b/eucaconsole/templates/dialogs/volume_dialogs.pt
@@ -2,8 +2,8 @@
 <div tal:omit-tag="">
     <!--! Attach/Detach/Delete modal dialogs -->
     <div id="attach-volume-modal" class="reveal-modal small" data-reveal=""
-         tal:define="landingpage_action request.route_url('volumes_attach');
-                     detailpage_action request.route_url('volume_attach', id=volume.id) if volume else '';
+         tal:define="landingpage_action request.route_path('volumes_attach');
+                     detailpage_action request.route_path('volume_attach', id=volume.id) if volume else '';
                      action landingpage_action if landingpage else detailpage_action;
                      html_attrs {'data-placeholder': 'select...'};">
         <h3 i18n:translate="">Attach volume</h3>
@@ -32,8 +32,8 @@
         </div>
     </div>
     <div id="detach-volume-modal" class="reveal-modal small" data-reveal=""
-         tal:define="landingpage_action request.route_url('volumes_detach');
-                     detailpage_action request.route_url('volume_detach', id=volume.id) if volume else '';
+         tal:define="landingpage_action request.route_path('volumes_detach');
+                     detailpage_action request.route_path('volume_detach', id=volume.id) if volume else '';
                      action landingpage_action if landingpage else detailpage_action;">
         <h3 i18n:translate="">Detach volume</h3>
         <p>
@@ -65,8 +65,8 @@
         <a class="close-reveal-modal">&#215;</a>
     </div>
     <div id="delete-volume-modal" class="reveal-modal small" data-reveal=""
-         tal:define="landingpage_action request.route_url('volumes_delete');
-                     detailpage_action request.route_url('volume_delete', id=volume.id) if volume else '';
+         tal:define="landingpage_action request.route_path('volumes_delete');
+                     detailpage_action request.route_path('volume_delete', id=volume.id) if volume else '';
                      action landingpage_action if landingpage else detailpage_action;">
         <h3 i18n:translate="">Delete volume</h3>
         <p><span i18n:translate="">All data on the volumes will be destroyed.</span></p>

--- a/eucaconsole/templates/groups/group_view.pt
+++ b/eucaconsole/templates/groups/group_view.pt
@@ -1,8 +1,8 @@
 <metal:block use-macro="main_template">
 
 <head metal:fill-slot="head_css">
-    <link rel="stylesheet" href="${request.static_url('eucaconsole:static/js/thirdparty/codemirror/codemirror.css')}" />
-    <link rel="stylesheet" type="text/css" href="${request.static_url('eucaconsole:static/css/pages/group.css')}" />
+    <link rel="stylesheet" href="${request.static_path('eucaconsole:static/js/thirdparty/codemirror/codemirror.css')}" />
+    <link rel="stylesheet" type="text/css" href="${request.static_path('eucaconsole:static/css/pages/group.css')}" />
 </head>
 
 <div metal:fill-slot="main_content">
@@ -10,7 +10,7 @@
          ng-app="GroupPage" ng-controller="GroupPageCtrl" ng-init="initController(${group_users}, ${all_users})">
         <metal:breadcrumbs metal:use-macro="layout.global_macros['breadcrumbs']">
             <metal:crumbs metal:fill-slot="crumbs">
-                <li><a href="${request.route_url('groups')}" i18n:translate="">IAM groups</a></li>
+                <li><a href="${request.route_path('groups')}" i18n:translate="">IAM groups</a></li>
                 <li class="current">
                     <a tal:condition="group" href="#" ng-non-bindable="">${group.group_name}</a>
                     <a tal:condition="not group and group_route_id == 'new'" i18n:translate="">Create new group</a>
@@ -40,7 +40,7 @@
                 <div tal:condition="not group and group_route_id == 'new'" i18n:translate=""
                     tal:define="html_attrs {'pattern': '^[a-zA-Z0-9\+\=\,\.\@\-]{1,128}$',
                          'error_msg': 'IAM group names must be between 1 and 128 characters long, and may contain letters, numbers, \'+\', \'=\', \',\', \'.\'. \'@\' and \'-\''};">
-                    <form action="${request.route_url('group_create')}" method="post" data-abide="abide">
+                    <form action="${request.route_path('group_create')}" method="post" data-abide="abide">
                         ${structure:group_form['csrf_token']}
                         <div class="section">
                             <div class="row controls-wrapper readonly">
@@ -69,7 +69,7 @@
                                     <button type="submit" class="button" id="create-btn">
                                         <span i18n:translate="">Create</span>
                                     </button>
-                                    <a href="${request.route_url('groups')}"
+                                    <a href="${request.route_path('groups')}"
                                         class="cancel-link" i18n:translate="">Cancel</a>
                                 </div>
                             </div>
@@ -77,7 +77,7 @@
                     </form>
                 </div>
                 <div tal:condition="group">
-                    <form action="${request.route_url('group_update', name=group.group_name)}" method="post" data-abide="abide">
+                    <form action="${request.route_path('group_update', name=group.group_name)}" method="post" data-abide="abide">
                         ${structure:group_update_form['csrf_token']}
                         <div class="section">
                             <h6 i18n:translate="">General</h6>
@@ -123,18 +123,18 @@
                                     <button type="submit" class="button" id="save-changes-btn">
                                         <span tal:condition="group" i18n:translate="">Save Changes</span>
                                     </button>
-                                    <a href="${request.route_url('groups')}"
+                                    <a href="${request.route_path('groups')}"
                                         class="cancel-link" i18n:translate="">Cancel</a>
                                 </div>
                             </div>
                         </div>
                     </form>
                     <hr />
-                    <div tal:define="policies_url request.route_url('group_policies_json', name=group.group_name);
-                                     policy_url request.route_url('group_policy_json', name=group.group_name, policy='_policy_');
-                                     remove_url request.route_url('group_delete_policy', name=group.group_name, policy='_policy_');
-                                     update_url request.route_url('group_update_policy', name=group.group_name, policy='_policy_');
-                                     add_url request.route_url('iam_policy_new')+'?type=group&id='+group.group_name">
+                    <div tal:define="policies_url request.route_path('group_policies_json', name=group.group_name);
+                                     policy_url request.route_path('group_policy_json', name=group.group_name, policy='_policy_');
+                                     remove_url request.route_path('group_delete_policy', name=group.group_name, policy='_policy_');
+                                     update_url request.route_path('group_update_policy', name=group.group_name, policy='_policy_');
+                                     add_url request.route_path('iam_policy_new')+'?type=group&id='+group.group_name">
                         <div class="section">
                             <h6 i18n:translate="">Permissions</h6>
                             <div>
@@ -154,12 +154,12 @@
 </div>
 
 <div metal:fill-slot="tail_js">
-    <script src="${request.static_url('eucaconsole:static/js/thirdparty/jquery/chosen.jquery.min.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/thirdparty/jquery/chosen.jquery.min.js')}"></script>
     <div tal:condition="group">
-        <script src="${request.static_url('eucaconsole:static/js/pages/group.js')}"></script>
+        <script src="${request.static_path('eucaconsole:static/js/pages/group.js')}"></script>
     </div>
     <div tal:condition="not:group">
-        <script src="${request.static_url('eucaconsole:static/js/pages/group_new.js')}"></script>
+        <script src="${request.static_path('eucaconsole:static/js/pages/group_new.js')}"></script>
     </div>
 </div>
 

--- a/eucaconsole/templates/groups/groups.pt
+++ b/eucaconsole/templates/groups/groups.pt
@@ -1,10 +1,10 @@
 <metal:block use-macro="main_template">
 
 <head metal:fill-slot="head_css">
-    <link rel="stylesheet" type="text/css" href="${request.static_url('eucaconsole:static/css/pages/groups.css')}" />
+    <link rel="stylesheet" type="text/css" href="${request.static_path('eucaconsole:static/css/pages/groups.css')}" />
 </head>
 
-<div metal:fill-slot="main_content" ng-app="GroupsPage" ng-controller="GroupsCtrl" ng-init="initPage('${request.route_url('group_view', name='_name_')}')">
+<div metal:fill-slot="main_content" ng-app="GroupsPage" ng-controller="GroupsCtrl" ng-init="initPage('${request.route_path('group_view', name='_name_')}')">
     <div class="row" id="contentwrap" ng-controller="ItemsCtrl"
          ng-init="initController('groups', '${initial_sort_key}', '${json_items_endpoint}')">
         <metal:breadcrumbs metal:use-macro="layout.global_macros['breadcrumbs']">
@@ -21,7 +21,7 @@
         <div metal:use-macro="layout.global_macros['landing_page_datagrid']">
             <div metal:fill-slot="new_button">
                 <a class="button" i18n:translate="" id="add-group-btn"
-                   href="${request.route_url('group_view', name='new')}">Create Group</a>
+                   href="${request.route_path('group_view', name='new')}">Create Group</a>
             </div>
             <div metal:fill-slot="tile_dropdown_button" tal:omit-tag="">
                 <a class="tiny secondary button dropdown right" data-dropdown="item-dropdown_{{ item.id }}"><i class="fi-widget"></i></a>
@@ -82,7 +82,7 @@
                 <p>
                     <span i18n:translate="">Deleting a group also deletes all permissions associated with that group. Are you sure you want to delete group <strong>{{ group_name }}</strong></span>?
                 </p>
-                <form method="post" id="delete-form" action="${request.route_url('group_delete', name='_name_')}">
+                <form method="post" id="delete-form" action="${request.route_path('group_delete', name='_name_')}">
                     ${structure:delete_form['csrf_token']}
                     <div>&nbsp;</div>
                     <div class="row">
@@ -105,9 +105,9 @@
 </metal:block>
 
 <div metal:fill-slot="tail_js">
-    <script src="${request.static_url('eucaconsole:static/js/pages/custom_filters.js')}"></script>
-    <script src="${request.static_url('eucaconsole:static/js/pages/landingpage.js')}"></script>
-    <script src="${request.static_url('eucaconsole:static/js/pages/groups.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/pages/custom_filters.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/pages/landingpage.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/pages/groups.js')}"></script>
 </div>
 
 </metal:block>

--- a/eucaconsole/templates/images/image_view.pt
+++ b/eucaconsole/templates/images/image_view.pt
@@ -4,7 +4,7 @@
     <div class="row" id="contentwrap" ng-app="ImagePage">
         <metal:breadcrumbs metal:use-macro="layout.global_macros['breadcrumbs']">
             <metal:crumbs metal:fill-slot="crumbs">
-                <li><a href="${request.route_url('images')}" i18n:translate="">Images</a></li>
+                <li><a href="${request.route_path('images')}" i18n:translate="">Images</a></li>
                 <li class="current"><a href="#" ng-non-bindable="">${image_display_name}</a></li>
             </metal:crumbs>
         </metal:breadcrumbs>
@@ -21,20 +21,20 @@
                 <metal:block metal:use-macro="layout.global_macros['actions_menu']" tal:condition="image">
                     <metal:actions metal:fill-slot="actions">
                         <li>
-                            <a href="${request.route_url('instance_create')}?image_id=${image.id}"
+                            <a href="${request.route_path('instance_create')}?image_id=${image.id}"
                                id="launch-instance-action" i18n:translate="">
                                 Launch instance
                             </a>
                         </li>
                         <li>
-                            <a href="${request.route_url('launchconfig_new')}?image_id=${image.id}"
+                            <a href="${request.route_path('launchconfig_new')}?image_id=${image.id}"
                                id="create-launchconfig-action" i18n:translate="">
                                 Create launch configuration
                             </a>
                         </li>
                     </metal:actions>
                 </metal:block>
-                <form action="${request.route_url('image_update', id=image.id)}" method="post" data-abide="abide">
+                <form action="${request.route_path('image_update', id=image.id)}" method="post" data-abide="abide">
                     ${structure:image_form['csrf_token']}
                     <div tal:condition="image">
                         <div class="section">
@@ -149,7 +149,7 @@
                         <button type="submit" class="button" id="save-changes-btn">
                             <span tal:condition="image" i18n:translate="">Save Changes</span>
                         </button>
-                        <a href="${request.route_url('images')}"
+                        <a href="${request.route_path('images')}"
                            class="cancel-link" i18n:translate="">Cancel</a>
                     </div>
                 </form>

--- a/eucaconsole/templates/images/images.pt
+++ b/eucaconsole/templates/images/images.pt
@@ -1,7 +1,7 @@
 <metal:block use-macro="main_template">
 
 <head metal:fill-slot="head_css">
-    <link rel="stylesheet" type="text/css" href="${request.static_url('eucaconsole:static/css/pages/images.css')}" />
+    <link rel="stylesheet" type="text/css" href="${request.static_path('eucaconsole:static/css/pages/images.css')}" />
 </head>
 
 <div metal:fill-slot="main_content">
@@ -34,8 +34,8 @@
                 <a class="tiny secondary button dropdown right" data-dropdown="item-dropdown_{{ item.id }}"><i class="fi-widget"></i></a>
                 <ul id="item-dropdown_{{ item.id }}" class="f-dropdown" data-dropdown-content="">
                     <li><a i18n:translate="" ng-href="${prefix}/{{ item.id }}">View details</a></li>
-                    <li><a i18n:translate="" ng-href="${request.route_url('instance_create')}?image_id={{ item.id }}">Launch instance</a></li>
-                    <li><a ng-href="${request.route_url('launchconfig_new')}?image_id={{ item.id }}"
+                    <li><a i18n:translate="" ng-href="${request.route_path('instance_create')}?image_id={{ item.id }}">Launch instance</a></li>
+                    <li><a ng-href="${request.route_path('launchconfig_new')}?image_id={{ item.id }}"
                            i18n:translate="">Create launch configuration</a>
                     </li>
                 </ul>
@@ -99,8 +99,8 @@
                         <a class="tiny secondary button dropdown round" data-dropdown="item-dropdown_{{ item.id }}"><i class="fi-widget"></i></a>
                         <ul id="item-dropdown_{{ item.id }}" class="f-dropdown" data-dropdown-content="">
                             <li><a i18n:translate="" ng-href="${prefix}/{{ item.id }}">View details</a></li>
-                            <li><a i18n:translate="" ng-href="${request.route_url('instance_create')}?image_id={{ item.id }}">Launch instance</a></li>
-                            <li><a ng-href="${request.route_url('launchconfig_new')}?image_id={{ item.id }}"
+                            <li><a i18n:translate="" ng-href="${request.route_path('instance_create')}?image_id={{ item.id }}">Launch instance</a></li>
+                            <li><a ng-href="${request.route_path('launchconfig_new')}?image_id={{ item.id }}"
                                    i18n:translate="">Create launch configuration</a>
                             </li>
                         </ul>
@@ -113,15 +113,15 @@
 
 <metal:block metal:fill-slot="offcanvas_right">
     <div id="help-content-div" class="help-content">
-        ${panel('help_images', 'image_landing_page', request.route_url('instance_create') )}
+        ${panel('help_images', 'image_landing_page', request.route_path('instance_create') )}
     </div>
 </metal:block>
 
 
 <div metal:fill-slot="tail_js">
-    <script src="${request.static_url('eucaconsole:static/js/thirdparty/jquery/chosen.jquery.min.js')}"></script>
-    <script src="${request.static_url('eucaconsole:static/js/pages/custom_filters.js')}"></script>
-    <script src="${request.static_url('eucaconsole:static/js/pages/landingpage.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/thirdparty/jquery/chosen.jquery.min.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/pages/custom_filters.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/pages/landingpage.js')}"></script>
     <script tal:condition="layout.cloud_type == 'aws'">
         // Set "owned by Amazon" as default filter if on AWS
         $(document).ready(function () {

--- a/eucaconsole/templates/instances/instance_launch.pt
+++ b/eucaconsole/templates/instances/instance_launch.pt
@@ -1,7 +1,7 @@
 <metal:block use-macro="main_template">
 
 <head metal:fill-slot="head_css">
-    <link rel="stylesheet" type="text/css" href="${request.static_url('eucaconsole:static/css/pages/instance_launch.css')}" />
+    <link rel="stylesheet" type="text/css" href="${request.static_path('eucaconsole:static/css/pages/instance_launch.css')}" />
 </head>
 
 <div metal:fill-slot="main_content">
@@ -9,7 +9,7 @@
          ng-init="initController('${securitygroups_rules_json}', '${keypair_choices_json}', '${securitygroup_choices_json}')">
         <metal:breadcrumbs metal:use-macro="layout.global_macros['breadcrumbs']">
             <metal:crumbs metal:fill-slot="crumbs">
-                <li><a href="${request.route_url('instances')}" i18n:translate="">Instances</a></li>
+                <li><a href="${request.route_path('instances')}" i18n:translate="">Instances</a></li>
                 <li class="current"><a href="#" i18n:translate="">Launch instance</a></li>
             </metal:crumbs>
         </metal:breadcrumbs>
@@ -20,7 +20,7 @@
         </h3>
         <div class="large-8 columns" tal:define="_ import: pyramid.i18n.TranslationString">
             <div class="wizard no-title">
-                <form action="${request.route_url('instance_launch')}" id="launch-instance-form"
+                <form action="${request.route_path('instance_launch')}" id="launch-instance-form"
                       method="post" data-abide="abide" enctype="multipart/form-data">
                     ${structure:launch_form['csrf_token']}
                     ${structure:launch_form['image_id']}
@@ -62,8 +62,8 @@
                                 <div class="small-9 columns value">
                                     <input type="text" name="image_id" id="image-id-input" ng-model="imageID" />
                                     <a class="button small" i18n:translate="" id="image-id-btn"
-                                       ng-click="inputImageID('${request.route_url('instance_create')}')">Next</a>
-                                    <a class="cancel-link" href="${request.route_url('instances')}">Cancel</a>
+                                       ng-click="inputImageID('${request.route_path('instance_create')}')">Next</a>
+                                    <a class="cancel-link" href="${request.route_path('instances')}">Cancel</a>
                                 </div>
                             </div>
                             ${panel('image_picker', image=image, filters_form=filters_form, images_json_endpoint=images_json_endpoint)}
@@ -72,7 +72,7 @@
                                 <div class="small-8 columns field inline">
                                     <a id="visit-step-2" class="button small round" ng-click="visitNextStep(2, $event)">
                                         <span i18n:translate="">Next</span>
-                                        <a class="cancel-link" href="${request.route_url('instances')}">Cancel</a>
+                                        <a class="cancel-link" href="${request.route_path('instances')}">Cancel</a>
                                     </a>
                                 </div>
                             </div>
@@ -106,7 +106,7 @@
                                 <div class="small-9 columns field inline">
                                     <a id="visit-step-3" class="button small round" ng-click="visitNextStep(3, $event)">
                                         <span i18n:translate="">Next</span>
-                                        <a class="cancel-link" href="${request.route_url('instances')}">Cancel</a>
+                                        <a class="cancel-link" href="${request.route_path('instances')}">Cancel</a>
                                     </a>
                                 </div>
                             </div>
@@ -136,7 +136,7 @@
                                     <button type="submit" class="button" id="launch-instance-btn-step3">
                                         <span i18n:translate="">Launch Instance<span ng-show="instanceNumber > 1">s</span></span>
                                     </button>
-                                    <a class="cancel-link" href="${request.route_url('instances')}">Cancel</a>
+                                    <a class="cancel-link" href="${request.route_path('instances')}">Cancel</a>
                                     <br />
                                     <span class="or">Or:</span>
                                     <a id="visit-step-4" ng-click="visitNextStep(4, $event)">
@@ -167,7 +167,7 @@
                                     <button type="submit" class="button" id="launch-instance-btn-step4">
                                         <span i18n:translate="">Launch Instance<span ng-show="instanceNumber > 1">s</span></span>
                                     </button>
-                                    <a href="${request.route_url('instances')}"
+                                    <a href="${request.route_path('instances')}"
                                        class="cancel-link" i18n:translate="">Cancel</a>
                                 </div>
                             </div>
@@ -264,10 +264,10 @@
 </div>
 
 <div metal:fill-slot="tail_js">
-    <script src="${request.static_url('eucaconsole:static/js/thirdparty/jquery/chosen.jquery.min.js')}"></script>
-    <script src="${request.static_url('eucaconsole:static/js/thirdparty/utils/purl.js')}"></script>
-    <script src="${request.static_url('eucaconsole:static/js/thirdparty/jquery/jquery.generateFile.js')}"></script>
-    <script src="${request.static_url('eucaconsole:static/js/pages/instance_launch.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/thirdparty/jquery/chosen.jquery.min.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/thirdparty/utils/purl.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/thirdparty/jquery/jquery.generateFile.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/pages/instance_launch.js')}"></script>
 </div>
 
 </metal:block>

--- a/eucaconsole/templates/instances/instance_launch_more.pt
+++ b/eucaconsole/templates/instances/instance_launch_more.pt
@@ -1,7 +1,7 @@
 <metal:block use-macro="main_template">
 
 <head metal:fill-slot="head_css">
-    <link rel="stylesheet" type="text/css" href="${request.static_url('eucaconsole:static/css/pages/instance_launch_more.css')}" />
+    <link rel="stylesheet" type="text/css" href="${request.static_path('eucaconsole:static/css/pages/instance_launch_more.css')}" />
 </head>
 
 <div metal:fill-slot="main_content">
@@ -9,7 +9,7 @@
          ng-controller="LaunchMoreInstancesCtrl" ng-init="initController()">
         <metal:breadcrumbs metal:use-macro="layout.global_macros['breadcrumbs']">
             <metal:crumbs metal:fill-slot="crumbs">
-                <li><a href="${request.route_url('instances')}" i18n:translate="">Instances</a></li>
+                <li><a href="${request.route_path('instances')}" i18n:translate="">Instances</a></li>
                 <li class="current"><a i18n:translate="" ng-non-bindable="">Launch more instances like ${instance_name}</a></li>
             </metal:crumbs>
         </metal:breadcrumbs>
@@ -21,7 +21,7 @@
         </h3>
         <div class="large-8 columns">
             <div class="panel">
-                <form action="${request.route_url('instance_more_launch', id=instance.id)}" method="post"
+                <form action="${request.route_path('instance_more_launch', id=instance.id)}" method="post"
                       data-abide="abide" enctype="multipart/form-data" id="launch-more-form">
                     ${structure:launch_more_form['csrf_token']}
                     ${panel('form_field', field=launch_more_form['number'], min=1, maxlength=2, leftcol_width=8, rightcol_width=4, ng_attrs={'model': 'instanceNumber'})}
@@ -104,7 +104,7 @@
                             <button type="submit" class="button" id="save-changes-btn">
                                 <span i18n:translate="">Launch Instance</span><span ng-show="instanceNumber > 1">s</span>
                             </button>
-                            <a href="${request.route_url('instance_view', id=instance.id)}" id="cancel-link"
+                            <a href="${request.route_path('instance_view', id=instance.id)}" id="cancel-link"
                                class="cancel-link" i18n:translate="">Cancel</a>
                         </div>
                     </div>
@@ -124,8 +124,8 @@
 </div>
 
 <div metal:fill-slot="tail_js">
-    <script src="${request.static_url('eucaconsole:static/js/thirdparty/jquery/chosen.jquery.min.js')}"></script>
-    <script src="${request.static_url('eucaconsole:static/js/pages/instance_launch_more.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/thirdparty/jquery/chosen.jquery.min.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/pages/instance_launch_more.js')}"></script>
 </div>
 
 </metal:block>

--- a/eucaconsole/templates/instances/instance_view.pt
+++ b/eucaconsole/templates/instances/instance_view.pt
@@ -1,18 +1,18 @@
 <metal:block use-macro="main_template">
 
 <head metal:fill-slot="head_css">
-    <link rel="stylesheet" type="text/css" href="${request.static_url('eucaconsole:static/css/pages/instance.css')}" />
+    <link rel="stylesheet" type="text/css" href="${request.static_path('eucaconsole:static/css/pages/instance.css')}" />
 </head>
 
 <div metal:fill-slot="main_content">
     <div class="row" id="contentwrap" ng-app="InstancePage" ng-controller="InstancePageCtrl"
-             ng-init="initController('${request.route_url('instance_state_json', id=instance.id)}',
-                                     '${request.route_url('instance_console_output_json', id=instance.id)}',
+             ng-init="initController('${request.route_path('instance_state_json', id=instance.id)}',
+                                     '${request.route_path('instance_console_output_json', id=instance.id)}',
                                      '${instance.state}', '${instance.id}', '${instance.groups[0].name}',
                                      '${instance.key_name}', '${instance.public_dns_name}', '${instance.platform}')">
         <metal:breadcrumbs metal:use-macro="layout.global_macros['breadcrumbs']">
             <metal:crumbs metal:fill-slot="crumbs">
-                <li><a href="${request.route_url('instances')}" i18n:translate="">Instances</a></li>
+                <li><a href="${request.route_path('instances')}" i18n:translate="">Instances</a></li>
                 <li class="current"><a href="#" ng-non-bindable="">${instance_name}</a></li>
             </metal:crumbs>
         </metal:breadcrumbs>
@@ -25,7 +25,7 @@
         <div class="large-8 columns">
             <dl class="tabs" id="instance-subnav">
                 <dd class="active"><a href="#" i18n:translate="">General</a></dd>
-                <dd><a href="${request.route_url('instance_volumes', id=instance.id)}" i18n:translate="">Volumes</a></dd>
+                <dd><a href="${request.route_path('instance_volumes', id=instance.id)}" i18n:translate="">Volumes</a></dd>
             </dl>
             <div class="panel has-actions">
                 <metal:block metal:use-macro="layout.global_macros['actions_menu']">
@@ -35,7 +35,7 @@
                                i18n:translate="">Connect to instance</a>
                         </li>
                         <li>
-                            <a href="${request.route_url('instance_more', id=instance.id)}"
+                            <a href="${request.route_path('instance_more', id=instance.id)}"
                                id="launchmore-instance-action"  i18n:translate="">
                                 Launch more like this
                             </a>
@@ -73,7 +73,7 @@
                     Instance type, user data, kernel ID and RAM disk ID (ramfs) may only be updated for instances with an EBS root device.
                     To update any of these attributes, stop the instance first.
                 </p>
-                <form action="${request.route_url('instance_update', id=instance.id)}" id="instance-form"
+                <form action="${request.route_path('instance_update', id=instance.id)}" id="instance-form"
                       method="post" data-abide="abide">
                     ${structure:instance_form['csrf_token']}
                     ${structure:instance_form['start_later']}
@@ -157,7 +157,7 @@
                     <div class="row controls-wrapper readonly" tal:condition="scaling_group">
                         <div class="small-4 columns"><label i18n:translate="">Scaling group</label></div>
                         <div class="small-8 columns value">
-                            <a href="${request.route_url('scalinggroup_view', id=scaling_group)}" ng-non-bindable="">${scaling_group}</a>
+                            <a href="${request.route_path('scalinggroup_view', id=scaling_group)}" ng-non-bindable="">${scaling_group}</a>
                         </div>
                     </div>
                     <div class="row controls-wrapper readonly" tal:condition="instance.owner_id">
@@ -212,7 +212,7 @@
                         <button type="submit" class="button" id="save-changes-btn" ng-click="submitSaveChanges($event)">
                             <span i18n:translate="">Save Changes</span>
                         </button>
-                        <a href="${request.route_url('instances')}" id="cancel-update-link"
+                        <a href="${request.route_path('instances')}" id="cancel-update-link"
                            class="cancel-link" i18n:translate="">Cancel</a>
                         <button type="submit" class="button" style="display:none;" id="save-update-button"></button>
                     </div>
@@ -255,8 +255,8 @@
 </div>
 
 <div metal:fill-slot="tail_js">
-    <script src="${request.static_url('eucaconsole:static/js/thirdparty/jquery/jquery.base64.js')}"></script>
-    <script src="${request.static_url('eucaconsole:static/js/pages/instance.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/thirdparty/jquery/jquery.base64.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/pages/instance.js')}"></script>
 </div>
 
 </metal:block>

--- a/eucaconsole/templates/instances/instance_volumes.pt
+++ b/eucaconsole/templates/instances/instance_volumes.pt
@@ -1,16 +1,16 @@
 <metal:block use-macro="main_template">
 
 <head metal:fill-slot="head_css">
-    <link rel="stylesheet" type="text/css" href="${request.static_url('eucaconsole:static/css/pages/instance.css')}" />
+    <link rel="stylesheet" type="text/css" href="${request.static_path('eucaconsole:static/css/pages/instance.css')}" />
 </head>
 
 <div metal:fill-slot="main_content">
     <div class="row" id="contentwrap" ng-app="InstanceVolumes"
          ng-controller="InstanceVolumesCtrl"
-         ng-init="initController('${request.route_url('instance_volumes_json', id=instance.id)}')">
+         ng-init="initController('${request.route_path('instance_volumes_json', id=instance.id)}')">
         <metal:breadcrumbs metal:use-macro="layout.global_macros['breadcrumbs']">
             <metal:crumbs metal:fill-slot="crumbs">
-                <li><a href="${request.route_url('instances')}" i18n:translate="">Instances</a></li>
+                <li><a href="${request.route_path('instances')}" i18n:translate="">Instances</a></li>
                 <li class="current"><a href="#" ng-non-bindable="">${instance_name}</a></li>
             </metal:crumbs>
         </metal:breadcrumbs>
@@ -22,7 +22,7 @@
         </h3>
         <div class="large-8 columns" tal:define="parse_date import: dateutil.parser.parse">
             <dl class="tabs" id="instance-subnav">
-                <dd><a href="${request.route_url('instance_view', id=instance.id)}" i18n:translate="">General</a></dd>
+                <dd><a href="${request.route_path('instance_view', id=instance.id)}" i18n:translate="">General</a></dd>
                 <dd class="active"><a i18n:translate="">Volumes</a></dd>
             </dl>
             <div class="panel gridwrapper no-title">
@@ -80,7 +80,7 @@
             <div id="attach-volume-modal" class="reveal-modal small" data-reveal="">
                 <h3 i18n:translate="">Attach volume</h3>
                 <p><span i18n:translate="">Attach a volume to instance</span> <strong ng-non-bindable="">${instance_name}</strong></p>
-                <form method="post" action="${request.route_url('instance_volume_attach', id=instance.id)}"
+                <form method="post" action="${request.route_path('instance_volume_attach', id=instance.id)}"
                       id="attach-form" data-abide="">
                     ${structure:attach_form['csrf_token']}
                     ${panel('form_field', field=attach_form.volume_id)}
@@ -126,8 +126,8 @@
 </div>
 
 <div metal:fill-slot="tail_js">
-    <script src="${request.static_url('eucaconsole:static/js/thirdparty/jquery/chosen.jquery.min.js')}"></script>
-    <script src="${request.static_url('eucaconsole:static/js/pages/instance_volumes.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/thirdparty/jquery/chosen.jquery.min.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/pages/instance_volumes.js')}"></script>
 </div>
 
 </metal:block>

--- a/eucaconsole/templates/instances/instances.pt
+++ b/eucaconsole/templates/instances/instances.pt
@@ -1,7 +1,7 @@
 <metal:block use-macro="main_template">
 
 <head metal:fill-slot="head_css">
-    <link rel="stylesheet" type="text/css" href="${request.static_url('eucaconsole:static/css/pages/instances.css')}" />
+    <link rel="stylesheet" type="text/css" href="${request.static_path('eucaconsole:static/css/pages/instances.css')}" />
 </head>
 
 <div metal:fill-slot="main_content" ng-app="InstancesPage" ng-controller="InstancesCtrl" ng-init="initController()">
@@ -21,7 +21,7 @@
         <div metal:use-macro="layout.global_macros['landing_page_datagrid']">
             <div metal:fill-slot="new_button">
                 <a class="button" i18n:translate="" id="launch-instance-btn"
-                   href="${request.route_url('instance_create')}">Launch New Instance</a>
+                   href="${request.route_path('instance_create')}">Launch New Instance</a>
                 <a class="button secondary" i18n:translate="" id="terminate-instances-btn" ng-cloak="" ng-show="!itemsLoading"
                    href="#" data-reveal-id="batch-terminate-modal">Terminate {{ unterminatedInstancesCount(items) }} Instances</a>
             </div>
@@ -194,11 +194,11 @@
 </metal:block>
 
 <div metal:fill-slot="tail_js">
-    <script src="${request.static_url('eucaconsole:static/js/thirdparty/jquery/jquery.base64.js')}"></script>
-    <script src="${request.static_url('eucaconsole:static/js/thirdparty/jquery/chosen.jquery.min.js')}"></script>
-    <script src="${request.static_url('eucaconsole:static/js/pages/custom_filters.js')}"></script>
-    <script src="${request.static_url('eucaconsole:static/js/pages/landingpage.js')}"></script>
-    <script src="${request.static_url('eucaconsole:static/js/pages/instances.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/thirdparty/jquery/jquery.base64.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/thirdparty/jquery/chosen.jquery.min.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/pages/custom_filters.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/pages/landingpage.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/pages/instances.js')}"></script>
 </div>
 
 </metal:block>

--- a/eucaconsole/templates/ipaddresses/ipaddress_view.pt
+++ b/eucaconsole/templates/ipaddresses/ipaddress_view.pt
@@ -10,7 +10,7 @@
     <div class="row" id="contentwrap" ng-app="">
         <metal:breadcrumbs metal:use-macro="layout.global_macros['breadcrumbs']">
             <metal:crumbs metal:fill-slot="crumbs">
-                <li><a href="${request.route_url('ipaddresses')}" i18n:translate="">Elastic IP addresses</a></li>
+                <li><a href="${request.route_path('ipaddresses')}" i18n:translate="">Elastic IP addresses</a></li>
                 <li class="current"><a href="#" ng-non-bindable="">${eip.public_ip if eip else ''}</a></li>
             </metal:crumbs>
         </metal:breadcrumbs>
@@ -73,7 +73,7 @@
 </div>
 
 <div metal:fill-slot="tail_js">
-    <script src="${request.static_url('eucaconsole:static/js/thirdparty/jquery/chosen.jquery.min.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/thirdparty/jquery/chosen.jquery.min.js')}"></script>
     <script>
         $(document).ready(function() {
             $('#instance_id').chosen({'width': '80%'});

--- a/eucaconsole/templates/ipaddresses/ipaddresses.pt
+++ b/eucaconsole/templates/ipaddresses/ipaddresses.pt
@@ -1,7 +1,7 @@
 <metal:block use-macro="main_template">
 
 <head metal:fill-slot="head_css">
-    <link rel="stylesheet" type="text/css" href="${request.static_url('eucaconsole:static/css/pages/ipaddresses.css')}" />
+    <link rel="stylesheet" type="text/css" href="${request.static_path('eucaconsole:static/css/pages/ipaddresses.css')}" />
 </head>
 
 <div metal:fill-slot="main_content" ng-app="ElasticIPsPage" ng-controller="ElasticIPsCtrl" ng-init="initController()">
@@ -90,7 +90,7 @@
                 you are allowed to manage.
             </p>
             <p i18n:translate="">How may IP addresses would you like to allocate?</p>
-            <form action="${request.route_url('ipaddresses')}" method="post" data-abide="abide">
+            <form action="${request.route_path('ipaddresses')}" method="post" data-abide="abide">
                 ${structure:allocate_form['csrf_token']}
                 ${panel('form_field', field=allocate_form.ipcount)}
                 <div class="row">
@@ -114,10 +114,10 @@
 </metal:block>
 
 <div metal:fill-slot="tail_js">
-    <script src="${request.static_url('eucaconsole:static/js/thirdparty/jquery/chosen.jquery.min.js')}"></script>
-    <script src="${request.static_url('eucaconsole:static/js/pages/custom_filters.js')}"></script>
-    <script src="${request.static_url('eucaconsole:static/js/pages/landingpage.js')}"></script>
-    <script src="${request.static_url('eucaconsole:static/js/pages/ipaddresses.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/thirdparty/jquery/chosen.jquery.min.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/pages/custom_filters.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/pages/landingpage.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/pages/ipaddresses.js')}"></script>
 </div>
 
 </metal:block>

--- a/eucaconsole/templates/keypairs/keypair_view.pt
+++ b/eucaconsole/templates/keypairs/keypair_view.pt
@@ -6,7 +6,7 @@
             ng-app="KeypairPage" ng-controller="KeypairPageCtrl" ng-init="initController()">
         <metal:breadcrumbs metal:use-macro="layout.global_macros['breadcrumbs']">
             <metal:crumbs metal:fill-slot="crumbs">
-                <li><a href="${request.route_url('keypairs')}" i18n:translate="">Key pairs</a></li>
+                <li><a href="${request.route_path('keypairs')}" i18n:translate="">Key pairs</a></li>
                 <li class="current">
                     <a tal:condition="keypair" ng-non-bindable="">${keypair.name }</a>
                     <a tal:condition="not keypair and keypair_route_id == 'new'" i18n:translate="">Create New Key Pair</a>
@@ -28,7 +28,7 @@
         </h3>
         <!-- New Keypair Material Download -->
         <div tal:condition="keypair_created ">
-           <form id="download-keypair-form" action="${request.route_url('file_download')}" method="post">
+           <form id="download-keypair-form" action="${request.route_path('file_download')}" method="post">
                ${structure:keypair_form['csrf_token']}
            </form>
            <script language="Javascript">
@@ -66,7 +66,7 @@
                     <p i18n:translate="">
                         Save the file in a place you will remember. You will need to enter the path later to connect to your instances.
                     </p>
-                    <form  action="${request.route_url('keypair_create')}" method="post" data-abide="abide">
+                    <form  action="${request.route_path('keypair_create')}" method="post" data-abide="abide">
                         ${structure:keypair_form['csrf_token']}
                         ${panel('form_field', field=keypair_form['name'], leftcol_width=3, rightcol_width=9, **html_attrs)}
                         <hr>
@@ -74,7 +74,7 @@
                             <div class="small-3 columns">&nbsp;</div>
                             <div class="small-9 columns field inline">
                                 <button type="submit" class="button" i18n:translate="">Create and Download</button>
-                                <a href="${request.route_url('keypairs')}"
+                                <a href="${request.route_path('keypairs')}"
                                    class="cancel-link" i18n:translate="">Cancel</a>
                             </div>
                         </div>
@@ -82,7 +82,7 @@
                  </div>
                 <div tal:condition="not keypair and keypair_route_id == 'new2'" i18n:translate="">
                     <p i18n:translate="">Importing a public key allows you to use an existing SSH key to access your Eucalyptus instances.</p>
-                    <form action="${request.route_url('keypair_import')}" method="post" data-abide="abide">
+                    <form action="${request.route_path('keypair_import')}" method="post" data-abide="abide">
                         ${structure:keypair_import_form['csrf_token']}
                         ${panel('form_field', field=keypair_import_form['name'], leftcol_width=3, rightcol_width=9, **html_attrs)}
                         ${panel('form_field', field=keypair_import_form['key_material'], leftcol_width=3, rightcol_width=9, **html_attrs)}
@@ -102,7 +102,7 @@
                             <div class="small-3 columns">&nbsp;</div>
                             <div class="small-9 columns field inline">
                                 <button type="submit" class="button">Import</button>
-                                <a href="${request.route_url('keypairs')}"
+                                <a href="${request.route_path('keypairs')}"
                                    class="cancel-link" i18n:translate="">Cancel</a>
                             </div>
                         </div>
@@ -130,7 +130,7 @@
 </div>
 
 <div metal:fill-slot="tail_js">
-    <script src="${request.static_url('eucaconsole:static/js/pages/keypair.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/pages/keypair.js')}"></script>
 </div>
 
 </metal:block>

--- a/eucaconsole/templates/keypairs/keypairs.pt
+++ b/eucaconsole/templates/keypairs/keypairs.pt
@@ -1,7 +1,7 @@
 <metal:block use-macro="main_template">
 
 <head metal:fill-slot="head_css">
-    <link rel="stylesheet" type="text/css" href="${request.static_url('eucaconsole:static/css/pages/keypairs.css')}" />
+    <link rel="stylesheet" type="text/css" href="${request.static_path('eucaconsole:static/css/pages/keypairs.css')}" />
 </head>
 
 <div metal:fill-slot="main_content" ng-app="KeypairsPage" ng-controller="KeypairsCtrl">
@@ -21,10 +21,10 @@
         <div metal:use-macro="layout.global_macros['landing_page_datagrid']">
             <div metal:fill-slot="new_button">
                 <a class="button small" i18n:translate="" id="create-keypair-btn"
-                    href="${request.route_url('keypair_view', id='new')}">Create New Key Pair</a>
+                    href="${request.route_path('keypair_view', id='new')}">Create New Key Pair</a>
                 &nbsp;&nbsp;
                 <a class="button small" i18n:translate=""
-                    href="${request.route_url('keypair_view', id='new2')}">Import Public Key</a>
+                    href="${request.route_path('keypair_view', id='new2')}">Import Public Key</a>
             </div>
             <div metal:fill-slot="tile_content" tal:omit-tag="">
                 <div>
@@ -78,9 +78,9 @@
 </metal:block>
 
 <div metal:fill-slot="tail_js">
-    <script src="${request.static_url('eucaconsole:static/js/pages/custom_filters.js')}"></script>
-    <script src="${request.static_url('eucaconsole:static/js/pages/landingpage.js')}"></script>
-    <script src="${request.static_url('eucaconsole:static/js/pages/keypairs.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/pages/custom_filters.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/pages/landingpage.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/pages/keypairs.js')}"></script>
 </div>
 
 </metal:block>

--- a/eucaconsole/templates/launchconfigs/launchconfig_view.pt
+++ b/eucaconsole/templates/launchconfigs/launchconfig_view.pt
@@ -4,7 +4,7 @@
     <div class="row" id="contentwrap" ng-app="">
         <metal:breadcrumbs metal:use-macro="layout.global_macros['breadcrumbs']">
             <metal:crumbs metal:fill-slot="crumbs">
-                <li><a href="${request.route_url('launchconfigs')}" i18n:translate="">Launch configurations</a></li>
+                <li><a href="${request.route_path('launchconfigs')}" i18n:translate="">Launch configurations</a></li>
                 <li class="current"><a href="#" ng-non-bindable="">${launch_config.name}</a></li>
             </metal:crumbs>
         </metal:breadcrumbs>
@@ -19,7 +19,7 @@
                 <metal:block metal:use-macro="layout.global_macros['actions_menu']" tal:condition="launch_config">
                     <metal:actions metal:fill-slot="actions">
                         <li>
-                            <a href="${request.route_url('scalinggroup_new')}?launch_config=${launch_config.name}"
+                            <a href="${request.route_path('scalinggroup_new')}?launch_config=${launch_config.name}"
                                id="create-scalinggroup-action" i18n:translate="">
                                 Use to create scaling group
                             </a>
@@ -39,14 +39,14 @@
                     <div class="row controls-wrapper readonly">
                         <div class="small-3 columns"><label i18n:translate="">Key pair</label></div>
                         <div class="small-9 columns value">
-                            <a href="${request.route_url('keypair_view', id=launch_config.key_name)}" ng-non-bindable="">${launch_config.key_name}</a>
+                            <a href="${request.route_path('keypair_view', id=launch_config.key_name)}" ng-non-bindable="">${launch_config.key_name}</a>
                         </div>
                     </div>
                     <div class="row controls-wrapper readonly">
                         <div class="small-3 columns"><label i18n:translate="">Security group</label></div>
                         <div class="small-9 columns value">
                             <div tal:repeat="security_group security_groups">
-                                <a href="${request.route_url('securitygroup_view', id=security_group.id)}" ng-non-bindable="">${security_group.name}</a>
+                                <a href="${request.route_path('securitygroup_view', id=security_group.id)}" ng-non-bindable="">${security_group.name}</a>
                             </div>
                         </div>
                     </div>
@@ -77,7 +77,7 @@
                     <div class="row controls-wrapper readonly">
                         <div class="small-3 columns"><label i18n:translate="">Image</label></div>
                         <div class="small-9 columns value">
-                            <a href="${request.route_url('image_view', id=image.id)}" ng-non-bindable="">${image.name or image.id}</a>
+                            <a href="${request.route_path('image_view', id=image.id)}" ng-non-bindable="">${image.name or image.id}</a>
                         </div>
                     </div>
                     <div class="row controls-wrapper readonly" tal:condition="image.id != image.name">

--- a/eucaconsole/templates/launchconfigs/launchconfig_wizard.pt
+++ b/eucaconsole/templates/launchconfigs/launchconfig_wizard.pt
@@ -1,7 +1,7 @@
 <metal:block use-macro="main_template">
 
 <head metal:fill-slot="head_css">
-    <link rel="stylesheet" type="text/css" href="${request.static_url('eucaconsole:static/css/pages/launchconfig_wizard.css')}" />
+    <link rel="stylesheet" type="text/css" href="${request.static_path('eucaconsole:static/css/pages/launchconfig_wizard.css')}" />
 </head>
 
 <div metal:fill-slot="main_content">
@@ -9,7 +9,7 @@
          ng-init="initController('${securitygroups_rules_json}', '${keypair_choices_json}', '${securitygroup_choices_json}')">
         <metal:breadcrumbs metal:use-macro="layout.global_macros['breadcrumbs']">
             <metal:crumbs metal:fill-slot="crumbs">
-                <li><a href="${request.route_url('launchconfigs')}" i18n:translate="">Launch configurations</a></li>
+                <li><a href="${request.route_path('launchconfigs')}" i18n:translate="">Launch configurations</a></li>
                 <li class="current"><a href="#" i18n:translate="">Create launch configuration</a></li>
             </metal:crumbs>
         </metal:breadcrumbs>
@@ -20,7 +20,7 @@
         </h3>
         <div class="large-8 columns" tal:define="_ import: pyramid.i18n.TranslationString">
             <div class="wizard no-title">
-                <form action="${request.route_url('launchconfig_create')}" id="launch-config-form"
+                <form action="${request.route_path('launchconfig_create')}" id="launch-config-form"
                       method="post" data-abide="abide" enctype="multipart/form-data">
                     ${structure:create_form['csrf_token']}
                     ${structure:create_form['image_id']}
@@ -62,7 +62,7 @@
                                 <div class="small-8 columns value">
                                     <input type="text" name="image_id" id="image-id-input" ng-model="imageID" />
                                     <a class="button small" i18n:translate="" id="image-id-btn"
-                                       ng-click="inputImageID('${request.route_url('launchconfig_new')}')">Next</a>
+                                       ng-click="inputImageID('${request.route_path('launchconfig_new')}')">Next</a>
                                 </div>
                             </div>
                             ${panel('image_picker', image=image, filters_form=filters_form, images_json_endpoint=images_json_endpoint, prefix_route='launchconfig_new')}
@@ -145,7 +145,7 @@
                                     <button type="submit" class="button" id="create-launchconfig-btn-step4">
                                         <span i18n:translate="">Create Launch Configuration</span>
                                     </button>
-                                    <a href="${request.route_url('launchconfigs')}"
+                                    <a href="${request.route_path('launchconfigs')}"
                                        class="cancel-link" i18n:translate="">Cancel</a>
                                 </div>
                             </div>
@@ -223,10 +223,10 @@
 </div>
 
 <div metal:fill-slot="tail_js">
-    <script src="${request.static_url('eucaconsole:static/js/thirdparty/jquery/chosen.jquery.min.js')}"></script>
-    <script src="${request.static_url('eucaconsole:static/js/thirdparty/utils/purl.js')}"></script>
-    <script src="${request.static_url('eucaconsole:static/js/thirdparty/jquery/jquery.generateFile.js')}"></script>
-    <script src="${request.static_url('eucaconsole:static/js/pages/launchconfig_wizard.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/thirdparty/jquery/chosen.jquery.min.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/thirdparty/utils/purl.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/thirdparty/jquery/jquery.generateFile.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/pages/launchconfig_wizard.js')}"></script>
 </div>
 
 </metal:block>

--- a/eucaconsole/templates/launchconfigs/launchconfigs.pt
+++ b/eucaconsole/templates/launchconfigs/launchconfigs.pt
@@ -1,7 +1,7 @@
 <metal:block use-macro="main_template">
 
 <head metal:fill-slot="head_css">
-    <link rel="stylesheet" type="text/css" href="${request.static_url('eucaconsole:static/css/pages/launchconfigs.css')}" />
+    <link rel="stylesheet" type="text/css" href="${request.static_path('eucaconsole:static/css/pages/launchconfigs.css')}" />
 </head>
 
 <div metal:fill-slot="main_content" ng-app="LaunchConfigsPage" ng-controller="LaunchConfigsPageCtrl">
@@ -22,7 +22,7 @@
         <div metal:use-macro="layout.global_macros['landing_page_datagrid']">
             <div metal:fill-slot="new_button">
                 <a class="button" i18n:translate="" id="create-launchconfig-btn"
-                   href="${request.route_url('launchconfig_new')}">Create New Launch Configuration</a>
+                   href="${request.route_path('launchconfig_new')}">Create New Launch Configuration</a>
             </div>
             <div metal:fill-slot="tile_dropdown_button" tal:omit-tag="">
                 <a class="tiny secondary button dropdown right" data-dropdown="item-dropdown_{{ item.name }}"><i class="fi-widget"></i></a>
@@ -94,9 +94,9 @@
 </metal:block>
 
 <div metal:fill-slot="tail_js">
-    <script src="${request.static_url('eucaconsole:static/js/pages/custom_filters.js')}"></script>
-    <script src="${request.static_url('eucaconsole:static/js/pages/landingpage.js')}"></script>
-    <script src="${request.static_url('eucaconsole:static/js/pages/launchconfigs.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/pages/custom_filters.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/pages/landingpage.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/pages/launchconfigs.js')}"></script>
 </div>
 
 </metal:block>

--- a/eucaconsole/templates/login.pt
+++ b/eucaconsole/templates/login.pt
@@ -1,7 +1,7 @@
 <metal:block use-macro="main_template">
 
 <div metal:fill-slot="head_css">
-    <link rel="stylesheet" href="${request.static_url('eucaconsole:static/css/pages/login.css')}" />
+    <link rel="stylesheet" href="${request.static_path('eucaconsole:static/css/pages/login.css')}" />
 </div>
 
 <div metal:fill-slot="main_content">
@@ -45,7 +45,7 @@
                 <div class="tabs-content">
                     <div class="content active large-10 medium-10 columns large-centered medium-centered" id="eucalyptus">
                         <form class="custom" id="euca-login-form" method="post" name="euca_login_form"
-                              action="${request.route_url('login')}?login_type=Eucalyptus">
+                              action="${request.route_path('login')}?login_type=Eucalyptus">
                             <input type="hidden" name="came_from" value="${came_from}" />
                             <div class="row controls-wrapper controls_${field.name}" tal:repeat="field euca_login_form">
                                 <div class="small-12 columns field">
@@ -75,7 +75,7 @@
                     <div class="content large-10 medium-10 columns large-centered medium-centered"
                          tal:condition="layout.aws_enabled" id="aws">
                         <form class="custom" id="aws-login-form" method="post" name="aws_login_form"
-                              action="${request.route_url('login')}?login_type=AWS">
+                              action="${request.route_path('login')}?login_type=AWS">
                             <input type="hidden" name="came_from" value="${came_from}" />
                             <input type="hidden" id="duration" name="duration" value="${duration}" />
                             <div class="row controls-wrapper controls_${field.name}" tal:repeat="field aws_login_form">
@@ -105,7 +105,7 @@
                             </div>
                         </form>
                         <form id="false-aws-login-form" method="post" name="aws_login_form"
-                              action="${request.route_url('login')}?login_type=AWS">
+                              action="${request.route_path('login')}?login_type=AWS">
                             <input type="hidden" id="aws_csrf_token" name="csrf_token"/>
                             <input type="hidden" name="came_from" value="${came_from}"/>
                             <input type="hidden" id="package" name="package"/>
@@ -120,11 +120,11 @@
 </div>
 
 <div metal:fill-slot="tail_js">
-    <script src="${request.static_url('eucaconsole:static/js/thirdparty/jquery/jquery.base64.js')}"></script>
-    <script src="${request.static_url('eucaconsole:static/js/thirdparty/jquery/jquery.cookie.js')}"></script>
-    <script src="${request.static_url('eucaconsole:static/js/thirdparty/utils/hmac-sha256.js')}"></script>
-    <script src="${request.static_url('eucaconsole:static/js/thirdparty/utils/enc-base64.js')}"></script>
-    <script src="${request.static_url('eucaconsole:static/js/pages/login.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/thirdparty/jquery/jquery.base64.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/thirdparty/jquery/jquery.cookie.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/thirdparty/utils/hmac-sha256.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/thirdparty/utils/enc-base64.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/pages/login.js')}"></script>
 </div>
 
 </metal:block>

--- a/eucaconsole/templates/macros.pt
+++ b/eucaconsole/templates/macros.pt
@@ -203,7 +203,7 @@
 <metal:breadcrumbs metal:define-macro="breadcrumbs">
     <div id="breadcrumbs">
         <ul class="breadcrumbs">
-            <li><a href="${request.route_url('dashboard')}" title="Dashboard" data-tooltip=""><i class="fi-home"></i></a></li>
+            <li><a href="${request.route_path('dashboard')}" title="Dashboard" data-tooltip=""><i class="fi-home"></i></a></li>
             <metal:block metal:define-slot="crumbs" />
         </ul>
         <span class="icon-block">

--- a/eucaconsole/templates/master_layout.pt
+++ b/eucaconsole/templates/master_layout.pt
@@ -7,19 +7,19 @@
     <title>Eucalyptus Management Console</title>
     <meta http-equiv="Content-Type" content="text/html;charset=UTF-8" />
     <meta name="viewport" content="width=device-width" />
-    <link rel="shortcut icon" href="${request.static_url('eucaconsole:static/img/favicon.ico')}" />
-    <link rel="stylesheet" href="${request.static_url('eucaconsole:static/fonts/foundation/foundation-icons.css')}"
+    <link rel="shortcut icon" href="${request.static_path('eucaconsole:static/img/favicon.ico')}" />
+    <link rel="stylesheet" href="${request.static_path('eucaconsole:static/fonts/foundation/foundation-icons.css')}"
           type="text/css" media="screen" charset="utf-8" />
-    <link rel="stylesheet" type="text/css" href="${request.static_url('eucaconsole:static/css/thirdparty/chosen.min.css')}" />
+    <link rel="stylesheet" type="text/css" href="${request.static_path('eucaconsole:static/css/thirdparty/chosen.min.css')}" />
     <link href='https://fonts.googleapis.com/css?family=Lato:300,400,700|Oswald:300,400,700' rel='stylesheet' type='text/css' />
-    <link rel="stylesheet" href="${request.static_url('eucaconsole:static/css/eucaconsole.css')}"
+    <link rel="stylesheet" href="${request.static_path('eucaconsole:static/css/eucaconsole.css')}"
           type="text/css" media="screen" charset="utf-8" />
     <meta metal:define-slot="head_css" />
-    <script src="${request.static_url('eucaconsole:static/js/thirdparty/modernizr/custom.modernizr.js')}"></script>
-    <script src="${request.static_url('eucaconsole:static/js/thirdparty/jquery/jquery-2.0.3.min.js')}"></script>
-    <script src="${request.static_url('eucaconsole:static/js/thirdparty/angular/angular-1.2.9.min.js')}"></script>
-    <script src="${request.static_url('eucaconsole:static/js/thirdparty/angular/angular-sanitize-1.2.9.min.js')}"></script>
-    <script src="${request.static_url('eucaconsole:static/js/widgets/notify.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/thirdparty/modernizr/custom.modernizr.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/thirdparty/jquery/jquery-2.0.3.min.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/thirdparty/angular/angular-1.2.9.min.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/thirdparty/angular/angular-sanitize-1.2.9.min.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/widgets/notify.js')}"></script>
     <script type="text/javascript">
         $(document).ready(function () {
             var notification = $('#notifications');
@@ -51,7 +51,7 @@
                 <ul id="user-dropdown" class="f-dropdown" data-dropdown-content="">
                     <li><a href="${layout.help_url}" target="_blank" i18n:translate="">Help</a></li>
                     <li tal:condition="layout.cloud_type == 'euca'">
-                        <a href="${request.route_url('changepassword')}" i18n:translate="">Change password</a>
+                        <a href="${request.route_path('changepassword')}" i18n:translate="">Change password</a>
                     </li>
                     <li>
                         <a i18n:translate="" data-reveal-id="about-modal">About your cloud</a>
@@ -68,7 +68,7 @@
                 </span>
                 <ul id="region-dropdown" class="f-dropdown" data-dropdown-content="">
                     <li tal:repeat="region layout.aws_regions" tal:attributes="data-selected (region.name == layout.selected_region)">
-                        <a href="${request.route_url('region_select')}?region=${region.name}&amp;returnto=${request.url}">
+                        <a href="${request.route_path('region_select')}?region=${region.name}&amp;returnto=${request.url}">
                                 ${region.label}
                         </a>
                     </li>
@@ -112,7 +112,7 @@
                © 2014 Eucalyptus Systems, Inc.
            </div>
         </div>
-        <form id="euca-logout-form" method="post" action="${request.route_url('logout')}">
+        <form id="euca-logout-form" method="post" action="${request.route_path('logout')}">
             ${structure:layout.euca_logout_form['csrf_token']}
             <input type="submit" style="display:none;" id="euca-logout-button"/>
         </form>
@@ -127,7 +127,7 @@
 
     <a class="exit-off-canvas"></a>
 
-<script type="text/javascript" src="${request.static_url('eucaconsole:static/js/thirdparty/foundation/foundation.min.js')}"></script>
+<script type="text/javascript" src="${request.static_path('eucaconsole:static/js/thirdparty/foundation/foundation.min.js')}"></script>
 <script type="text/javascript">
     // Initialize all Zurb Foundation components
     $(document).foundation();

--- a/eucaconsole/templates/panels/autoscale_tag_editor.pt
+++ b/eucaconsole/templates/panels/autoscale_tag_editor.pt
@@ -46,5 +46,5 @@
         <!--! Add class="debug" to textarea to view tags data posted by form -->
         <textarea id="tags" name="tags" class="hidden"></textarea>
     </div>
-    <script src="${request.static_url('eucaconsole:static/js/widgets/autoscale_tag_editor.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/widgets/autoscale_tag_editor.js')}"></script>
 </div>

--- a/eucaconsole/templates/panels/bdmapping_editor.pt
+++ b/eucaconsole/templates/panels/bdmapping_editor.pt
@@ -86,5 +86,5 @@
         <hr />
         <textarea id="bdmapping" name="block_device_mapping" class="hidden"></textarea>
     </div>
-    <script src="${request.static_url('eucaconsole:static/js/widgets/bdmapping_editor.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/widgets/bdmapping_editor.js')}"></script>
 </div>

--- a/eucaconsole/templates/panels/image_picker.pt
+++ b/eucaconsole/templates/panels/image_picker.pt
@@ -1,6 +1,6 @@
 
 <!--! Image Picker widget (Used in Launch Instance wizard) -->
-<link rel="stylesheet" type="text/css" href="${request.static_url('eucaconsole:static/css/widgets/image_picker.css')}" />
+<link rel="stylesheet" type="text/css" href="${request.static_path('eucaconsole:static/css/widgets/image_picker.css')}" />
 <div id="image-picker" ng-app="ImagePicker"
      ng-controller="ImagePickerCtrl" ng-init="initImagePicker('${images_json_endpoint}', '${layout.cloud_type}')">
 
@@ -45,7 +45,7 @@
                         </td>
                         <td>
                             <div class="name">
-                                <a href="${request.route_url(prefix_route)}?image_id={{ item.id }}">{{ item.name || item.id }}</a>
+                                <a href="${request.route_path(prefix_route)}?image_id={{ item.id }}">{{ item.name || item.id }}</a>
                                 <span ng-show="!item.name" class="label radius {{ item.architecture }}">{{ item.architecture }}</span>
                             </div>
                             <div ng-show="item.name">
@@ -62,6 +62,6 @@
             </table>
         </div>
     </div>
-    <script src="${request.static_url('eucaconsole:static/js/widgets/image_picker.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/widgets/image_picker.js')}"></script>
 </div>
 

--- a/eucaconsole/templates/panels/landingpage_filters.pt
+++ b/eucaconsole/templates/panels/landingpage_filters.pt
@@ -1,7 +1,7 @@
 <!-- Landing page filters form -->
 <div id="filters">
     <strong i18n:translate="">Filter by:</strong>
-    <form method="get" action="${request.current_route_url()}" ng-cloak="">
+    <form method="get" action="${request.current_route_path()}" ng-cloak="">
         <div tal:repeat="field filters_form" id="filterfieldwrapper_${field.short_name}">
             <div tal:condition="field.short_name != 'csrf_token'" tal:omit-tag="">
                 <label>${field.label}</label>
@@ -11,7 +11,7 @@
         <div>&nbsp;</div>
         <div>
             <button type="submit" class="small button round" i18n:translate="">Apply</button>
-            &nbsp;&nbsp;&nbsp;<a href="${request.current_route_url().split('?')[0]}" class="clear-link">Clear</a>
+            &nbsp;&nbsp;&nbsp;<a href="${request.current_route_path().split('?')[0]}" class="clear-link">Clear</a>
         </div>
     </form>
 </div>

--- a/eucaconsole/templates/panels/policy_list.pt
+++ b/eucaconsole/templates/panels/policy_list.pt
@@ -60,8 +60,8 @@
             <a class="close-reveal-modal">&#215;</a>
         </div>
     </div>
-    <script src="${request.static_url('eucaconsole:static/js/thirdparty/codemirror/codemirror.js')}"></script>
-    <script src="${request.static_url('eucaconsole:static/js/thirdparty/codemirror/javascript.js')}"></script>
-    <script src="${request.static_url('eucaconsole:static/js/thirdparty/codemirror/active-line.js')}"></script>
-    <script src="${request.static_url('eucaconsole:static/js/widgets/policy_list.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/thirdparty/codemirror/codemirror.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/thirdparty/codemirror/javascript.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/thirdparty/codemirror/active-line.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/widgets/policy_list.js')}"></script>
 </div>

--- a/eucaconsole/templates/panels/securitygroup_rules.pt
+++ b/eucaconsole/templates/panels/securitygroup_rules.pt
@@ -2,7 +2,7 @@
 <!--! Security group rules editor -->
 <div id="rules-editor" class="row controls-wrapper" ng-app="SecurityGroupRules"
      ng-controller="SecurityGroupRulesCtrl" ng-init="initRules('${rules_json}')">
-    <link rel="stylesheet" href="${request.static_url('eucaconsole:static/css/widgets/securitygroup_rules.css')}"
+    <link rel="stylesheet" href="${request.static_path('eucaconsole:static/css/widgets/securitygroup_rules.css')}"
           type="text/css" charset="utf-8" />
     <div class="columns">
         <h6 i18n:translate="">Inbound rules</h6>
@@ -94,6 +94,6 @@
         <!--! Add class="debug" to textarea to view tags data posted by form -->
         <textarea id="rules" name="rules" class="hidden" style="height: 8rem;"></textarea>
     </div>
-    <script src="${request.static_url('eucaconsole:static/js/widgets/securitygroup_rules.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/widgets/securitygroup_rules.js')}"></script>
     <script>setTimeout(function(){ $(document).foundation({abide : { timeout : 2000 } })}, 500);</script>
 </div>

--- a/eucaconsole/templates/panels/tag_editor.pt
+++ b/eucaconsole/templates/panels/tag_editor.pt
@@ -39,5 +39,5 @@
         <!--! Add class="debug" to textarea to view tags data posted by form -->
         <textarea id="tags" name="tags" class="hidden"></textarea>
     </div>
-    <script src="${request.static_url('eucaconsole:static/js/widgets/tag_editor.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/widgets/tag_editor.js')}"></script>
 </div>

--- a/eucaconsole/templates/panels/top_nav.pt
+++ b/eucaconsole/templates/panels/top_nav.pt
@@ -1,40 +1,40 @@
 <!-- top nav links (reused in off-canvas menu) -->
 <ul class="resources-nav left-align ${'off-canvas-list' if off_canvas else ''}">
-    <li><a id="resource-menu-dashboard" class="lnk-dashboard" href="${request.route_url('dashboard')}">Dashboard</a></li>
-    <li><a id="resource-menu-images" href="${request.route_url('images')}">Images</a></li>
-    <li><a id="resource-menu-instances" href="${request.route_url('instances')}">Instances</a></li>
+    <li><a id="resource-menu-dashboard" class="lnk-dashboard" href="${request.route_path('dashboard')}">Dashboard</a></li>
+    <li><a id="resource-menu-images" href="${request.route_path('images')}">Images</a></li>
+    <li><a id="resource-menu-instances" href="${request.route_path('instances')}">Instances</a></li>
     <li class="has-dropdown">
         <a id="resource-menu-autoscaling">Auto Scaling</a>
         <ul class="dropdown">
-            <li><a id="resource-menuitem-scalinggroups" href="${request.route_url('scalinggroups')}">Scaling Groups</a></li>
+            <li><a id="resource-menuitem-scalinggroups" href="${request.route_path('scalinggroups')}">Scaling Groups</a></li>
             <li class="divider" tal:condition="not off_canvas"></li>
-            <li><a id="resource-menuitem-launchconfigs" href="${request.route_url('launchconfigs')}">Launch Configurations</a></li>
+            <li><a id="resource-menuitem-launchconfigs" href="${request.route_path('launchconfigs')}">Launch Configurations</a></li>
         </ul>
     </li>
     <li class="has-dropdown">
         <a id="resource-menu-storage">Storage</a>
         <ul class="dropdown">
-            <li><a id="resource-menuitem-volumes" href="${request.route_url('volumes')}">Volumes</a></li>
+            <li><a id="resource-menuitem-volumes" href="${request.route_path('volumes')}">Volumes</a></li>
             <li class="divider" tal:condition="not off_canvas"></li>
-            <li><a id="resource-menuitem-snapshots" href="${request.route_url('snapshots')}">Snapshots</a></li>
+            <li><a id="resource-menuitem-snapshots" href="${request.route_path('snapshots')}">Snapshots</a></li>
         </ul>
     </li>
     <li class="has-dropdown">
         <a id="resource-menu-netsec">Network &amp; Security</a>
         <ul class="dropdown">
-            <li><a id="resource-menuitem-securitygroups" href="${request.route_url('securitygroups')}">Security Groups</a></li>
+            <li><a id="resource-menuitem-securitygroups" href="${request.route_path('securitygroups')}">Security Groups</a></li>
             <li class="divider" tal:condition="not off_canvas"></li>
-            <li><a id="resource-menuitem-keypairs" href="${request.route_url('keypairs')}">Key Pairs</a></li>
+            <li><a id="resource-menuitem-keypairs" href="${request.route_path('keypairs')}">Key Pairs</a></li>
             <li class="divider" tal:condition="not off_canvas"></li>
-            <li><a id="resource-menuitem-eips" href="${request.route_url('ipaddresses')}">Elastic IPs</a></li>
+            <li><a id="resource-menuitem-eips" href="${request.route_path('ipaddresses')}">Elastic IPs</a></li>
         </ul>
     </li>
     <li class="has-dropdown" tal:condition="layout.cloud_type == 'euca' and layout.username == 'admin'">
         <a id="resource-menu-iam">IAM</a>
         <ul class="dropdown">
-            <li><a id="resource-menuitem-users" href="${request.route_url('users')}">IAM Users</a></li>
+            <li><a id="resource-menuitem-users" href="${request.route_path('users')}">IAM Users</a></li>
             <li class="divider" tal:condition="not off_canvas"></li>
-            <li><a id="resource-menuitem-groups" href="${request.route_url('groups')}">IAM Groups</a></li>
+            <li><a id="resource-menuitem-groups" href="${request.route_path('groups')}">IAM Groups</a></li>
         </ul>
     </li>
 </ul>

--- a/eucaconsole/templates/panels/user_editor.pt
+++ b/eucaconsole/templates/panels/user_editor.pt
@@ -44,5 +44,5 @@
         <!--! Add class="debug" to textarea to view users data posted by form -->
         <textarea id="users" name="users" class="hidden"></textarea>
     </div>
-    <script src="${request.static_url('eucaconsole:static/js/widgets/user_editor.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/widgets/user_editor.js')}"></script>
 </div>

--- a/eucaconsole/templates/policies/iam_policy_wizard.pt
+++ b/eucaconsole/templates/policies/iam_policy_wizard.pt
@@ -1,8 +1,8 @@
 <metal:block use-macro="main_template">
 
 <head metal:fill-slot="head_css">
-    <link rel="stylesheet" type="text/css" href="${request.static_url('eucaconsole:static/js/thirdparty/codemirror/codemirror.css')}" />
-    <link rel="stylesheet" type="text/css" href="${request.static_url('eucaconsole:static/css/pages/iam_policy_wizard.css')}" />
+    <link rel="stylesheet" type="text/css" href="${request.static_path('eucaconsole:static/js/thirdparty/codemirror/codemirror.css')}" />
+    <link rel="stylesheet" type="text/css" href="${request.static_path('eucaconsole:static/css/pages/iam_policy_wizard.css')}" />
 </head>
 
 <div metal:fill-slot="main_content">
@@ -118,7 +118,7 @@
             <!--! Preview Policy -->
             <div id="policy-preview" ng-cloak="">
                 <h6 class="title">View/Edit policy</h6>
-                <form action="${request.route_url('iam_policy_create')}" id="iam-policy-form"
+                <form action="${request.route_path('iam_policy_create')}" id="iam-policy-form"
                       method="post" data-abide="abide" enctype="multipart/form-data">
                     ${structure:create_form['csrf_token']}
                     <input type="hidden" name="type" value="${request.params.get('type', '')}" />
@@ -139,11 +139,11 @@
 </div>
 
 <div metal:fill-slot="tail_js">
-    <script src="${request.static_url('eucaconsole:static/js/thirdparty/jquery/chosen.jquery.min.js')}"></script>
-    <script src="${request.static_url('eucaconsole:static/js/thirdparty/codemirror/codemirror.js')}"></script>
-    <script src="${request.static_url('eucaconsole:static/js/thirdparty/codemirror/javascript.js')}"></script>
-    <script src="${request.static_url('eucaconsole:static/js/thirdparty/codemirror/active-line.js')}"></script>
-    <script src="${request.static_url('eucaconsole:static/js/pages/iam_policy_wizard.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/thirdparty/jquery/chosen.jquery.min.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/thirdparty/codemirror/codemirror.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/thirdparty/codemirror/javascript.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/thirdparty/codemirror/active-line.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/pages/iam_policy_wizard.js')}"></script>
 </div>
 
 </metal:block>

--- a/eucaconsole/templates/scalinggroups/scalinggroup_instances.pt
+++ b/eucaconsole/templates/scalinggroups/scalinggroup_instances.pt
@@ -1,7 +1,7 @@
 <metal:block use-macro="main_template">
 
 <head metal:fill-slot="head_css">
-    <link rel="stylesheet" type="text/css" href="${request.static_url('eucaconsole:static/css/pages/scalinggroup.css')}" />
+    <link rel="stylesheet" type="text/css" href="${request.static_path('eucaconsole:static/css/pages/scalinggroup.css')}" />
 </head>
 
 <div metal:fill-slot="main_content">
@@ -9,7 +9,7 @@
          ng-init="initController('${json_items_endpoint}')">
         <metal:breadcrumbs metal:use-macro="layout.global_macros['breadcrumbs']">
             <metal:crumbs metal:fill-slot="crumbs">
-                <li><a href="${request.route_url('scalinggroups')}" i18n:translate="">Scaling groups</a></li>
+                <li><a href="${request.route_path('scalinggroups')}" i18n:translate="">Scaling groups</a></li>
                 <li class="current"><a ng-non-bindable="">${scaling_group.name}</a></li>
             </metal:crumbs>
         </metal:breadcrumbs>
@@ -21,14 +21,14 @@
         </h3>
         <div class="large-8 columns">
             <dl class="tabs" id="scalinggroup-subnav">
-                <dd><a href="${request.route_url('scalinggroup_view', id=scaling_group.name)}" i18n:translate="">General</a></dd>
-                <dd><a href="${request.route_url('scalinggroup_policies', id=scaling_group.name)}" i18n:translate="">Policies</a></dd>
+                <dd><a href="${request.route_path('scalinggroup_view', id=scaling_group.name)}" i18n:translate="">General</a></dd>
+                <dd><a href="${request.route_path('scalinggroup_policies', id=scaling_group.name)}" i18n:translate="">Policies</a></dd>
                 <dd class="active"><a href="#">Instances</a></dd>
             </dl>
             <div class="panel gridwrapper no-title">
                 <p tal:condition="not policies">
                     <span i18n:translate="">To automatically scale your group up or down, please</span>
-                    <a href="${request.route_url('scalinggroup_policy_new', id=scaling_group.name)}" i18n:translate="">add scaling policies</a>
+                    <a href="${request.route_path('scalinggroup_policy_new', id=scaling_group.name)}" i18n:translate="">add scaling policies</a>
                 </p>
                 <div ng-show="initialLoading">
                     <span class="dots">&nbsp;</span>
@@ -79,7 +79,7 @@
             <h3 i18n:translate="">Mark instance unhealthy</h3>
             <p><span i18n:translate="">Marking an instance unhealthy will cause the system to terminate it. Are you sure you want to mark the following instance as unhealthy?</span>
                <b>{{ instanceID }}</b>?</p>
-            <form action="${request.route_url('scalinggroup_instances_markunhealthy', id=scaling_group.name)}" method="post">
+            <form action="${request.route_path('scalinggroup_instances_markunhealthy', id=scaling_group.name)}" method="post">
                 ${structure:markunhealthy_form['csrf_token']}
                 <input type="hidden" name="instance_id" value="{{ instanceID }}">
                 ${panel('form_field', field=markunhealthy_form['respect_grace_period'],
@@ -97,7 +97,7 @@
             <h3 i18n:translate="">Terminate instance</h3>
             <p><span i18n:translate="">Are you sure you want to terminate instance</span>
                <b>{{ instanceID }}</b>?</p>
-            <form action="${request.route_url('scalinggroup_instances_terminate', id=scaling_group.name)}" method="post">
+            <form action="${request.route_path('scalinggroup_instances_terminate', id=scaling_group.name)}" method="post">
                 ${structure:terminate_form['csrf_token']}
                 <input type="hidden" name="instance_id" value="{{ instanceID }}">
                 ${panel('form_field', field=terminate_form['decrement_capacity'],
@@ -115,7 +115,7 @@
 </div>
 
 <div metal:fill-slot="tail_js">
-    <script src="${request.static_url('eucaconsole:static/js/pages/scalinggroup_instances.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/pages/scalinggroup_instances.js')}"></script>
 </div>
 
 </metal:block>

--- a/eucaconsole/templates/scalinggroups/scalinggroup_policies.pt
+++ b/eucaconsole/templates/scalinggroups/scalinggroup_policies.pt
@@ -1,14 +1,14 @@
 <metal:block use-macro="main_template">
 
 <head metal:fill-slot="head_css">
-    <link rel="stylesheet" type="text/css" href="${request.static_url('eucaconsole:static/css/pages/scalinggroup.css')}" />
+    <link rel="stylesheet" type="text/css" href="${request.static_path('eucaconsole:static/css/pages/scalinggroup.css')}" />
 </head>
 
 <div metal:fill-slot="main_content">
     <div class="row" id="contentwrap" ng-app="ScalingGroupPolicies" ng-controller="ScalingGroupPoliciesCtrl" ng-init="initPage()">
         <metal:breadcrumbs metal:use-macro="layout.global_macros['breadcrumbs']">
             <metal:crumbs metal:fill-slot="crumbs">
-                <li><a href="${request.route_url('scalinggroups')}" i18n:translate="">Scaling groups</a></li>
+                <li><a href="${request.route_path('scalinggroups')}" i18n:translate="">Scaling groups</a></li>
                 <li class="current"><a ng-non-bindable="">${scaling_group.name}</a></li>
             </metal:crumbs>
         </metal:breadcrumbs>
@@ -20,13 +20,13 @@
         </h3>
         <div class="large-8 columns">
             <dl class="tabs" id="scalinggroup-subnav">
-                <dd><a href="${request.route_url('scalinggroup_view', id=scaling_group.name)}" i18n:translate="">General</a></dd>
+                <dd><a href="${request.route_path('scalinggroup_view', id=scaling_group.name)}" i18n:translate="">General</a></dd>
                 <dd class="active"><a href="#" i18n:translate="">Policies</a></dd>
-                <dd><a href="${request.route_url('scalinggroup_instances', id=scaling_group.name)}">Instances</a></dd>
+                <dd><a href="${request.route_path('scalinggroup_instances', id=scaling_group.name)}">Instances</a></dd>
             </dl>
             <div class="panel gridwrapper no-title">
                 <div class="tile add" id="add-policy">
-                    <a href="${request.route_url('scalinggroup_policy_new', id=scaling_group.name)}">
+                    <a href="${request.route_path('scalinggroup_policy_new', id=scaling_group.name)}">
                         <div class="plus">+</div>
                         <div i18n:translate="">Add a policy</div>
                     </a>
@@ -65,7 +65,7 @@
                 <span i18n:translate="">Are you sure you want to delete the policy</span>
                 <b>{{ policyName }}</b>?
             </p>
-            <form action="${request.route_url('scalinggroup_policy_delete', id=scaling_group.name)}" method="post">
+            <form action="${request.route_path('scalinggroup_policy_delete', id=scaling_group.name)}" method="post">
                 ${structure:delete_form['csrf_token']}
                 <input type="hidden" name="name" value="{{ policyName }}" />
                 <button type="submit" class="button" i18n:translate="" id="delete-policy-dialog-btn">
@@ -79,8 +79,8 @@
 </div>
 
 <div metal:fill-slot="tail_js">
-    <script src="${request.static_url('eucaconsole:static/js/thirdparty/jquery/chosen.jquery.min.js')}"></script>
-    <script src="${request.static_url('eucaconsole:static/js/pages/scalinggroup_policies.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/thirdparty/jquery/chosen.jquery.min.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/pages/scalinggroup_policies.js')}"></script>
 </div>
 
 </metal:block>

--- a/eucaconsole/templates/scalinggroups/scalinggroup_policy.pt
+++ b/eucaconsole/templates/scalinggroups/scalinggroup_policy.pt
@@ -1,15 +1,15 @@
 <metal:block use-macro="main_template">
 
 <head metal:fill-slot="head_css">
-    <link rel="stylesheet" type="text/css" href="${request.static_url('eucaconsole:static/css/pages/scalinggroup.css')}" />
+    <link rel="stylesheet" type="text/css" href="${request.static_path('eucaconsole:static/css/pages/scalinggroup.css')}" />
 </head>
 
 <div metal:fill-slot="main_content">
     <div class="row" id="contentwrap" ng-app="ScalingGroupPolicy" ng-controller="ScalingGroupPolicyCtrl" ng-init="initPage()">
         <metal:breadcrumbs metal:use-macro="layout.global_macros['breadcrumbs']">
             <metal:crumbs metal:fill-slot="crumbs">
-                <li><a href="${request.route_url('scalinggroups')}" i18n:translate="">Scaling groups</a></li>
-                <li><a href="${request.route_url('scalinggroup_view', id=scaling_group.name)}" ng-non-bindable="">${scaling_group.name}</a></li>
+                <li><a href="${request.route_path('scalinggroups')}" i18n:translate="">Scaling groups</a></li>
+                <li><a href="${request.route_path('scalinggroup_view', id=scaling_group.name)}" ng-non-bindable="">${scaling_group.name}</a></li>
                 <li class="current"><a href="#">Create policy</a></li>
             </metal:crumbs>
         </metal:breadcrumbs>
@@ -18,12 +18,12 @@
 
         <div class="large-7 columns">
             <dl class="tabs" id="scalinggroup-subnav">
-                <dd><a href="${request.route_url('scalinggroup_view', id=scaling_group.name)}" i18n:translate="">General</a></dd>
-                <dd class="active"><a href="${request.route_url('scalinggroup_policies', id=scaling_group.name)}" i18n:translate="">Policies</a></dd>
-                <dd><a href="${request.route_url('scalinggroup_instances', id=scaling_group.name)}" i18n:translate="">Instances</a></dd>
+                <dd><a href="${request.route_path('scalinggroup_view', id=scaling_group.name)}" i18n:translate="">General</a></dd>
+                <dd class="active"><a href="${request.route_path('scalinggroup_policies', id=scaling_group.name)}" i18n:translate="">Policies</a></dd>
+                <dd><a href="${request.route_path('scalinggroup_instances', id=scaling_group.name)}" i18n:translate="">Instances</a></dd>
             </dl>
             <div class="panel no-title">
-                <form action="${request.route_url('scalinggroup_policy_create', id=scaling_group.name)}" method="post" data-abide="">
+                <form action="${request.route_path('scalinggroup_policy_create', id=scaling_group.name)}" method="post" data-abide="">
                     ${structure:policy_form['csrf_token']}
                     <h6 i18n:translate="">New policy</h6>
                     ${panel('form_field', field=policy_form['name'])}
@@ -44,7 +44,7 @@
                             Add Policy
                         </button>
                         <a class="cancel-link" i18n:translate=""
-                           href="${request.route_url('scalinggroup_view', id=scaling_group.name)}">Cancel</a>
+                           href="${request.route_path('scalinggroup_view', id=scaling_group.name)}">Cancel</a>
                     </div>
                 </form>
             </div>
@@ -62,7 +62,7 @@
 </div>
 
 <div metal:fill-slot="tail_js">
-    <script src="${request.static_url('eucaconsole:static/js/pages/scalinggroup_policy.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/pages/scalinggroup_policy.js')}"></script>
 </div>
 
 </metal:block>

--- a/eucaconsole/templates/scalinggroups/scalinggroup_view.pt
+++ b/eucaconsole/templates/scalinggroups/scalinggroup_view.pt
@@ -1,7 +1,7 @@
 <metal:block use-macro="main_template">
 
 <head metal:fill-slot="head_css">
-    <link rel="stylesheet" type="text/css" href="${request.static_url('eucaconsole:static/css/pages/scalinggroup.css')}" />
+    <link rel="stylesheet" type="text/css" href="${request.static_path('eucaconsole:static/css/pages/scalinggroup.css')}" />
 </head>
 
 <div metal:fill-slot="main_content">
@@ -9,7 +9,7 @@
          ng-init="initController()">
         <metal:breadcrumbs metal:use-macro="layout.global_macros['breadcrumbs']">
             <metal:crumbs metal:fill-slot="crumbs">
-                <li><a href="${request.route_url('scalinggroups')}" i18n:translate="">Scaling groups</a></li>
+                <li><a href="${request.route_path('scalinggroups')}" i18n:translate="">Scaling groups</a></li>
                 <li class="current"><a href="#" ng-non-bindable="">${scaling_group.name}</a></li>
             </metal:crumbs>
         </metal:breadcrumbs>
@@ -22,8 +22,8 @@
         <div class="large-7 columns">
             <dl class="tabs" id="scalinggroup-subnav">
                 <dd class="active"><a href="#" i18n:translate="">General</a></dd>
-                <dd><a href="${request.route_url('scalinggroup_policies', id=scaling_group.name)}" i18n:translate="">Policies</a></dd>
-                <dd><a href="${request.route_url('scalinggroup_instances', id=scaling_group.name)}" i18n:translate="">Instances</a></dd>
+                <dd><a href="${request.route_path('scalinggroup_policies', id=scaling_group.name)}" i18n:translate="">Policies</a></dd>
+                <dd><a href="${request.route_path('scalinggroup_instances', id=scaling_group.name)}" i18n:translate="">Instances</a></dd>
             </dl>
             <div class="panel has-actions">
                 <metal:block metal:use-macro="layout.global_macros['actions_menu']" tal:condition="scaling_group">
@@ -37,9 +37,9 @@
                 </metal:block>
                 <p tal:condition="not policies">
                     <span i18n:translate="">To automatically scale your group up or down, please</span>
-                    <a href="${request.route_url('scalinggroup_policy_new', id=scaling_group.name)}" i18n:translate="">add scaling policies</a>
+                    <a href="${request.route_path('scalinggroup_policy_new', id=scaling_group.name)}" i18n:translate="">add scaling policies</a>
                 </p>
-                <form action="${request.route_url('scalinggroup_update', id=scaling_group.name)}" method="post" data-abide=""
+                <form action="${request.route_path('scalinggroup_update', id=scaling_group.name)}" method="post" data-abide=""
                       tal:define="avail_zone_html_attrs {'data-placeholder': avail_zone_placeholder_text};
                                   load_balancers_html_attrs {'data-placeholder': ' '};
                                   term_policies_html_attrs {'data-placeholder': termination_policies_placeholder_text};">
@@ -74,7 +74,7 @@
                         <button type="submit" class="button" id="save-change-btn">
                             <span tal:condition="scaling_group" i18n:translate="">Save changes</span>
                         </button>
-                        <a href="${request.route_url('scalinggroups')}"
+                        <a href="${request.route_path('scalinggroups')}"
                            class="cancel-link" i18n:translate="">Cancel</a>
                     </div>
                 </form>
@@ -93,8 +93,8 @@
 </div>
 
 <div metal:fill-slot="tail_js">
-    <script src="${request.static_url('eucaconsole:static/js/thirdparty/jquery/chosen.jquery.min.js')}"></script>
-    <script src="${request.static_url('eucaconsole:static/js/pages/scalinggroup.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/thirdparty/jquery/chosen.jquery.min.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/pages/scalinggroup.js')}"></script>
 </div>
 
 </metal:block>

--- a/eucaconsole/templates/scalinggroups/scalinggroup_wizard.pt
+++ b/eucaconsole/templates/scalinggroups/scalinggroup_wizard.pt
@@ -1,7 +1,7 @@
 <metal:block use-macro="main_template">
 
 <head metal:fill-slot="head_css">
-    <link rel="stylesheet" type="text/css" href="${request.static_url('eucaconsole:static/css/pages/scalinggroup_wizard.css')}" />
+    <link rel="stylesheet" type="text/css" href="${request.static_path('eucaconsole:static/css/pages/scalinggroup_wizard.css')}" />
 </head>
 
 <div metal:fill-slot="main_content">
@@ -9,7 +9,7 @@
          ng-init="initController()">
         <metal:breadcrumbs metal:use-macro="layout.global_macros['breadcrumbs']">
             <metal:crumbs metal:fill-slot="crumbs">
-                <li><a href="${request.route_url('scalinggroups')}" i18n:translate="">Scaling groups</a></li>
+                <li><a href="${request.route_path('scalinggroups')}" i18n:translate="">Scaling groups</a></li>
                 <li class="current"><a href="#" i18n:translate="">Create scaling group</a></li>
             </metal:crumbs>
         </metal:breadcrumbs>
@@ -20,7 +20,7 @@
         </h3>
         <div class="large-8 columns" tal:define="_ import: pyramid.i18n.TranslationString">
             <div class="wizard no-title">
-                <form action="${request.route_url('scalinggroup_create')}" id="scalinggroup-wizard-form"
+                <form action="${request.route_path('scalinggroup_create')}" id="scalinggroup-wizard-form"
                       method="post" data-abide="abide">
                     ${structure:create_form['csrf_token']}
                     <dl class="tabs" data-tab="">
@@ -132,9 +132,9 @@
 </div>
 
 <div metal:fill-slot="tail_js">
-    <script src="${request.static_url('eucaconsole:static/js/thirdparty/jquery/chosen.jquery.min.js')}"></script>
-    <script src="${request.static_url('eucaconsole:static/js/thirdparty/utils/purl.js')}"></script>
-    <script src="${request.static_url('eucaconsole:static/js/pages/scalinggroup_wizard.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/thirdparty/jquery/chosen.jquery.min.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/thirdparty/utils/purl.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/pages/scalinggroup_wizard.js')}"></script>
 </div>
 
 </metal:block>

--- a/eucaconsole/templates/scalinggroups/scalinggroups.pt
+++ b/eucaconsole/templates/scalinggroups/scalinggroups.pt
@@ -1,7 +1,7 @@
 <metal:block use-macro="main_template">
 
 <head metal:fill-slot="head_css">
-    <link rel="stylesheet" type="text/css" href="${request.static_url('eucaconsole:static/css/pages/scalinggroups.css')}" />
+    <link rel="stylesheet" type="text/css" href="${request.static_path('eucaconsole:static/css/pages/scalinggroups.css')}" />
 </head>
 
 <div metal:fill-slot="main_content" ng-app="ScalingGroupsPage" ng-controller="ScalingGroupsCtrl">
@@ -21,7 +21,7 @@
         <div metal:use-macro="layout.global_macros['landing_page_datagrid']">
             <div metal:fill-slot="new_button">
                 <a class="button" i18n:translate="" id="create-scalinggroup-btn"
-                   href="${request.route_url('scalinggroup_new')}">Create New Scaling Group</a>
+                   href="${request.route_path('scalinggroup_new')}">Create New Scaling Group</a>
             </div>
             <div metal:fill-slot="tile_dropdown_button" tal:omit-tag="">
                 <span class="tiny secondary button dropdown" data-dropdown="item-dropdown_{{ item.name }}"><i class="fi-widget"></i></span>
@@ -140,9 +140,9 @@
 </metal:block>
 
 <div metal:fill-slot="tail_js">
-    <script src="${request.static_url('eucaconsole:static/js/pages/custom_filters.js')}"></script>
-    <script src="${request.static_url('eucaconsole:static/js/pages/landingpage.js')}"></script>
-    <script src="${request.static_url('eucaconsole:static/js/pages/scalinggroups.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/pages/custom_filters.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/pages/landingpage.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/pages/scalinggroups.js')}"></script>
 
 </div>
 

--- a/eucaconsole/templates/securitygroups/securitygroup_view.pt
+++ b/eucaconsole/templates/securitygroups/securitygroup_view.pt
@@ -14,7 +14,7 @@
     <div class="row" id="contentwrap" ng-app="SecurityGroupPage">
         <metal:breadcrumbs metal:use-macro="layout.global_macros['breadcrumbs']">
             <metal:crumbs metal:fill-slot="crumbs">
-                <li><a href="${request.route_url('securitygroups')}" i18n:translate="">Security groups</a></li>
+                <li><a href="${request.route_path('securitygroups')}" i18n:translate="">Security groups</a></li>
                 <li class="current"><a href="#" ng-non-bindable="">${security_group.name if security_group else 'Create security group'}</a></li>
             </metal:crumbs>
         </metal:breadcrumbs>
@@ -30,8 +30,8 @@
             </metal:block>
         </h3>
         <div class="large-7 columns"
-                tal:define="form_action request.route_url('securitygroup_update', id=security_group.id)
-                        if security_group else request.route_url('securitygroup_create')">
+                tal:define="form_action request.route_path('securitygroup_update', id=security_group.id)
+                        if security_group else request.route_path('securitygroup_create')">
             <div class="panel ${'has-actions' if security_group else ''}"
                     tal:define="sgroup_rules security_group.rules if security_group else [];
                                 sgroup_tags security_group.tags if security_group else {};
@@ -74,7 +74,7 @@
                                 Create Security Group
                             </span>
                         </button>
-                        <a href="${request.route_url('securitygroups')}"
+                        <a href="${request.route_path('securitygroups')}"
                            class="cancel-link" i18n:translate="">Cancel</a>
                     </div>
                 </form>
@@ -97,7 +97,7 @@
 </div>
 
 <div metal:fill-slot="tail_js">
-    <script src="${request.static_url('eucaconsole:static/js/thirdparty/jquery/chosen.jquery.min.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/thirdparty/jquery/chosen.jquery.min.js')}"></script>
     <script>
         angular.module('SecurityGroupPage', ['TagEditor', 'SecurityGroupRules'])
     </script>

--- a/eucaconsole/templates/securitygroups/securitygroups.pt
+++ b/eucaconsole/templates/securitygroups/securitygroups.pt
@@ -1,7 +1,7 @@
 <metal:block use-macro="main_template">
 
 <head metal:fill-slot="head_css">
-    <link rel="stylesheet" type="text/css" href="${request.static_url('eucaconsole:static/css/pages/securitygroups.css')}" />
+    <link rel="stylesheet" type="text/css" href="${request.static_path('eucaconsole:static/css/pages/securitygroups.css')}" />
 </head>
 
 <div metal:fill-slot="main_content" ng-app="SecurityGroupsPage" ng-controller="SecurityGroupsCtrl">
@@ -21,7 +21,7 @@
         <div metal:use-macro="layout.global_macros['landing_page_datagrid']">
             <div metal:fill-slot="new_button">
                 <a class="button" i18n:translate="" id="create-securitygroup-btn"
-                   href="${request.route_url('securitygroup_view', id='new')}">Create New Security Group</a>
+                   href="${request.route_path('securitygroup_view', id='new')}">Create New Security Group</a>
             </div>
             <div metal:fill-slot="tile_dropdown_button" tal:omit-tag="">
                 <a class="tiny secondary button dropdown right" data-dropdown="item-dropdown_{{ item.id }}"><i class="fi-widget"></i></a>
@@ -79,10 +79,10 @@
 </metal:block>
 
 <div metal:fill-slot="tail_js">
-    <script src="${request.static_url('eucaconsole:static/js/thirdparty/jquery/chosen.jquery.min.js')}"></script>
-    <script src="${request.static_url('eucaconsole:static/js/pages/custom_filters.js')}"></script>
-    <script src="${request.static_url('eucaconsole:static/js/pages/landingpage.js')}"></script>
-    <script src="${request.static_url('eucaconsole:static/js/pages/securitygroups.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/thirdparty/jquery/chosen.jquery.min.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/pages/custom_filters.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/pages/landingpage.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/pages/securitygroups.js')}"></script>
 </div>
 
 </metal:block>

--- a/eucaconsole/templates/snapshots/snapshot_view.pt
+++ b/eucaconsole/templates/snapshots/snapshot_view.pt
@@ -1,17 +1,17 @@
 <metal:block use-macro="main_template">
 
 <head metal:fill-slot="head_css">
-    <link rel="stylesheet" type="text/css" href="${request.static_url('eucaconsole:static/css/pages/snapshot.css')}" />
+    <link rel="stylesheet" type="text/css" href="${request.static_path('eucaconsole:static/css/pages/snapshot.css')}" />
 </head>
 
 <div metal:fill-slot="main_content">
     <div class="row" id="contentwrap"
          ng-app="SnapshotPage" ng-controller="SnapshotPageCtrl"
-         ng-init="initController('${request.route_url('snapshot_state_json', id=snapshot.id) if snapshot else ''}',
+         ng-init="initController('${request.route_path('snapshot_state_json', id=snapshot.id) if snapshot else ''}',
                  '${snapshot.status if snapshot else ''}', '${snapshot.progress if snapshot else ''}')">
         <metal:breadcrumbs metal:use-macro="layout.global_macros['breadcrumbs']">
             <metal:crumbs metal:fill-slot="crumbs">
-                <li><a href="${request.route_url('snapshots')}" i18n:translate="">Snapshots</a></li>
+                <li><a href="${request.route_path('snapshots')}" i18n:translate="">Snapshots</a></li>
                 <li class="current"><a href="#" ng-non-bindable="">${snapshot_name or 'Create new snapshot'}</a></li>
             </metal:crumbs>
         </metal:breadcrumbs>
@@ -27,15 +27,15 @@
             </metal:block>
         </h3>
         <div class="large-7 columns"
-             tal:define="form_action request.route_url('snapshot_update', id=snapshot.id)
-                         if snapshot else request.route_url('snapshot_create');
+             tal:define="form_action request.route_path('snapshot_update', id=snapshot.id)
+                         if snapshot else request.route_path('snapshot_create');
                          snapshot_tags snapshot.tags if snapshot else {};
                          html_attrs {'disabled': 'disabled'} if snapshot else {'data-placeholder': 'select...'};">
             <div class="panel ${'has-actions' if snapshot else ''}">
                 <metal:block metal:use-macro="layout.global_macros['actions_menu']" tal:condition="snapshot">
                     <metal:actions metal:fill-slot="actions">
                         <li>
-                            <a href="${request.route_url('volume_view', id='new')}?from_snapshot=${snapshot.id}"
+                            <a href="${request.route_path('volume_view', id='new')}?from_snapshot=${snapshot.id}"
                                id="create-volume-action" i18n:translate="">
                                 Create volume from snapshot
                             </a>
@@ -93,7 +93,7 @@
                     <div class="row controls-wrapper readonly" tal:condition="snapshot">
                         <div class="small-4 columns"><label i18n:translate="">Created from volume</label></div>
                         <div class="small-8 columns value breakword">
-                            <a href="${request.route_url('volume_view', id=snapshot.volume_id)}" ng-non-bindable="">${volume_name}</a>
+                            <a href="${request.route_path('volume_view', id=snapshot.volume_id)}" ng-non-bindable="">${volume_name}</a>
                         </div>
                     </div>
                     <div class="row controls-wrapper readonly" tal:condition="snapshot">
@@ -111,14 +111,14 @@
                     <hr  />
                     <div ng-show="snapshotStatus == 'deleted'">
                         <span i18n:translate="">Snapshot was successfully deleted.</span>
-                        <a href="${request.route_url('snapshots')}" i18n:translate="">Return to snapshots page</a>
+                        <a href="${request.route_path('snapshots')}" i18n:translate="">Return to snapshots page</a>
                     </div>
                     <div>
                         <button type="submit" class="button">
                             <span tal:condition="snapshot" i18n:translate="" ng-show="snapshotStatus !== 'deleted'">Save Changes</span>
                             <span tal:condition="not snapshot" i18n:translate="">Create snapshot</span>
                         </button>
-                        <a href="${request.route_url('snapshots')}"
+                        <a href="${request.route_path('snapshots')}"
                            class="cancel-link" i18n:translate="">Cancel</a>
                     </div>
                 </form>
@@ -161,7 +161,7 @@
 </div>
 
 <div metal:fill-slot="tail_js">
-    <script src="${request.static_url('eucaconsole:static/js/thirdparty/jquery/chosen.jquery.min.js')}"></script>
-    <script src="${request.static_url('eucaconsole:static/js/pages/snapshot.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/thirdparty/jquery/chosen.jquery.min.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/pages/snapshot.js')}"></script>
 </div>
 </metal:block>

--- a/eucaconsole/templates/snapshots/snapshots.pt
+++ b/eucaconsole/templates/snapshots/snapshots.pt
@@ -1,7 +1,7 @@
 <metal:block use-macro="main_template">
 
 <head metal:fill-slot="head_css">
-    <link rel="stylesheet" type="text/css" href="${request.static_url('eucaconsole:static/css/pages/snapshots.css')}" />
+    <link rel="stylesheet" type="text/css" href="${request.static_path('eucaconsole:static/css/pages/snapshots.css')}" />
 </head>
 
 <div metal:fill-slot="main_content" ng-app="SnapshotsPage" ng-controller="SnapshotsCtrl">
@@ -20,7 +20,7 @@
         </div>
         <div metal:use-macro="layout.global_macros['landing_page_datagrid']">
             <div metal:fill-slot="new_button">
-                <a href="${request.route_url('snapshot_view', id='new')}" id="create-snapshot-btn"
+                <a href="${request.route_path('snapshot_view', id='new')}" id="create-snapshot-btn"
                    class="button" i18n:translate="">Create New Snapshot</a>
             </div>
             <div metal:fill-slot="tile_dropdown_button" tal:omit-tag="">
@@ -124,10 +124,10 @@
 </metal:block>
 
 <div metal:fill-slot="tail_js">
-    <script src="${request.static_url('eucaconsole:static/js/thirdparty/jquery/chosen.jquery.min.js')}"></script>
-    <script src="${request.static_url('eucaconsole:static/js/pages/custom_filters.js')}"></script>
-    <script src="${request.static_url('eucaconsole:static/js/pages/landingpage.js')}"></script>
-    <script src="${request.static_url('eucaconsole:static/js/pages/snapshots.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/thirdparty/jquery/chosen.jquery.min.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/pages/custom_filters.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/pages/landingpage.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/pages/snapshots.js')}"></script>
 </div>
 
 </metal:block>

--- a/eucaconsole/templates/users/user_new.pt
+++ b/eucaconsole/templates/users/user_new.pt
@@ -5,13 +5,13 @@
 
 <div metal:fill-slot="main_content">
     <div class="row" id="contentwrap" ng-app="UserNew" ng-controller="UserNewCtrl"
-            ng-init="initController('${request.route_url('user_create')}',
-                                    '${request.route_url('users')}',
-                                    '${request.route_url('user_view', name='_name_')}',
-                                    '${request.route_url('file_download')}')">
+            ng-init="initController('${request.route_path('user_create')}',
+                                    '${request.route_path('users')}',
+                                    '${request.route_path('user_view', name='_name_')}',
+                                    '${request.route_path('file_download')}')">
         <metal:breadcrumbs metal:use-macro="layout.global_macros['breadcrumbs']">
             <metal:crumbs metal:fill-slot="crumbs">
-                <li><a href="${request.route_url('users')}" i18n:translate="">IAM users</a></li>
+                <li><a href="${request.route_path('users')}" i18n:translate="">IAM users</a></li>
                 <li class="current" i18n:translate="">Create new users</li>
             </metal:crumbs>
         </metal:breadcrumbs>
@@ -61,7 +61,7 @@
                             <button type="submit" class="button" id="create-user-btn">
                                 <span i18n:translate="">Create Users</span>
                             </button>
-                            <a href="${request.route_url('users')}"
+                            <a href="${request.route_path('users')}"
                                class="cancel-link" i18n:translate="">Cancel</a>
                         </div>
                     </div>
@@ -72,8 +72,8 @@
 </div>
 
 <div metal:fill-slot="tail_js">
-    <script src="${request.static_url('eucaconsole:static/js/thirdparty/jquery/jquery.generateFile.js')}"></script>
-    <script src="${request.static_url('eucaconsole:static/js/pages/user_new.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/thirdparty/jquery/jquery.generateFile.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/pages/user_new.js')}"></script>
 </div>
 
 </metal:block>

--- a/eucaconsole/templates/users/user_view.pt
+++ b/eucaconsole/templates/users/user_view.pt
@@ -1,16 +1,16 @@
 <metal:block use-macro="main_template">
 
 <div metal:fill-slot="head_css">
-    <link rel="stylesheet" href="${request.static_url('eucaconsole:static/js/thirdparty/codemirror/codemirror.css')}" />
-    <link rel="stylesheet" href="${request.static_url('eucaconsole:static/css/pages/user.css')}" />
-    <link rel="stylesheet" href="${request.static_url('eucaconsole:static/css/pages/changepassword.css')}" />
+    <link rel="stylesheet" href="${request.static_path('eucaconsole:static/js/thirdparty/codemirror/codemirror.css')}" />
+    <link rel="stylesheet" href="${request.static_path('eucaconsole:static/css/pages/user.css')}" />
+    <link rel="stylesheet" href="${request.static_path('eucaconsole:static/css/pages/changepassword.css')}" />
 </div>
 
 <div metal:fill-slot="main_content">
     <div class="row" id="contentwrap" ng-app="UserView" ng-controller="UserViewCtrl">
         <metal:breadcrumbs metal:use-macro="layout.global_macros['breadcrumbs']">
             <metal:crumbs metal:fill-slot="crumbs">
-                <li><a href="${request.route_url('users')}" i18n:translate="">IAM users</a></li>
+                <li><a href="${request.route_path('users')}" i18n:translate="">IAM users</a></li>
                 <li class="current"><a href="#" ng-non-bindable="">${user.user_name}</a></li>
             </metal:crumbs>
         </metal:breadcrumbs>
@@ -35,7 +35,7 @@
                         </metal:actions>
                     </metal:block>
                     <div ng-controller="UserUpdateCtrl"
-                         ng-init="initController('${request.route_url('user_update', name=user.user_name)}')">
+                         ng-init="initController('${request.route_path('user_update', name=user.user_name)}')">
 
                         <form data-abide="abide" id="user-update-form" ng-submit="submit($event)">
                             ${structure:user_form['csrf_token']}
@@ -61,7 +61,7 @@
                                     <button type="submit" class="button" id="save-user-btn">
                                         <span tal:condition="user" i18n:translate="">Save Changes</span>
                                     </button>
-                                    <a href="${request.route_url('users')}"
+                                    <a href="${request.route_path('users')}"
                                        class="cancel-link" i18n:translate="">Cancel</a>
                                 </div>
                             </div>
@@ -70,12 +70,12 @@
                     <hr id="group-section"/>
                     <div ng-controller="UserGroupsCtrl"
                          ng-init="initController(
-                                '${request.route_url('user_add_to_group', name=user.user_name, group='_group_')}',
-                                '${request.route_url('user_remove_from_group', name=user.user_name, group='_group_')}',
-                                '${request.route_url('user_groups_json', name=user.user_name)}',
-                                '${request.route_url('user_avail_groups_json', name=user.user_name)}',
-                                '${request.route_url('group_policies_json', name='_name_')}',
-                                '${request.route_url('group_policy_json', name='_name_', policy='_policy_')}')">
+                                '${request.route_path('user_add_to_group', name=user.user_name, group='_group_')}',
+                                '${request.route_path('user_remove_from_group', name=user.user_name, group='_group_')}',
+                                '${request.route_path('user_groups_json', name=user.user_name)}',
+                                '${request.route_path('user_avail_groups_json', name=user.user_name)}',
+                                '${request.route_path('group_policies_json', name='_name_')}',
+                                '${request.route_path('group_policy_json', name='_name_', policy='_policy_')}')">
                         <div class="section">
                             <h6 i18n:translate="">Groups</h6>
                             <form id="user-add-group-form" ng-submit="addUserToGroup($event)">
@@ -121,11 +121,11 @@
                         </div>
                     </div>
                     <hr/>
-                    <div tal:define="policies_url request.route_url('user_policies_json', name=user.user_name);
-                                     policy_url request.route_url('user_policy_json', name=user.user_name, policy='_policy_');
-                                     remove_url request.route_url('user_delete_policy', name=user.user_name, policy='_policy_');
-                                     update_url request.route_url('user_update_policy', name=user.user_name, policy='_policy_');
-                                     add_url request.route_url('iam_policy_new')+'?type=user&id='+user.user_name">
+                    <div tal:define="policies_url request.route_path('user_policies_json', name=user.user_name);
+                                     policy_url request.route_path('user_policy_json', name=user.user_name, policy='_policy_');
+                                     remove_url request.route_path('user_delete_policy', name=user.user_name, policy='_policy_');
+                                     update_url request.route_path('user_update_policy', name=user.user_name, policy='_policy_');
+                                     add_url request.route_path('iam_policy_new')+'?type=user&id='+user.user_name">
                         <div class="section">
                             <h6 i18n:translate="">Permissions</h6>
                             <div>
@@ -147,10 +147,10 @@
                         </metal:actions>
                     </metal:block>
                     <div id="password-section" ng-controller="UserPasswordCtrl"
-                         ng-init="initController('${request.route_url('user_random_password', name=user.user_name)}',
-                                                 '${request.route_url('user_delete_password', name=user.user_name)}',
-                                                 '${request.route_url('user_change_password', name=user.user_name)}',
-                                                 '${request.route_url('file_download')}', '${has_password}')">
+                         ng-init="initController('${request.route_path('user_random_password', name=user.user_name)}',
+                                                 '${request.route_path('user_delete_password', name=user.user_name)}',
+                                                 '${request.route_path('user_change_password', name=user.user_name)}',
+                                                 '${request.route_path('file_download')}', '${has_password}')">
                         <h6 i18n:translate="">Password</h6>
                         <p i18n:translate="">Users managing their cloud with the Management Console require a password.</p>
                         <span class='password-set' i18n:translate="">Password set?: </span> <span ng-show="has_password">Yes &nbsp;&nbsp;<a data-reveal-id="delete-password-modal" i18n:translate="">Delete password</a></span> <span ng-hide="has_password">No</span>
@@ -192,7 +192,7 @@
                                             <button type="submit" class="button" id="save-password-btn">
                                                 <span tal:condition="user" i18n:translate="">Save Password</span>
                                             </button>
-                                            <a href="${request.route_url('users')}"
+                                            <a href="${request.route_path('users')}"
                                                class="cancel-link" i18n:translate="">Cancel</a>
                                         </div>
                                     </div>
@@ -238,9 +238,9 @@
                     <hr id="access-keys-section"/>
                     <div ng-controller="UserAccessKeysCtrl"
                          ng-init="initController(
-                                '${request.route_url('user_generate_keys', name=user.user_name)}',
-                                '${request.route_url('user_access_keys_json', name=user.user_name)}',
-                                '${request.route_url('file_download')}')">
+                                '${request.route_path('user_generate_keys', name=user.user_name)}',
+                                '${request.route_path('user_access_keys_json', name=user.user_name)}',
+                                '${request.route_path('file_download')}')">
                         <div class="section">
                             <h6 i18n:translate="">Access keys</h6>
                             <p i18n:translate="">Users managing their cloud with other tools than the Management Console require access keys.</p>
@@ -267,10 +267,10 @@
                                             <a class="tiny secondary button dropdown round" data-dropdown="item-dropdown_{{ item.id }}"><i class="fi-widget"></i></a>
                                             <ul id="item-dropdown_{{ item.id }}" class="f-dropdown" data-dropdown-content="">
                                                 <li ng-show="item.status === 'Active'">
-                                                    <a i18n:translate="" ng-click="makeAjaxCall('${request.route_url('user_deactivate_key', name='_name_', key='_key_')}', item)">Deactivate</a>
+                                                    <a i18n:translate="" ng-click="makeAjaxCall('${request.route_path('user_deactivate_key', name='_name_', key='_key_')}', item)">Deactivate</a>
                                                 </li>
                                                 <li ng-show="item.status === 'Inactive'">
-                                                    <a i18n:translate="" ng-click="makeAjaxCall('${request.route_url('user_activate_key', name='_name_', key='_key_')}', item)">Activate</a>
+                                                    <a i18n:translate="" ng-click="makeAjaxCall('${request.route_path('user_activate_key', name='_name_', key='_key_')}', item)">Activate</a>
                                                 </li>
                                                 <li>
                                                     <a i18n:translate="" ng-click="confirmDelete(item)">Delete</a>
@@ -286,7 +286,7 @@
                                     <p>
                                         <span i18n:translate="">Are you sure you want to delete the access key?</span>
                                     </p>
-                                    <form id="delete-key-form" ng-submit="deleteKey('${request.route_url('user_delete_key', name='_name_', key='_key_')}')">
+                                    <form id="delete-key-form" ng-submit="deleteKey('${request.route_path('user_delete_key', name='_name_', key='_key_')}')">
                                         ${structure:user_form['csrf_token']}
                                         <div>&nbsp;</div>
                                         <div class="row">
@@ -315,7 +315,7 @@
                         </metal:actions>
                     </metal:block>
                     <div ng-controller="UserQuotasCtrl" ng-init="initController(
-                                '${request.route_url('user_update_quotas', name=user.user_name)}')">
+                                '${request.route_path('user_update_quotas', name=user.user_name)}')">
                         <form ng-submit="submit($event)" id="user-update-quotas-form">
                             <div class="section">
                                 <h6 i18n:translate="">Quotas</h6>
@@ -328,7 +328,7 @@
                                     <button type="submit" class="button" id="save-quotas-btn">
                                         <span tal:condition="user" i18n:translate="">Save Quotas</span>
                                     </button>
-                                    <a href="${request.route_url('users')}"
+                                    <a href="${request.route_path('users')}"
                                        class="cancel-link" i18n:translate="">Cancel</a>
                                 </div>
                             </div>
@@ -347,7 +347,7 @@
                 <p>
                     <span i18n:translate="">Deleting a user also deletes all keys, passwords and permissions associated with that user. Are you sure you want to delete user <strong ng-non-bindable="">${user.user_name}</strong></span>?
                 </p>
-                <form method="post" id="delete-form" action="${request.route_url('user_delete', name=user.user_name)}">
+                <form method="post" id="delete-form" action="${request.route_path('user_delete', name=user.user_name)}">
                     ${structure:delete_form['csrf_token']}
                     <div>&nbsp;</div>
                     <div class="row">
@@ -364,10 +364,10 @@
 </div>
 
 <div metal:fill-slot="tail_js">
-    <script src="${request.static_url('eucaconsole:static/js/thirdparty/jquery/chosen.jquery.min.js')}"></script>
-    <script src="${request.static_url('eucaconsole:static/js/thirdparty/utils/zxcvbn-async.js')}"></script>
-    <script src="${request.static_url('eucaconsole:static/js/thirdparty/jquery/jquery.generateFile.js')}"></script>
-    <script src="${request.static_url('eucaconsole:static/js/pages/user_view.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/thirdparty/jquery/chosen.jquery.min.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/thirdparty/utils/zxcvbn-async.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/thirdparty/jquery/jquery.generateFile.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/pages/user_view.js')}"></script>
 </div>
 
 </metal:block>

--- a/eucaconsole/templates/users/users.pt
+++ b/eucaconsole/templates/users/users.pt
@@ -1,16 +1,16 @@
 <metal:block use-macro="main_template">
 
 <head metal:fill-slot="head_css">
-    <link rel="stylesheet" type="text/css" href="${request.static_url('eucaconsole:static/css/pages/users.css')}" />
+    <link rel="stylesheet" type="text/css" href="${request.static_path('eucaconsole:static/css/pages/users.css')}" />
 </head>
 
 <div metal:fill-slot="main_content" ng-app="UsersPage" ng-controller="UsersCtrl" ng-init="initPage(
-                '${request.route_url('user_view', name='_name_')}',
-                '${request.route_url('group_view', name='_name_')}',
-                '${request.route_url('user_summary_json', name='_name_')}',
-                '${request.route_url('user_disable', name='_name_')}',
-                '${request.route_url('user_enable', name='_name_')}',
-                '${request.route_url('file_download')}')">
+                '${request.route_path('user_view', name='_name_')}',
+                '${request.route_path('group_view', name='_name_')}',
+                '${request.route_path('user_summary_json', name='_name_')}',
+                '${request.route_path('user_disable', name='_name_')}',
+                '${request.route_path('user_enable', name='_name_')}',
+                '${request.route_path('file_download')}')">
     <div class="row" id="contentwrap" ng-controller="ItemsCtrl"
          ng-init="initController('users', '${initial_sort_key}', '${json_items_endpoint}')">
         <metal:breadcrumbs metal:use-macro="layout.global_macros['breadcrumbs']">
@@ -27,7 +27,7 @@
         <div metal:use-macro="layout.global_macros['landing_page_datagrid']">
             <div metal:fill-slot="new_button">
                 <a class="button" i18n:translate="" id="add-user-btn"
-                   href="${request.route_url('user_view', name='new')}">Create New Users</a>
+                   href="${request.route_path('user_view', name='new')}">Create New Users</a>
             </div>
             <div metal:fill-slot="tile_dropdown_button" tal:omit-tag="">
                 <a class="tiny secondary button dropdown right" data-dropdown="item-dropdown_{{ item.id }}"><i class="fi-widget"></i></a>
@@ -144,7 +144,7 @@
                 <p>
                     <span i18n:translate="">Deleting a user also deletes all keys, passwords and permissions associated with that user. Are you sure you want to delete user <strong>{{ user_name }}</strong></span>?
                 </p>
-                <form method="post" id="delete-form" action="${request.route_url('user_delete', name='_name_')}">
+                <form method="post" id="delete-form" action="${request.route_path('user_delete', name='_name_')}">
                     ${structure:delete_form['csrf_token']}
                     <div>&nbsp;</div>
                     <div class="row">
@@ -206,10 +206,10 @@
 </metal:block>
 
 <div metal:fill-slot="tail_js">
-    <script src="${request.static_url('eucaconsole:static/js/thirdparty/jquery/jquery.generateFile.js')}"></script>
-    <script src="${request.static_url('eucaconsole:static/js/pages/custom_filters.js')}"></script>
-    <script src="${request.static_url('eucaconsole:static/js/pages/landingpage.js')}"></script>
-    <script src="${request.static_url('eucaconsole:static/js/pages/users.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/thirdparty/jquery/jquery.generateFile.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/pages/custom_filters.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/pages/landingpage.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/pages/users.js')}"></script>
 </div>
 
 </metal:block>

--- a/eucaconsole/templates/volumes/volume_snapshots.pt
+++ b/eucaconsole/templates/volumes/volume_snapshots.pt
@@ -1,16 +1,16 @@
 <metal:block use-macro="main_template">
 
 <head metal:fill-slot="head_css">
-    <link rel="stylesheet" type="text/css" href="${request.static_url('eucaconsole:static/css/pages/volume.css')}" />
+    <link rel="stylesheet" type="text/css" href="${request.static_path('eucaconsole:static/css/pages/volume.css')}" />
 </head>
 
 <div metal:fill-slot="main_content">
     <div class="row" id="contentwrap" ng-app="VolumeSnapshots"
          ng-controller="VolumeSnapshotsCtrl"
-         ng-init="initController('${request.route_url('volume_snapshots_json', id=volume.id)}')">
+         ng-init="initController('${request.route_path('volume_snapshots_json', id=volume.id)}')">
         <metal:breadcrumbs metal:use-macro="layout.global_macros['breadcrumbs']">
             <metal:crumbs metal:fill-slot="crumbs">
-                <li><a href="${request.route_url('volumes')}" i18n:translate="">Volumes</a></li>
+                <li><a href="${request.route_path('volumes')}" i18n:translate="">Volumes</a></li>
                 <li class="current"><a href="#" ng-non-bindable="">${volume_name}</a></li>
             </metal:crumbs>
         </metal:breadcrumbs>
@@ -23,7 +23,7 @@
 
         <div class="large-8 columns">
             <dl class="tabs" id="volume-subnav">
-                <dd><a href="${request.route_url('volume_view', id=volume.id)}" i18n:translate="">General</a></dd>
+                <dd><a href="${request.route_path('volume_view', id=volume.id)}" i18n:translate="">General</a></dd>
                 <dd class="active"><a href="#" i18n:translate="">Snapshots</a></dd>
             </dl>
             <div class="panel gridwrapper no-title">
@@ -83,7 +83,7 @@
                 tal:define="snapshot_tags {};">
                 <h3 i18n:translate="">Create snapshot from volume</h3>
                 <p><span i18n:translate="">Add a snapshot for</span> <strong ng-non-bindable="">${volume_name}</strong></p>
-                <form method="post" action="${request.route_url('volume_snapshot_create', id=volume.id)}"
+                <form method="post" action="${request.route_path('volume_snapshot_create', id=volume.id)}"
                       id="create-snapshot-form" data-abide="">
                     ${structure:create_form['csrf_token']}
                     ${panel('form_field', field=create_form.name, leftcol_width=3, rightcol_width=9)}
@@ -119,7 +119,7 @@
 </div>
 
 <div metal:fill-slot="tail_js">
-    <script src="${request.static_url('eucaconsole:static/js/pages/volume_snapshots.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/pages/volume_snapshots.js')}"></script>
 </div>
 
 </metal:block>

--- a/eucaconsole/templates/volumes/volume_view.pt
+++ b/eucaconsole/templates/volumes/volume_view.pt
@@ -1,7 +1,7 @@
 <metal:block use-macro="main_template">
 
 <head metal:fill-slot="head_css">
-    <link rel="stylesheet" type="text/css" href="${request.static_url('eucaconsole:static/css/pages/volume.css')}" />
+    <link rel="stylesheet" type="text/css" href="${request.static_path('eucaconsole:static/css/pages/volume.css')}" />
     <style type="text/css">
         input#size { width: 4rem; }
         input#name { width: 50%; }
@@ -12,13 +12,13 @@
 <div metal:fill-slot="main_content">
     <div class="row" id="contentwrap"
          ng-app="VolumePage" ng-controller="VolumePageCtrl"
-         ng-init="initController('${request.route_url('volume_state_json', id=volume.id) if volume else ''}',
+         ng-init="initController('${request.route_path('volume_state_json', id=volume.id) if volume else ''}',
                  '${volume.status if volume else ''}',
                  '${volume.attach_data.status if volume else ''}'
                  )">
         <metal:breadcrumbs metal:use-macro="layout.global_macros['breadcrumbs']">
             <metal:crumbs metal:fill-slot="crumbs">
-                <li><a href="${request.route_url('volumes')}" i18n:translate="">Volumes</a></li>
+                <li><a href="${request.route_path('volumes')}" i18n:translate="">Volumes</a></li>
                 <li class="current"><a href="#" ng-non-bindable="">${volume_name or 'Create volume'}</a></li>
             </metal:crumbs>
         </metal:breadcrumbs>
@@ -34,13 +34,13 @@
             </metal:block>
         </h3>
         <div class="large-8 columns"
-             tal:define="form_action request.route_url('volume_update', id=volume.id)
-                         if volume else request.route_url('volume_create');
+             tal:define="form_action request.route_path('volume_update', id=volume.id)
+                         if volume else request.route_path('volume_create');
                          volume_tags volume.tags if volume else {};
                          html_attrs {'disabled': 'disabled'} if volume else {};">
             <dl class="tabs" id="volume-subnav" tal:condition="volume">
                 <dd class="active"><a href="#" i18n:translate="">General</a></dd>
-                <dd><a href="${request.route_url('volume_snapshots', id=volume.id)}" i18n:translate="">Snapshots</a></dd>
+                <dd><a href="${request.route_path('volume_snapshots', id=volume.id)}" i18n:translate="">Snapshots</a></dd>
             </dl>
             <div class="panel ${'has-actions' if volume else ''}">
                 <metal:block metal:use-macro="layout.global_macros['actions_menu']" tal:condition="volume">
@@ -74,7 +74,7 @@
                          tal:condition="instance_id">
                         <div class="small-4 columns"><label i18n:translate="">Attached to instance</label></div>
                         <div class="small-8 columns value">
-                            <a href="${request.route_url('instance_view', id=instance_id)}" ng-non-bindable="">${instance_name}</a>
+                            <a href="${request.route_path('instance_view', id=instance_id)}" ng-non-bindable="">${instance_name}</a>
                         </div>
                     </div>
                     <div tal:condition="not volume" tal:omit-tag="">
@@ -112,14 +112,14 @@
                     <hr />
                     <div ng-show="volumeStatus == 'deleted'">
                         <span i18n:translate="">Volume was successfully deleted.</span>
-                        <a href="${request.route_url('volumes')}" i18n:translate="">Return to volumes page</a>
+                        <a href="${request.route_path('volumes')}" i18n:translate="">Return to volumes page</a>
                     </div>
                     <div>
                         <button type="submit" class="button">
                             <span tal:condition="volume" i18n:translate="" ng-show="volumeStatus !== 'deleted'">Save Changes</span>
                             <span tal:condition="not volume" i18n:translate="">Create Volume</span>
                         </button>
-                        <a href="${request.route_url('volumes')}"
+                        <a href="${request.route_path('volumes')}"
                            class="cancel-link" i18n:translate="">Cancel</a>
                     </div>
                 </form>
@@ -132,7 +132,7 @@
                 ${panel('help_volumes', 'create_volume')}
             </div>
             <div class="help-content" tal:condition="volume" ng-show="isHelpExpanded" ng-cloak="">
-                ${panel('help_volumes', 'manage_snapshot', request.route_url('volume_snapshots', id=volume.id))}
+                ${panel('help_volumes', 'manage_snapshot', request.route_path('volume_snapshots', id=volume.id))}
             </div>
             <div class="help-content" tal:condition="volume" ng-show="isHelpExpanded" ng-cloak="">
                 ${panel('help_volumes', 'delete_volume')}
@@ -150,8 +150,8 @@
 </div>
 
 <div metal:fill-slot="tail_js">
-    <script src="${request.static_url('eucaconsole:static/js/thirdparty/jquery/chosen.jquery.min.js')}"></script>
-    <script src="${request.static_url('eucaconsole:static/js/thirdparty/utils/purl.js')}"></script>
-    <script src="${request.static_url('eucaconsole:static/js/pages/volume.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/thirdparty/jquery/chosen.jquery.min.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/thirdparty/utils/purl.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/pages/volume.js')}"></script>
 </div>
 </metal:block>

--- a/eucaconsole/templates/volumes/volumes.pt
+++ b/eucaconsole/templates/volumes/volumes.pt
@@ -1,7 +1,7 @@
 <metal:block use-macro="main_template">
 
 <head metal:fill-slot="head_css">
-    <link rel="stylesheet" type="text/css" href="${request.static_url('eucaconsole:static/css/pages/volumes.css')}" />
+    <link rel="stylesheet" type="text/css" href="${request.static_path('eucaconsole:static/css/pages/volumes.css')}" />
 </head>
 
 <div metal:fill-slot="main_content" ng-app="VolumesPage" ng-controller="VolumesCtrl" ng-init="initPage(${instances_by_zone})">
@@ -21,7 +21,7 @@
         <div metal:use-macro="layout.global_macros['landing_page_datagrid']">
             <div metal:fill-slot="new_button">
                 <a class="button" i18n:translate="" id="create-volume-btn"
-                   href="${request.route_url('volume_view', id='new')}">Create New Volume</a>
+                   href="${request.route_path('volume_view', id='new')}">Create New Volume</a>
             </div>
             <div metal:fill-slot="tile_dropdown_button" tal:omit-tag="">
                 <a class="tiny secondary button dropdown right" data-dropdown="item-dropdown_{{ item.id }}"><i class="fi-widget"></i></a>
@@ -139,10 +139,10 @@
 </metal:block>
 
 <div metal:fill-slot="tail_js">
-    <script src="${request.static_url('eucaconsole:static/js/thirdparty/jquery/chosen.jquery.min.js')}"></script>
-    <script src="${request.static_url('eucaconsole:static/js/pages/custom_filters.js')}"></script>
-    <script src="${request.static_url('eucaconsole:static/js/pages/landingpage.js')}"></script>
-    <script src="${request.static_url('eucaconsole:static/js/pages/volumes.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/thirdparty/jquery/chosen.jquery.min.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/pages/custom_filters.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/pages/landingpage.js')}"></script>
+    <script src="${request.static_path('eucaconsole:static/js/pages/volumes.js')}"></script>
 </div>
 
 </metal:block>

--- a/eucaconsole/views/__init__.py
+++ b/eucaconsole/views/__init__.py
@@ -113,7 +113,7 @@ class BaseView(object):
             request.session.flash(notice, queue='warning')
             # Empty Beaker cache to clear connection objects
             cls.invalidate_cache()
-            location = request.route_url('login')
+            location = request.route_path('login')
             return HTTPFound(location=location)
         return HTTPForbidden()
 
@@ -300,12 +300,12 @@ class LandingPageView(BaseView):
 
     def get_json_endpoint(self, route):
         return '{0}{1}'.format(
-            self.request.route_url(route),
+            self.request.route_path(route),
             '?{0}'.format(urlencode(self.request.params)) if self.request.params else ''
         )
 
     def get_redirect_location(self, route):
-        return '{0}'.format(self.request.route_url(route))
+        return '{0}'.format(self.request.route_path(route))
 
 
 @notfound_view_config(renderer='../templates/notfound.pt')

--- a/eucaconsole/views/alarms.py
+++ b/eucaconsole/views/alarms.py
@@ -45,7 +45,7 @@ class CloudWatchAlarmsView(LandingPageView):
             sort_keys=self.sort_keys,
             prefix=self.prefix,
             initial_sort_key=self.initial_sort_key,
-            json_items_endpoint=self.request.route_url('cloudwatch_alarms_json'),
+            json_items_endpoint=self.request.route_path('cloudwatch_alarms_json'),
         )
 
     @view_config(route_name='cloudwatch_alarms', renderer=TEMPLATE, request_method='GET')
@@ -54,7 +54,7 @@ class CloudWatchAlarmsView(LandingPageView):
 
     @view_config(route_name='cloudwatch_alarms_create', renderer=TEMPLATE, request_method='POST')
     def cloudwatch_alarms_create(self):
-        location = self.request.params.get('redirect_location') or self.request.route_url('cloudwatch_alarms')
+        location = self.request.params.get('redirect_location') or self.request.route_path('cloudwatch_alarms')
         if self.create_form.validate():
             try:
                 metric = self.request.params.get('metric')
@@ -93,7 +93,7 @@ class CloudWatchAlarmsView(LandingPageView):
     @view_config(route_name='cloudwatch_alarms_delete', renderer=TEMPLATE, request_method='POST')
     def cloudwatch_alarms_delete(self):
         if self.delete_form.validate():
-            location = self.request.route_url('cloudwatch_alarms')
+            location = self.request.route_path('cloudwatch_alarms')
             alarm_name = self.request.params.get('name')
             try:
                 self.cloudwatch_conn.delete_alarm(alarm_name)

--- a/eucaconsole/views/changepassword.py
+++ b/eucaconsole/views/changepassword.py
@@ -26,7 +26,7 @@ class ChangePasswordView(BaseView):
         self.changepassword_form = EucaChangePasswordForm(self.request)
         referrer = self.request.url
         referrer_root = referrer.split('?',1)[0] if referrer.find('?') > -1 else referrer
-        changepassword_url = self.request.route_url('changepassword')
+        changepassword_url = self.request.route_path('changepassword')
         if referrer_root in [changepassword_url]:
             referrer = '/'  # never use the changepassword form itself as came_from
         came_from_param = self.request.params.get('came_from', referrer)

--- a/eucaconsole/views/dialogs.py
+++ b/eucaconsole/views/dialogs.py
@@ -93,7 +93,7 @@ def create_securitygroup_dialog(context, request, securitygroup_form=None, secur
 @panel_config('create_alarm_dialog', renderer='../templates/dialogs/create_alarm_dialog.pt')
 def create_alarm_dialog(context, request, alarm_form=None, redirect_location=None, modal_size='medium'):
     """Create alarm dialog page."""
-    redirect_location = redirect_location or request.route_url('cloudwatch_alarms')
+    redirect_location = redirect_location or request.route_path('cloudwatch_alarms')
     return dict(
         alarm_form=alarm_form,
         redirect_location=redirect_location,

--- a/eucaconsole/views/groups.py
+++ b/eucaconsole/views/groups.py
@@ -29,7 +29,7 @@ class GroupsView(LandingPageView):
 
     @view_config(route_name='groups', renderer=TEMPLATE)
     def groups_landing(self):
-        json_items_endpoint = self.request.route_url('groups_json')
+        json_items_endpoint = self.request.route_path('groups_json')
         if self.request.GET:
             json_items_endpoint += '?{params}'.format(params=urlencode(self.request.GET))
         user_choices = []  # sorted(set(item.user_name for item in conn.get_all_users().users))
@@ -159,7 +159,7 @@ class GroupView(BaseView):
             except EC2ResponseError as err:
                 msg = err.message
                 queue = Notification.ERROR
-            location = self.request.route_url('group_view', name=new_group_name)
+            location = self.request.route_path('group_view', name=new_group_name)
             self.request.session.flash(msg, queue=queue)
             return HTTPFound(location=location)
 
@@ -177,14 +177,14 @@ class GroupView(BaseView):
                 self.group_update_users( self.group.group_name, new_users)
             if new_group_name is not None or new_path is not None:
                 self.group_update_name_and_path(new_group_name, new_path)
-            location = self.request.route_url('group_view', name=this_group_name)
+            location = self.request.route_path('group_view', name=this_group_name)
             return HTTPFound(location=location)
 
         return self.render_dict
 
     @view_config(route_name='group_delete', request_method='POST')
     def group_delete(self):
-        location = self.request.route_url('groups')
+        location = self.request.route_path('groups')
         if self.group is None:
             raise HTTPNotFound()
         try:

--- a/eucaconsole/views/images.py
+++ b/eucaconsole/views/images.py
@@ -171,7 +171,7 @@ class ImageView(TaggedItemView):
         if self.image_form.validate():
             self.update_tags()
 
-            location = self.request.route_url('image_view', id=self.image.id)
+            location = self.request.route_path('image_view', id=self.image.id)
             msg = _(u'Successfully modified image')
             self.request.session.flash(msg, queue=Notification.SUCCESS)
             return HTTPFound(location=location)

--- a/eucaconsole/views/instances.py
+++ b/eucaconsole/views/instances.py
@@ -412,7 +412,7 @@ class InstanceView(TaggedItemView, BaseInstanceView):
 
     @view_config(route_name='instance_reboot', renderer=VIEW_TEMPLATE, request_method='POST')
     def instance_reboot(self):
-        location = self.request.route_url('instance_view', id=self.instance.id)
+        location = self.request.route_path('instance_view', id=self.instance.id)
         if self.instance and self.reboot_form.validate():
             try:
                 rebooted = self.instance.reboot()
@@ -475,7 +475,7 @@ class InstanceView(TaggedItemView, BaseInstanceView):
 
     def get_redirect_location(self):
         if self.instance:
-            return self.request.route_url('instance_view', id=self.instance.id)
+            return self.request.route_path('instance_view', id=self.instance.id)
         return ''
 
     def disassociate_ip_address(self, ip_address=None):
@@ -558,7 +558,7 @@ class InstanceVolumesView(BaseInstanceView):
             status = volume.status
             attach_status = volume.attach_data.status
             is_transitional = status in transitional_states or attach_status in transitional_states
-            detach_form_action = self.request.route_url(
+            detach_form_action = self.request.route_path(
                 'instance_volume_detach', id=self.instance.id, volume_id=volume.id)
             volumes.append(dict(
                 id=volume.id,
@@ -584,7 +584,7 @@ class InstanceVolumesView(BaseInstanceView):
                 volumes = self.conn.get_all_volumes(volume_ids=volume_ids)
                 volume = volumes[0] if volumes else None
             if self.instance and volume and device:
-                location = self.request.route_url('instance_volumes', id=self.instance.id)
+                location = self.request.route_path('instance_volumes', id=self.instance.id)
                 try:
                     volume.attach(self.instance.id, device)
                     msg = _(u'Request successfully submitted.  It may take a moment to attach the volume.')
@@ -608,7 +608,7 @@ class InstanceVolumesView(BaseInstanceView):
             if volume:
                 volume.detach()
                 time.sleep(1)
-                location = self.request.route_url('instance_volumes', id=self.instance.id)
+                location = self.request.route_path('instance_volumes', id=self.instance.id)
                 msg = _(u'Request successfully submitted.  It may take a moment to detach the volume.')
                 queue = Notification.SUCCESS
                 self.request.session.flash(msg, queue=queue)
@@ -627,7 +627,7 @@ class InstanceLaunchView(BlockDeviceMappingItemView):
         super(InstanceLaunchView, self).__init__(request)
         self.request = request
         self.image = self.get_image()
-        self.location = self.request.route_url('instances')
+        self.location = self.request.route_path('instances')
         self.securitygroups = self.get_security_groups()
         self.launch_form = LaunchInstanceForm(
             self.request, image=self.image, securitygroups=self.securitygroups,
@@ -638,7 +638,7 @@ class InstanceLaunchView(BlockDeviceMappingItemView):
         self.securitygroup_form = SecurityGroupForm(self.request, formdata=self.request.params or None)
         self.generate_file_form = GenerateFileForm(self.request, formdata=self.request.params or None)
         self.securitygroups_rules_json = json.dumps(self.get_securitygroups_rules())
-        self.images_json_endpoint = self.request.route_url('images_json')
+        self.images_json_endpoint = self.request.route_path('images_json')
         self.owner_choices = self.get_owner_choices()
         self.keypair_choices_json = json.dumps(dict(self.launch_form.keypair.choices))
         self.securitygroup_choices_json = json.dumps(dict(self.launch_form.securitygroup.choices))
@@ -744,7 +744,7 @@ class InstanceLaunchMoreView(BaseInstanceView, BlockDeviceMappingItemView):
         self.instance = self.get_instance()
         self.instance_name = TaggedItemView.get_display_name(self.instance)
         self.image = self.get_image(instance=self.instance)  # From BaseInstanceView
-        self.location = self.request.route_url('instances')
+        self.location = self.request.route_path('instances')
         self.launch_more_form = LaunchMoreInstancesForm(
             self.request, image=self.image, conn=self.conn, formdata=self.request.params or None)
         self.render_dict = dict(

--- a/eucaconsole/views/ipaddresses.py
+++ b/eucaconsole/views/ipaddresses.py
@@ -221,7 +221,7 @@ class IPAddressView(BaseView):
     def ipaddress_associate(self):
         if self.associate_form.validate():
             instance_id = self.request.params.get('instance_id')
-            location = self.request.route_url('ipaddresses')
+            location = self.request.route_path('ipaddresses')
             try:
                 self.elastic_ip.associate(instance_id)
                 msg = _(u'Successfully associated IP {ip} with instance {instance}')
@@ -237,7 +237,7 @@ class IPAddressView(BaseView):
     @view_config(route_name='ipaddress_disassociate', renderer=VIEW_TEMPLATE, request_method="POST")
     def ipaddress_disassociate(self):
         if self.disassociate_form.validate():
-            location = self.request.route_url('ipaddresses')
+            location = self.request.route_path('ipaddresses')
             try:
                 self.elastic_ip.disassociate()
                 msg = _(u'Successfully disassociated IP {ip} from instance {instance}')
@@ -253,7 +253,7 @@ class IPAddressView(BaseView):
     @view_config(route_name='ipaddress_release', renderer=VIEW_TEMPLATE, request_method="POST")
     def ipaddress_release(self):
         if self.release_form.validate():
-            location = self.request.route_url('ipaddresses')
+            location = self.request.route_path('ipaddresses')
             try:
                 self.elastic_ip.release()
                 msg = _(u'Successfully released {ip} to the cloud')

--- a/eucaconsole/views/keypairs.py
+++ b/eucaconsole/views/keypairs.py
@@ -25,7 +25,7 @@ class KeyPairsView(LandingPageView):
 
     @view_config(route_name='keypairs', renderer='../templates/keypairs/keypairs.pt')
     def keypairs_landing(self):
-        json_items_endpoint = self.request.route_url('keypairs_json')
+        json_items_endpoint = self.request.route_path('keypairs_json')
         # filter_keys are passed to client-side filtering in search box
         self.filter_keys = ['name', 'fingerprint']
         # sort_keys are passed to sorting drop-down
@@ -142,7 +142,7 @@ class KeyPairView(BaseView):
                 resp_body = json.dumps(dict(message=msg, payload=keypair_material))
                 return Response(status=status, body=resp_body, content_type='application/x-pem-file;charset=ISO-8859-1')
             else:
-                location = self.request.route_url('keypair_view', id=name)
+                location = self.request.route_path('keypair_view', id=name)
                 self.request.session.flash(msg, queue=queue)
                 return HTTPFound(location=location)
         if self.request.is_xhr:
@@ -168,7 +168,7 @@ class KeyPairView(BaseView):
             except EC2ResponseError as err:
                 msg = err.message
                 queue = Notification.ERROR
-            location = self.request.route_url('keypair_view', id=name)
+            location = self.request.route_path('keypair_view', id=name)
             self.request.session.flash(msg, queue=queue)
             return HTTPFound(location=location)
 
@@ -188,7 +188,7 @@ class KeyPairView(BaseView):
                 queue = Notification.ERROR
             notification_msg = msg
             self.request.session.flash(notification_msg, queue=queue)
-            location = self.request.route_url('keypairs')
+            location = self.request.route_path('keypairs')
             return HTTPFound(location=location)
 
         return self.render_dict

--- a/eucaconsole/views/launchconfigs.py
+++ b/eucaconsole/views/launchconfigs.py
@@ -34,7 +34,7 @@ class LaunchConfigsView(LandingPageView):
         self.prefix = '/launchconfigs'
         self.filter_keys = ['image_id', 'image_name', 'key_name', 'name', 'security_groups']
         self.sort_keys = self.get_sort_keys()
-        self.json_items_endpoint = self.request.route_url('launchconfigs_json')
+        self.json_items_endpoint = self.request.route_path('launchconfigs_json')
         self.delete_form = LaunchConfigDeleteForm(self.request, formdata=self.request.params or None)
         self.render_dict = dict(
             filter_fields=self.filter_fields,
@@ -66,7 +66,7 @@ class LaunchConfigsView(LandingPageView):
                 queue = Notification.ERROR
             notification_msg = msg
             self.request.session.flash(notification_msg, queue=queue)
-            location = self.request.route_url('launchconfigs')
+            location = self.request.route_path('launchconfigs')
             return HTTPFound(location=location)
         return self.render_dict
 
@@ -183,7 +183,7 @@ class LaunchConfigView(BaseView):
                 queue = Notification.ERROR
             notification_msg = msg
             self.request.session.flash(notification_msg, queue=queue)
-            location = self.request.route_url('launchconfigs')
+            location = self.request.route_path('launchconfigs')
             return HTTPFound(location=location)
         return self.render_dict
 
@@ -242,7 +242,7 @@ class CreateLaunchConfigView(BlockDeviceMappingItemView):
         self.securitygroup_form = SecurityGroupForm(self.request, formdata=self.request.params or None)
         self.generate_file_form = GenerateFileForm(self.request, formdata=self.request.params or None)
         self.securitygroups_rules_json = json.dumps(self.get_securitygroups_rules())
-        self.images_json_endpoint = self.request.route_url('images_json')
+        self.images_json_endpoint = self.request.route_path('images_json')
         self.securitygroups_rules_json = json.dumps(self.get_securitygroups_rules())
         self.owner_choices = self.get_owner_choices()
         self.keypair_choices_json = json.dumps(dict(self.create_form.keypair.choices))
@@ -273,7 +273,7 @@ class CreateLaunchConfigView(BlockDeviceMappingItemView):
         """Handles the POST from the Create Launch Configuration wizard"""
         if self.create_form.validate():
             autoscale_conn = self.get_connection(conn_type='autoscale')
-            location = self.request.route_url('launchconfigs')
+            location = self.request.route_path('launchconfigs')
             image_id = self.image.id
             name=self.request.params.get('name')
             key_name = self.request.params.get('keypair')

--- a/eucaconsole/views/login.py
+++ b/eucaconsole/views/login.py
@@ -21,7 +21,7 @@ from ..views import BaseView
 
 @forbidden_view_config()
 def redirect_to_login_page(request):
-    login_url = request.route_url('login')
+    login_url = request.route_path('login')
     return HTTPFound(login_url)
 
 
@@ -34,8 +34,8 @@ class LoginView(BaseView):
         self.aws_login_form = AWSLoginForm(self.request, formdata=self.request.params or None)
         self.aws_enabled = asbool(request.registry.settings.get('enable.aws'))
         referrer = self.request.url
-        login_url = self.request.route_url('login')
-        logout_url = self.request.route_url('logout')
+        login_url = self.request.route_path('login')
+        logout_url = self.request.route_path('logout')
         if referrer in [login_url, logout_url]:
             referrer = '/'  # never use the login form (or logout view) itself as came_from
         came_from_param = self.request.params.get('came_from', referrer)
@@ -98,7 +98,7 @@ class LoginView(BaseView):
             except HTTPError, err:
                 logging.info("http error "+str(vars(err)))
                 if err.code == 403:  # password expired
-                    changepwd_url = self.request.route_url('changepassword')
+                    changepwd_url = self.request.route_path('changepassword')
                     return HTTPFound(changepwd_url+("?expired=true&account=%s&username=%s" % (account, username)))
                 elif err.msg == u'Unauthorized':
                     msg = _(u'Invalid user/account name and/or password.')
@@ -144,7 +144,7 @@ class LogoutView(BaseView):
     def __init__(self, request):
         super(LogoutView, self).__init__(request)
         self.request = request
-        self.login_url = request.route_url('login')
+        self.login_url = request.route_path('login')
         self.euca_logout_form = EucaLogoutForm(self.request, formdata=self.request.params or None)
 
     @view_config(route_name='logout', request_method='POST')

--- a/eucaconsole/views/policies.py
+++ b/eucaconsole/views/policies.py
@@ -26,7 +26,7 @@ class IAMPolicyWizardView(BaseView):
         self.request = request
         self.ec2_conn = self.get_connection()
         self.iam_conn = self.get_connection(conn_type='iam')
-        self.policy_json_endpoint = self.request.route_url('iam_policy_json')
+        self.policy_json_endpoint = self.request.route_path('iam_policy_json')
         self.create_form = IAMPolicyWizardForm(request=self.request, formdata=self.request.params or None)
         self.target_type = self.request.params.get('type', 'user')  # 'user' or 'group'
         self.target_name = self.request.params.get('id', '')  # user or group name
@@ -58,7 +58,7 @@ class IAMPolicyWizardView(BaseView):
     def iam_policy_create(self):
         """Handles the POST from the Create IAM Policy wizard"""
         target_route = '{0}_view'.format(self.target_type)  # 'user_view' or 'group_view'
-        location = self.request.route_url(target_route, name=self.target_name)  # redirect to detail page after submit
+        location = self.request.route_path(target_route, name=self.target_name)  # redirect to detail page after submit
         if self.create_form.validate():
             policy_name = self.request.params.get('name')
             policy_json = self.request.params.get('policy', '{}')

--- a/eucaconsole/views/regions.py
+++ b/eucaconsole/views/regions.py
@@ -20,9 +20,9 @@ class RegionSelectView(BaseView):
         """Select region and redirect to referring page"""
         return_to = self.request.params.get('returnto')
         return_to_path = urlparse(return_to).path
-        landingpage_route_paths = [urlparse(self.request.route_url(name)).path for name in LANDINGPAGE_ROUTE_NAMES]
+        landingpage_route_paths = [urlparse(self.request.route_path(name)).path for name in LANDINGPAGE_ROUTE_NAMES]
         if return_to_path not in landingpage_route_paths:
-            return_to = self.request.route_url('dashboard')
+            return_to = self.request.route_path('dashboard')
         region = self.request.params.get('region')
         # NOTE: We normally don't want a GET request to modify data,
         #       but we're only updating the selected region in the session here.

--- a/eucaconsole/views/scalinggroups.py
+++ b/eucaconsole/views/scalinggroups.py
@@ -35,7 +35,7 @@ class ScalingGroupsView(LandingPageView):
 
     @view_config(route_name='scalinggroups', renderer=TEMPLATE, request_method='GET')
     def scalinggroups_landing(self):
-        json_items_endpoint = self.request.route_url('scalinggroups_json')
+        json_items_endpoint = self.request.route_path('scalinggroups_json')
         self.filter_keys = ['availability_zones', 'launch_config', 'name', 'placement_group']
         # sort_keys are passed to sorting drop-down
         self.sort_keys = [
@@ -59,7 +59,7 @@ class ScalingGroupsView(LandingPageView):
     @view_config(route_name='scalinggroups_delete', request_method='POST', renderer=TEMPLATE)
     def scalinggroups_delete(self):
         if self.delete_form.validate():
-            location = self.request.route_url('scalinggroups')
+            location = self.request.route_path('scalinggroups')
             name = self.request.params.get('name')
             try:
                 conn = self.get_connection(conn_type='autoscale')
@@ -187,7 +187,7 @@ class ScalingGroupView(BaseScalingGroupView):
     @view_config(route_name='scalinggroup_update', request_method='POST', renderer=TEMPLATE)
     def scalinggroup_update(self):
         if self.edit_form.validate():
-            location = self.request.route_url('scalinggroup_view', id=self.scaling_group.name)
+            location = self.request.route_path('scalinggroup_view', id=self.scaling_group.name)
             try:
                 self.update_tags()
                 self.update_properties()
@@ -205,7 +205,7 @@ class ScalingGroupView(BaseScalingGroupView):
     @view_config(route_name='scalinggroup_delete', request_method='POST', renderer=TEMPLATE)
     def scalinggroup_delete(self):
         if self.delete_form.validate():
-            location = self.request.route_url('scalinggroups')
+            location = self.request.route_path('scalinggroups')
             name = self.request.params.get('name')
             try:
                 # Need to shut down instances prior to scaling group deletion
@@ -260,7 +260,7 @@ class ScalingGroupInstancesView(BaseScalingGroupView):
             policies=self.policies,
             markunhealthy_form=self.markunhealthy_form,
             terminate_form=self.terminate_form,
-            json_items_endpoint=self.request.route_url('scalinggroup_instances_json', id=self.scaling_group.name),
+            json_items_endpoint=self.request.route_path('scalinggroup_instances_json', id=self.scaling_group.name),
         )
 
     @view_config(route_name='scalinggroup_instances', renderer=TEMPLATE, request_method='GET')
@@ -269,7 +269,7 @@ class ScalingGroupInstancesView(BaseScalingGroupView):
 
     @view_config(route_name='scalinggroup_instances_markunhealthy', renderer=TEMPLATE, request_method='POST')
     def scalinggroup_instances_markunhealthy(self):
-        location = self.request.route_url('scalinggroup_instances', id=self.scaling_group.name)
+        location = self.request.route_path('scalinggroup_instances', id=self.scaling_group.name)
         if self.markunhealthy_form.validate():
             instance_id = self.request.params.get('instance_id')
             respect_grace_period = self.request.params.get('respect_grace_period') == 'y'
@@ -292,7 +292,7 @@ class ScalingGroupInstancesView(BaseScalingGroupView):
 
     @view_config(route_name='scalinggroup_instances_terminate', renderer=TEMPLATE, request_method='POST')
     def scalinggroup_instances_terminate(self):
-        location = self.request.route_url('scalinggroup_instances', id=self.scaling_group.name)
+        location = self.request.route_path('scalinggroup_instances', id=self.scaling_group.name)
         if self.terminate_form.validate():
             instance_id = self.request.params.get('instance_id')
             decrement_capacity = self.request.params.get('decrement_capacity') == 'y'
@@ -378,7 +378,7 @@ class ScalingGroupPoliciesView(BaseScalingGroupView):
     @view_config(route_name='scalinggroup_policy_delete', renderer=TEMPLATE, request_method='POST')
     def scalinggroup_policy_delete(self):
         if self.delete_form.validate():
-            location = self.request.route_url('scalinggroup_policies', id=self.scaling_group.name)
+            location = self.request.route_path('scalinggroup_policies', id=self.scaling_group.name)
             policy_name = self.request.params.get('name')
             try:
                 self.autoscale_conn.delete_policy(policy_name, autoscale_group=self.scaling_group.name)
@@ -414,7 +414,7 @@ class ScalingGroupPolicyView(BaseScalingGroupView):
             scaling_group=self.scaling_group,
             policy_form=self.policy_form,
             alarm_form=self.alarm_form,
-            create_alarm_redirect=self.request.route_url('scalinggroup_policy_new', id=self.scaling_group.name),
+            create_alarm_redirect=self.request.route_path('scalinggroup_policy_new', id=self.scaling_group.name),
             scale_down_text=_(u'Scale down by'),
             scale_up_text=_(u'Scale up by'),
         )
@@ -425,7 +425,7 @@ class ScalingGroupPolicyView(BaseScalingGroupView):
 
     @view_config(route_name='scalinggroup_policy_create', renderer=TEMPLATE, request_method='POST')
     def scalinggroup_policy_create(self):
-        location = self.request.route_url('scalinggroup_policies', id=self.scaling_group.name)
+        location = self.request.route_path('scalinggroup_policies', id=self.scaling_group.name)
         if self.policy_form.validate():
             adjustment_amount = self.request.params.get('adjustment_amount')
             adjustment_direction = self.request.params.get('adjustment_direction', 'up')
@@ -513,12 +513,12 @@ class ScalingGroupWizardView(BaseScalingGroupView):
                 msg += ' {0}'.format(scaling_group.name)
                 queue = Notification.SUCCESS
                 self.request.session.flash(msg, queue=queue)
-                location = self.request.route_url('scalinggroup_view', id=scaling_group.name)
+                location = self.request.route_path('scalinggroup_view', id=scaling_group.name)
                 return HTTPFound(location=location)
             except BotoServerError as err:
                 msg = err.message
                 queue = Notification.ERROR
                 self.request.session.flash(msg, queue=queue)
-                location = self.request.route_url('scalinggroups')
+                location = self.request.route_path('scalinggroups')
                 return HTTPFound(location=location)
         return self.render_dict

--- a/eucaconsole/views/securitygroups.py
+++ b/eucaconsole/views/securitygroups.py
@@ -150,7 +150,7 @@ class SecurityGroupView(TaggedItemView):
 
     @view_config(route_name='securitygroup_delete', renderer=TEMPLATE, request_method='POST')
     def securitygroup_delete(self):
-        location = self.request.route_url('securitygroups')
+        location = self.request.route_path('securitygroups')
         if self.security_group and self.delete_form.validate():
             name = self.security_group.name
             try:
@@ -181,12 +181,12 @@ class SecurityGroupView(TaggedItemView):
                         new_security_group.add_tag(tagname, tagvalue)
                 msg = _(u'Successfully created security group')
                 queue = Notification.SUCCESS
-                location = self.request.route_url('securitygroup_view', id=new_security_group.id)
+                location = self.request.route_path('securitygroup_view', id=new_security_group.id)
                 status = 200
             except EC2ResponseError as err:
                 msg = err.message
                 queue = Notification.ERROR
-                location = self.request.route_url('securitygroups')
+                location = self.request.route_path('securitygroups')
                 status = getattr(err, 'status', 400)
             if self.request.is_xhr:
                 return JSONResponse(status=status, message=msg)
@@ -207,7 +207,7 @@ class SecurityGroupView(TaggedItemView):
             self.update_tags()
             self.update_rules()
 
-            location = self.request.route_url('securitygroup_view', id=self.security_group.id)
+            location = self.request.route_path('securitygroup_view', id=self.security_group.id)
             msg = _(u'Successfully modified security group')
             self.request.session.flash(msg, queue=Notification.SUCCESS)
             return HTTPFound(location=location)

--- a/eucaconsole/views/snapshots.py
+++ b/eucaconsole/views/snapshots.py
@@ -99,7 +99,7 @@ class SnapshotsView(LandingPageView):
                 queue = Notification.SUCCESS
                 # Clear images cache
                 ImagesView.clear_images_cache()
-                location = self.request.route_url('image_view', id=image_id)
+                location = self.request.route_path('image_view', id=image_id)
             except EC2ResponseError as err:
                 msg = err.message
                 queue = Notification.ERROR
@@ -244,7 +244,7 @@ class SnapshotView(TaggedItemView):
             # Update tags
             self.update_tags()
 
-            location = self.request.route_url('snapshot_view', id=self.snapshot.id)
+            location = self.request.route_path('snapshot_view', id=self.snapshot.id)
             msg = _(u'Successfully modified snapshot')
             self.request.session.flash(msg, queue=Notification.SUCCESS)
             return HTTPFound(location=location)
@@ -272,7 +272,7 @@ class SnapshotView(TaggedItemView):
                 msg = _(u'Successfully sent create snapshot request.  It may take a moment to create the snapshot.')
                 queue = Notification.SUCCESS
                 self.request.session.flash(msg, queue=queue)
-                location = self.request.route_url('snapshot_view', id=snapshot.id)
+                location = self.request.route_path('snapshot_view', id=snapshot.id)
                 return HTTPFound(location=location)
             except EC2ResponseError as err:
                 msg = err.message
@@ -297,7 +297,7 @@ class SnapshotView(TaggedItemView):
             except EC2ResponseError as err:
                 msg = err.message
                 queue = Notification.ERROR
-            location = self.request.route_url('snapshots')
+            location = self.request.route_path('snapshots')
             self.request.session.flash(msg, queue=queue)
             return HTTPFound(location=location)
         return self.render_dict
@@ -313,7 +313,7 @@ class SnapshotView(TaggedItemView):
         root_vol.delete_on_termination = dot
         bdm = BlockDeviceMapping()
         bdm['/dev/sda'] = root_vol
-        location = self.request.route_url('snapshot_view', id=snapshot_id)
+        location = self.request.route_path('snapshot_view', id=snapshot_id)
         if self.snapshot and self.register_form.validate():
             try:
                 self.snapshot.connection.register_image(

--- a/eucaconsole/views/users.py
+++ b/eucaconsole/views/users.py
@@ -49,7 +49,7 @@ class UsersView(LandingPageView):
 
     @view_config(route_name='users', renderer=TEMPLATE)
     def users_landing(self):
-        json_items_endpoint = self.request.route_url('users_json')
+        json_items_endpoint = self.request.route_path('users_json')
         if self.request.GET:
             json_items_endpoint += '?{params}'.format(params=urlencode(self.request.GET))
         # filter_keys are passed to client-side filtering in search box
@@ -206,9 +206,9 @@ class UserView(BaseView):
         self.conn = self.get_connection(conn_type="iam")
         self.user = self.get_user()
         if self.user is None:
-            self.location = self.request.route_url('users')
+            self.location = self.request.route_path('users')
         else:
-            self.location = self.request.route_url('user_view', name=self.user.user_name)
+            self.location = self.request.route_path('user_view', name=self.user.user_name)
         self.prefix = '/users'
         self.user_form = None
         self.change_password_form = ChangePasswordForm(self.request)
@@ -593,7 +593,7 @@ class UserView(BaseView):
             params = {'UserName': self.user.user_name, 'IsRecursive': 'true'}
             self.conn.get_response('DeleteUser', params)
             
-            location = self.request.route_url('users')
+            location = self.request.route_path('users')
             msg = _(u'Successfully deleted user')
             queue = Notification.SUCCESS
         except BotoServerError as err:

--- a/eucaconsole/views/volumes.py
+++ b/eucaconsole/views/volumes.py
@@ -282,7 +282,7 @@ class VolumeView(TaggedItemView, BaseVolumeView):
             # Update tags
             self.update_tags()
 
-            location = self.request.route_url('volume_view', id=self.volume.id)
+            location = self.request.route_path('volume_view', id=self.volume.id)
             msg = _(u'Successfully modified volume')
             self.request.session.flash(msg, queue=Notification.SUCCESS)
             return HTTPFound(location=location)
@@ -314,13 +314,13 @@ class VolumeView(TaggedItemView, BaseVolumeView):
                 msg = _(u'Successfully sent create volume request.  It may take a moment to create the volume.')
                 queue = Notification.SUCCESS
                 self.request.session.flash(msg, queue=queue)
-                location = self.request.route_url('volume_view', id=volume.id)
+                location = self.request.route_path('volume_view', id=volume.id)
                 return HTTPFound(location=location)
             except EC2ResponseError as err:
                 msg = err.message
                 queue = Notification.ERROR
                 self.request.session.flash(msg, queue=queue)
-                location = self.request.route_url('volumes')
+                location = self.request.route_path('volumes')
                 return HTTPFound(location=location)
         else:
             self.request.error_messages = self.volume_form.get_errors_list()
@@ -337,7 +337,7 @@ class VolumeView(TaggedItemView, BaseVolumeView):
             except EC2ResponseError as err:
                 msg = err.message.split('remoteDevice')[0]
                 queue = Notification.ERROR
-            location = self.request.route_url('volume_view', id=self.volume.id)
+            location = self.request.route_path('volume_view', id=self.volume.id)
             self.request.session.flash(msg, queue=queue)
             return HTTPFound(location=location)
         else:
@@ -357,7 +357,7 @@ class VolumeView(TaggedItemView, BaseVolumeView):
             except EC2ResponseError as err:
                 msg = err.message
                 queue = Notification.ERROR
-            location = self.request.route_url('volume_view', id=self.volume.id)
+            location = self.request.route_path('volume_view', id=self.volume.id)
             self.request.session.flash(msg, queue=queue)
             return HTTPFound(location=location)
         else:
@@ -375,7 +375,7 @@ class VolumeView(TaggedItemView, BaseVolumeView):
             except EC2ResponseError as err:
                 msg = err.message
                 queue = Notification.ERROR
-            location = self.request.route_url('volume_view', id=self.volume.id)
+            location = self.request.route_path('volume_view', id=self.volume.id)
             self.request.session.flash(msg, queue=queue)
             return HTTPFound(location=location)
         else:
@@ -445,7 +445,7 @@ class VolumeSnapshotsView(BaseVolumeView):
     def volume_snapshots_json(self):
         snapshots = []
         for snapshot in self.volume.snapshots():
-            delete_form_action = self.request.route_url(
+            delete_form_action = self.request.route_path(
                 'volume_snapshot_delete', id=self.volume.id, snapshot_id=snapshot.id)
             snapshots.append(dict(
                 id=snapshot.id,
@@ -483,7 +483,7 @@ class VolumeSnapshotsView(BaseVolumeView):
             except EC2ResponseError as err:
                 msg = err.message
                 queue = Notification.ERROR
-            location = self.request.route_url('volume_snapshots', id=self.volume.id)
+            location = self.request.route_path('volume_snapshots', id=self.volume.id)
             self.request.session.flash(msg, queue=queue)
             return HTTPFound(location=location)
         else:
@@ -505,7 +505,7 @@ class VolumeSnapshotsView(BaseVolumeView):
                 except EC2ResponseError as err:
                     msg = err.message
                     queue = Notification.ERROR
-                location = self.request.route_url('volume_snapshots', id=self.volume.id)
+                location = self.request.route_path('volume_snapshots', id=self.volume.id)
                 self.request.session.flash(msg, queue=queue)
                 return HTTPFound(location=location)
         return self.render_dict


### PR DESCRIPTION
HEADS UP!  Use static_path() rather than static_url() and route_path() rather than route_url() to generate host/port/protocol-independent URLs everywhere for nginx compatibility.

Discovered while working on https://eucalyptus.atlassian.net/browse/GUI-571
