### PR TITLE
GUI-577: Add filters for launch configs landing page

### DIFF
--- a/eucaconsole/forms/launchconfigs.py
+++ b/eucaconsole/forms/launchconfigs.py
@@ -81,3 +81,21 @@ class CreateLaunchConfigForm(BaseSecureForm):
         self.instance_type.error_msg = self.instance_type_error_msg
         self.securitygroup.error_msg = self.securitygroup_error_msg
 
+
+class LaunchConfigsFiltersForm(BaseSecureForm):
+    """Form class for filters on landing page"""
+    instance_type = wtforms.SelectMultipleField(label=_(u'Instance type'))
+    key_name = wtforms.SelectMultipleField(label=_(u'Key pair'))
+    security_groups = wtforms.SelectMultipleField(label=_(u'Security group'))
+
+    def __init__(self, request, cloud_type='euca', ec2_conn=None, **kwargs):
+        super(LaunchConfigsFiltersForm, self).__init__(request, **kwargs)
+        self.request = request
+        self.cloud_type = cloud_type
+        self.ec2_conn = ec2_conn
+        self.ec2_choices_manager = ChoicesManager(conn=ec2_conn)
+        self.instance_type.choices = self.ec2_choices_manager.instance_types(
+            add_blank=False, cloud_type=self.cloud_type, add_description=False)
+        self.key_name.choices = self.ec2_choices_manager.keypairs(add_blank=False)
+        self.security_groups.choices = self.ec2_choices_manager.security_groups(add_blank=False)
+

--- a/eucaconsole/templates/launchconfigs/launchconfigs.pt
+++ b/eucaconsole/templates/launchconfigs/launchconfigs.pt
@@ -12,12 +12,11 @@
                 <li class="current"><a href="#" i18n:translate="">Launch configurations</a></li>
             </metal:crumbs>
         </metal:breadcrumbs>
-
         <!-- Notifications -->
         <metal:block metal:use-macro="layout.global_macros['notifications']" />
-
         <div class="large-2 columns" id="landing-page-filters">
-            <!--! Filters go here -->
+            <h3 id="pagetitle" class="landingpage" i18n:translate="">Launch Configurations</h3>
+            ${panel('landingpage_filters', filters_form=filters_form)}
         </div>
         <div metal:use-macro="layout.global_macros['landing_page_datagrid']">
             <div metal:fill-slot="new_button">
@@ -94,6 +93,7 @@
 </metal:block>
 
 <div metal:fill-slot="tail_js">
+    <script src="${request.static_path('eucaconsole:static/js/thirdparty/jquery/chosen.jquery.min.js')}"></script>
     <script src="${request.static_path('eucaconsole:static/js/pages/custom_filters.js')}"></script>
     <script src="${request.static_path('eucaconsole:static/js/pages/landingpage.js')}"></script>
     <script src="${request.static_path('eucaconsole:static/js/pages/launchconfigs.js')}"></script>


### PR DESCRIPTION
Implements filters for the launch configs landing page for https://eucalyptus.atlassian.net/browse/GUI-577

@JMoLo: Note that although the spec calls for the filters to be by availability zone, instance type, root device type, security group, and scaling group, we can only implement filters for instance type and security group per what's available in the data set returned from Boto.  We can also filter by key pair, so that field has been added to the filters.
