### PR TITLE
Don't show help expanded by default in Attach New Volume modal

### DIFF
--- a/eucaconsole/static/js/pages/instance_volumes.js
+++ b/eucaconsole/static/js/pages/instance_volumes.js
@@ -14,6 +14,7 @@ angular.module('InstanceVolumes', [])
         $scope.jsonEndpoint = '';
         $scope.initialLoading = true;
         $scope.detachFormAction = '';
+        $scope.isDialogHelpExpanded = false;
         $scope.initController = function (jsonEndpoint) {
             $scope.jsonEndpoint = jsonEndpoint;
             $scope.initChosenSelector();

--- a/eucaconsole/templates/instances/instance_volumes.pt
+++ b/eucaconsole/templates/instances/instance_volumes.pt
@@ -93,9 +93,13 @@
                     </div>
                 </form>
                 <a class="close-reveal-modal">&#215;</a>
-                <hr />
                 <!--! Volume device help -->
-                <metal:block metal:use-macro="layout.global_macros['volumedevice_help']" />
+                <hr />
+                <metal:block metal:use-macro="layout.global_macros['dialog_help_expando']" />
+                <div class="help-content" ng-show="isDialogHelpExpanded" ng-cloak="">
+                    <!--! Volume device help -->
+                    <metal:block metal:use-macro="layout.global_macros['volumedevice_help']" />
+                </div>
             </div>
             <div id="detach-volume-modal" class="reveal-modal small" data-reveal="">
                 <h3 i18n:translate="">Detach volume</h3>


### PR DESCRIPTION
Help content wasn't inside an expando on the instance-volumes detail page in the Attach Volume modal
