### PR TITLE
GUI-629: Better handling of instance choices in Attach Volume to Instance dialog

### DIFF
--- a/eucaconsole/forms/volumes.py
+++ b/eucaconsole/forms/volumes.py
@@ -8,7 +8,7 @@ from wtforms import validators
 
 from pyramid.i18n import TranslationString as _
 
-from . import BaseSecureForm, ChoicesManager
+from . import BaseSecureForm, ChoicesManager, BLANK_CHOICE
 
 
 class VolumeForm(BaseSecureForm):
@@ -145,7 +145,7 @@ class AttachForm(BaseSecureForm):
     def set_instance_choices(self):
         """Populate instance field with instances available to attach volume to"""
         if self.volume:
-            choices = []
+            choices = [BLANK_CHOICE]
             for instance in self.instances:
                 if instance.state == "running" and self.volume.zone == instance.placement:
                     name_tag = instance.tags.get('Name')
@@ -153,7 +153,9 @@ class AttachForm(BaseSecureForm):
                     vol_name = '{id}{extra}'.format(id=instance.id, extra=extra)
                     choices.append((instance.id, vol_name))
             if len(choices) == 1:
-                choices = [('', _(u'No available instances in the same availability zone'))]
+                prefix = _(u'No available instances in availability zone ')
+                msg = '{0} {1}'.format(prefix, self.volume.zone)
+                choices = [('', msg)]
             self.instance_id.choices = choices
         else:
             # We need to set all instances as choices for the landing page to avoid failed validation of instance field

--- a/eucaconsole/static/js/pages/volumes.js
+++ b/eucaconsole/static/js/pages/volumes.js
@@ -32,7 +32,7 @@ angular.module('VolumesPage', ['LandingPage'])
                             $scope.instanceChoices[instance['id']] = instance['name'];
                         });
                     } else {
-                        $scope.instanceChoices[''] = 'No instances available in zone ' + volumeZone;
+                        $scope.instanceChoices[''] = 'No available instances in availability zone ' + volumeZone;
                     }
                     $timeout(function () {
                         instanceSelect.trigger('chosen:updated');

--- a/eucaconsole/templates/dialogs/volume_dialogs.pt
+++ b/eucaconsole/templates/dialogs/volume_dialogs.pt
@@ -8,13 +8,12 @@
                      html_attrs {'data-placeholder': 'select...'};">
         <h3 i18n:translate="">Attach volume</h3>
         <p><span i18n:translate="">Attach a volume to an instance</span></p>
-        <form method="post" action="${action}"
-              id="attach-form" data-abide="">
+        <form method="post" action="${action}" id="attach-form" data-abide="">
             ${structure:attach_form['csrf_token']}
             <div tal:condition="landingpage" tal:omit-tag="">
                 <input type="hidden" name="volume_id" value="{{ volumeID }}" />
             </div>
-            ${panel('form_field', field=attach_form.instance_id, ng_attrs={'model': 'instanceId', 'change': 'getDeviceSuggestion()', 'options': 'k as v for (k, v) in instanceChoices'}, **html_attrs)}
+            ${panel('form_field', field=attach_form.instance_id, ng_attrs=ng_attrs, **html_attrs)}
             ${panel('form_field', field=attach_form.device, placeholder='/dev/sdf')}
             <div class="row">
                 <div>

--- a/eucaconsole/views/dialogs.py
+++ b/eucaconsole/views/dialogs.py
@@ -61,6 +61,10 @@ def terminate_instances_dialog(context, request, batch_terminate_form=None):
 def volume_dialogs(context, request, volume=None, volume_name=None, instance_name=None, landingpage=False,
                    attach_form=None, detach_form=None, delete_form=None):
     """Modal dialogs for Volume landing and detail page."""
+    ng_attrs = {'model': 'instanceId', 'change': 'getDeviceSuggestion()'}
+    # If landing page, build instance choices based on selected volumes availability zone (see volumes.js)
+    if landingpage:
+        ng_attrs['options'] = 'k as v for (k, v) in instanceChoices'
     return dict(
         volume=volume,
         volume_name=volume_name,
@@ -69,6 +73,7 @@ def volume_dialogs(context, request, volume=None, volume_name=None, instance_nam
         attach_form=attach_form,
         detach_form=detach_form,
         delete_form=delete_form,
+        ng_attrs=ng_attrs,
     )
 
 


### PR DESCRIPTION
On the volume detail page, the instance choices in the Attach Volume dialog weren't properly populated and didn't display the "there are no instances in this avail zone" message.

Fixes https://eucalyptus.atlassian.net/browse/GUI-629
