### PR TITLE
Fix came_from to handle relative URLs in login form/handler

### DIFF
--- a/eucaconsole/views/changepassword.py
+++ b/eucaconsole/views/changepassword.py
@@ -6,13 +6,10 @@ Pyramid views for Change password
 import logging
 
 from urllib2 import HTTPError, URLError
-from urlparse import urlparse
 
-from beaker.cache import cache_managers
 from pyramid.httpexceptions import HTTPFound
-from pyramid.security import NO_PERMISSION_REQUIRED, remember, forget
-from pyramid.settings import asbool
-from pyramid.view import view_config, forbidden_view_config
+from pyramid.security import NO_PERMISSION_REQUIRED, remember
+from pyramid.view import view_config
 
 from ..forms.login import EucaChangePasswordForm
 from ..views import BaseView
@@ -30,7 +27,7 @@ class ChangePasswordView(BaseView):
         if referrer_root in [changepassword_url]:
             referrer = '/'  # never use the changepassword form itself as came_from
         came_from_param = self.request.params.get('came_from', referrer)
-        self.came_from = urlparse(came_from_param).path or '/'
+        self.came_from = came_from_param or '/'
         self.changepassword_form_errors = []
 
     @view_config(route_name='changepassword', request_method='GET', renderer=template, permission=NO_PERMISSION_REQUIRED)

--- a/eucaconsole/views/login.py
+++ b/eucaconsole/views/login.py
@@ -33,13 +33,13 @@ class LoginView(BaseView):
         self.euca_login_form = EucaLoginForm(self.request, formdata=self.request.params or None)
         self.aws_login_form = AWSLoginForm(self.request, formdata=self.request.params or None)
         self.aws_enabled = asbool(request.registry.settings.get('enable.aws'))
-        referrer = self.request.url
+        referrer = urlparse(self.request.url).path
         login_url = self.request.route_path('login')
         logout_url = self.request.route_path('logout')
         if referrer in [login_url, logout_url]:
             referrer = '/'  # never use the login form (or logout view) itself as came_from
         came_from_param = self.request.params.get('came_from', referrer)
-        self.came_from = urlparse(came_from_param).path or '/'
+        self.came_from = came_from_param or '/'
         self.login_form_errors = []
         self.duration = str(int(self.request.registry.settings.get('session.cookie_expires'))+60)
         self.https_required = asbool(self.request.registry.settings.get('session.secure', False))

--- a/eucaconsole/views/regions.py
+++ b/eucaconsole/views/regions.py
@@ -3,8 +3,6 @@
 Region selector view
 
 """
-from urlparse import urlparse
-
 from pyramid.httpexceptions import HTTPFound
 from pyramid.view import view_config
 
@@ -19,14 +17,13 @@ class RegionSelectView(BaseView):
     def select_region(self):
         """Select region and redirect to referring page"""
         return_to = self.request.params.get('returnto')
-        return_to_path = urlparse(return_to).path
-        landingpage_route_paths = [urlparse(self.request.route_path(name)).path for name in LANDINGPAGE_ROUTE_NAMES]
+        return_to_path = return_to
+        landingpage_route_paths = [self.request.route_path(name) for name in LANDINGPAGE_ROUTE_NAMES]
         if return_to_path not in landingpage_route_paths:
             return_to = self.request.route_path('dashboard')
         region = self.request.params.get('region')
         # NOTE: We normally don't want a GET request to modify data,
         #       but we're only updating the selected region in the session here.
         self.request.session['region'] = region
-        safe_return_to = urlparse(return_to).path  # Prevent arbitrary redirects
-        return HTTPFound(location=safe_return_to)
+        return HTTPFound(location=return_to)
 

--- a/eucaconsole/views/users.py
+++ b/eucaconsole/views/users.py
@@ -11,7 +11,6 @@ import string
 import StringIO
 import simplejson as json
 import sys
-import urlparse
 
 from urllib2 import HTTPError, URLError
 from urllib import urlencode
@@ -21,7 +20,6 @@ from boto.exception import EC2ResponseError
 from pyramid.httpexceptions import HTTPFound, HTTPNotFound
 from pyramid.i18n import TranslationString as _
 from pyramid.view import view_config
-from pyramid.response import Response
 
 from ..forms.users import UserForm, ChangePasswordForm, GeneratePasswordForm, DeleteUserForm, AddToGroupForm, DisableUserForm, EnableUserForm
 from ..models import Notification
@@ -37,6 +35,7 @@ class PasswordGeneration(object):
         chars = string.ascii_letters + string.digits + '!@#$%^&*()'
         random.seed = (os.urandom(1024))
         return ''.join(random.choice(chars) for i in range(12))
+
 
 class UsersView(LandingPageView):
     TEMPLATE = '../templates/users/users.pt'
@@ -118,6 +117,7 @@ class UsersView(LandingPageView):
                 return dict(message=_(u"Successfully enabled user"))
         except BotoServerError as err:
             return JSONResponse(status=400, message=err.message);
+
 
 class UsersJsonView(BaseView):
     EUCA_DENY_POLICY = 'euca-console-deny-access-policy'


### PR DESCRIPTION
And we no longer need to prune the came_from URL to prevent arbitrary redirects, now that we're using route_path() rather than route_url() everywhere
