### PR TITLE
GUI-489: Disable Foundation tooltips for title attributes with Angular expressions

### DIFF
--- a/eucaconsole/templates/panels/autoscale_tag_editor.pt
+++ b/eucaconsole/templates/panels/autoscale_tag_editor.pt
@@ -6,7 +6,7 @@
     <div class="columns field">
         <div class="items">
             <span class="label radius secondary tagentry" ng-repeat="tag in tagsArray" ng-cloak="cloak">
-                <span title="{{ getSafeTitle(tag) }}" data-tooltip="">
+                <span title="{{ getSafeTitle(tag) }}"><!--! XSS Heads up!  Don't enable Foundation tooltips here -->
                     {{ tag.name | ellipsis: 20 }} <em>=</em> {{ tag.value | ellipsis: 40 }}
                 </span>
                 <small ng-show="tag.propagate_at_launch" class="propagates">&nbsp;(<small i18n:translate="">propagate</small>)</small>

--- a/eucaconsole/templates/panels/securitygroup_rules_landingpage.pt
+++ b/eucaconsole/templates/panels/securitygroup_rules_landingpage.pt
@@ -9,7 +9,8 @@
         </span>
         <br ng-show="!$last" />
         <span style="display: block;" tal:condition="tile_view" ng-show="$last && item.rules.length > 3">
-            <span data-tooltip="" class="label round has-tip ellipsis" title="{{ item.rules.length - 3 }} more rules">...</span>
+            <!--! XSS Heads up!  Don't enable Foundation tooltips below -->
+            <span class="label round has-tip ellipsis" title="{{ item.rules.length - 3 }} more rules">...</span>
         </span>
     </span>
 </span>

--- a/eucaconsole/templates/panels/tag_editor.pt
+++ b/eucaconsole/templates/panels/tag_editor.pt
@@ -6,7 +6,7 @@
     <div class="columns field">
         <div class="items">
             <span class="label radius secondary tagentry" ng-repeat="tag in tagsArray" ng-cloak="cloak">
-                <span title="{{ getSafeTitle(tag) }}" data-tooltip="">
+                <span title="{{ getSafeTitle(tag) }}"><!--! XSS Heads up!  Don't enable Foundation tooltips here -->
                     {{ tag.name | ellipsis: 20 }} <em>=</em> {{ tag.value | ellipsis: 40 }}
                 </span>
                 <a href="#" class="remove" ng-click="removeTag($index, $event)"


### PR DESCRIPTION
Foundation does not sanitize the DOM rendered in a tooltip (as of version 5.0.3), so we can't enable tooltips for tags with title attributes that have AngularJS expressions.
