### PR TITLE
GUI-642: Display snapshot name in delete snapshot dialogs

### DIFF
--- a/eucaconsole/static/js/pages/snapshots.js
+++ b/eucaconsole/static/js/pages/snapshots.js
@@ -7,9 +7,11 @@
 angular.module('SnapshotsPage', ['LandingPage'])
     .controller('SnapshotsCtrl', function ($scope) {
         $scope.snapshotID = '';
-        $scope.revealModal = function (action, snapshot_id) {
+        $scope.snapshotName = '';
+        $scope.revealModal = function (action, snapshot) {
             var modal = $('#' + action + '-snapshot-modal');
-            $scope.snapshotID = snapshot_id;
+            $scope.snapshotID = snapshot['id'];
+            $scope.snapshotName = snapshot['name'];
             modal.foundation('reveal', 'open');
         };
     })

--- a/eucaconsole/static/js/pages/volume_snapshots.js
+++ b/eucaconsole/static/js/pages/volume_snapshots.js
@@ -12,6 +12,8 @@ angular.module('VolumeSnapshots', ['TagEditor'])
         $scope.jsonEndpoint = '';
         $scope.initialLoading = true;
         $scope.deleteFormAction = '';
+        $scope.snapshotID = '';
+        $scope.snapshotName = '';
         $scope.initController = function (jsonEndpoint) {
             $scope.jsonEndpoint = jsonEndpoint;
             $scope.getVolumeSnapshots();
@@ -23,10 +25,11 @@ angular.module('VolumeSnapshots', ['TagEditor'])
             $scope.snapshotID = snapshot_id;
             modal.foundation('reveal', 'open');
         };
-        $scope.revealDeleteModal = function (volume_id, snapshot_id) {
+        $scope.revealDeleteModal = function (volume_id, snapshot) {
             var modal = $('#delete-snapshot-modal');
             $scope.volumeID = volume_id;
-            $scope.snapshotID = snapshot_id;
+            $scope.snapshotID = snapshot['id'];
+            $scope.snapshotName = snapshot['name'];
             modal.foundation('reveal', 'open');
         };
         $scope.setFocus = function () {

--- a/eucaconsole/templates/dialogs/snapshot_dialogs.pt
+++ b/eucaconsole/templates/dialogs/snapshot_dialogs.pt
@@ -7,7 +7,7 @@
         <h3 i18n:translate="">Delete snapshot</h3>
         <p><span i18n:translate="">Are you sure you want to delete snapshot</span><br />
            <span tal:condition="snapshot"><b ng-non-bindable="">${snapshot_name}</b></span>
-           <span tal:condition="not snapshot"><b>{{ snapshotID }}</b></span>
+           <span tal:condition="not snapshot"><b>{{ snapshotName }}</b></span>
            ?</p>
         <form action="${action}" method="post">
             ${structure:delete_form['csrf_token']}

--- a/eucaconsole/templates/snapshots/snapshots.pt
+++ b/eucaconsole/templates/snapshots/snapshots.pt
@@ -28,13 +28,15 @@
                 <ul id="item-dropdown_{{ item.id }}" class="f-dropdown" data-dropdown-content="">
                     <li><a i18n:translate="" ng-href="${prefix}/{{ item.id }}">View details</a></li>
                     <li>
-                        <a ng-href="${request.route_path('volume_view', id='new')}?from_snapshot={{item.id}}" id="create-volume-action-tile-{{item.id}}" i18n:translate="">
+                        <a ng-href="${request.route_path('volume_view', id='new')}?from_snapshot={{item.id}}"
+                           id="create-volume-action-tile-{{item.id}}" i18n:translate="">
                             Create volume from snapshot
                         </a>
                     </li>
                     <li><a i18n:translate="" ng-click="revealModal('register', item.id)">Register as image</a></li>
-                    <li><a i18n:translate="" ng-click="revealModal('delete', item.id)">Delete snapshot</a></li>
-
+                    <li ng-show="item.status === 'completed'">
+                        <a i18n:translate="" ng-click="revealModal('delete', item)">Delete snapshot</a>
+                    </li>
                 </ul>
             </div>
             <div metal:fill-slot="tile_content" tal:omit-tag="">
@@ -116,8 +118,9 @@
                                 </a>
                             </li>
                             <li><a i18n:translate="" ng-click="revealModal('register', item.id)">Register as image</a></li>
-                            <li><a i18n:translate="" ng-click="revealModal('delete', item.id)">Delete snapshot</a></li>
-
+                            <li ng-show="item.status === 'completed'">
+                                <a i18n:translate="" ng-click="revealModal('delete', item)">Delete snapshot</a>
+                            </li>
                         </ul>
                     </span>
                 </td>

--- a/eucaconsole/templates/volumes/volume_snapshots.pt
+++ b/eucaconsole/templates/volumes/volume_snapshots.pt
@@ -20,7 +20,6 @@
             <strong i18n:translate="">Details for volume:</strong>
             <em ng-non-bindable="">${volume_name}</em>
         </h3>
-
         <div class="large-8 columns">
             <dl class="tabs" id="volume-subnav">
                 <dd><a href="${request.route_path('volume_view', id=volume.id)}" i18n:translate="">General</a></dd>
@@ -41,7 +40,7 @@
                         <ul id="item-dropdown_{{ snapshot.id }}" class="f-dropdown" data-dropdown-content="">
                             <li><a ng-href="/snapshots/{{ snapshot.id }}" i18n:translate="">View details</a></li>
                             <li><a ng-click="revealRegisterSnapshotModal(snapshot.id)" i18n:translate="">Register as image</a></li>
-                            <li><a ng-click="revealDeleteModal('${volume.id}', snapshot.id)" i18n:translate="">Delete snapshot</a></li>
+                            <li><a ng-click="revealDeleteModal('${volume.id}', snapshot)" i18n:translate="">Delete snapshot</a></li>
                         </ul>
                     </div>
                     <div class="content">

--- a/eucaconsole/views/volumes.py
+++ b/eucaconsole/views/volumes.py
@@ -417,7 +417,7 @@ class VolumeSnapshotsView(BaseVolumeView):
                     'volume_snapshot_delete', id=self.volume.id, snapshot_id=snapshot.id)
                 snapshots.append(dict(
                     id=snapshot.id,
-                    name=snapshot.tags.get('Name', ''),
+                    name=TaggedItemView.get_display_name(snapshot),
                     progress=snapshot.progress,
                     volume_size=self.volume.size,
                     start_time=snapshot.start_time,


### PR DESCRIPTION
Dialogs opened from snapshots landing page and volume-snapshots page were missing the snapshot name.

Also include snapshot name in delete notification message.

Fixes https://eucalyptus.atlassian.net/browse/GUI-642
