### PR TITLE
Remove blanket ng-non-bindable attribute from form_field_row panel

### DIFF
--- a/eucaconsole/views/panels.py
+++ b/eucaconsole/views/panels.py
@@ -41,7 +41,7 @@ def form_field_row(context, request, field=None, reverse=False, leftcol_width=4,
         Pass any HTML attributes to this widget as keyword arguments.
             e.g. ${panel('form_field', field=the_field, readonly='readonly')}
     """
-    html_attrs = {'ng-non-bindable': ''}
+    html_attrs = {}
     error_msg = kwargs.get('error_msg') or getattr(field, 'error_msg', None) 
 
     # Add required="required" HTML attribute to form field if any "required" validators


### PR DESCRIPTION
Discovered while working on GUI-619 that we need to be more selective on where we add the ng-non-bindable attribute.
