### PR TITLE
GUI-302: Prevent angular expression injections in filters on landing pages

### DIFF
--- a/eucaconsole/templates/panels/landingpage_filters.pt
+++ b/eucaconsole/templates/panels/landingpage_filters.pt
@@ -5,7 +5,7 @@
         <div tal:repeat="field filters_form" id="filterfieldwrapper_${field.short_name}">
             <div tal:condition="field.short_name != 'csrf_token'" tal:omit-tag="">
                 <label>${field.label}</label>
-                ${structure:field()}
+                <div ng-non-bindable="">${structure:field()}</div>
             </div>
         </div>
         <div>&nbsp;</div>

--- a/eucaconsole/views/panels.py
+++ b/eucaconsole/views/panels.py
@@ -33,14 +33,15 @@ def landingpage_filters(context, request, filters_form=None):
 
 
 @panel_config('form_field', renderer='../templates/panels/form_field_row.pt')
-def form_field_row(context, request, field=None, reverse=False, leftcol_width=4, rightcol_width=8, inline='', ng_attrs=None, **kwargs):
+def form_field_row(context, request, field=None, reverse=False, leftcol_width=4, rightcol_width=8,
+                   inline='', ng_attrs=None, **kwargs):
     """ Widget for a singe form field row.
         The left/right column widths are Zurb Foundation grid units.
             e.g. leftcol_width=3 would set column for labels with a wrapper of <div class="small-3 columns">...</div>
         Pass any HTML attributes to this widget as keyword arguments.
             e.g. ${panel('form_field', field=the_field, readonly='readonly')}
     """
-    html_attrs = {}
+    html_attrs = {'ng-non-bindable': ''}
     error_msg = kwargs.get('error_msg') or getattr(field, 'error_msg', None) 
 
     # Add required="required" HTML attribute to form field if any "required" validators


### PR DESCRIPTION
Also add ng-non-bindable attribute to all form fields leveraging form_field_row panel.
