### PR TITLE
GUI-689: Quick fix to unblock testing on environments with Beaker 1.5.4

### DIFF
--- a/eucaconsole/views/__init__.py
+++ b/eucaconsole/views/__init__.py
@@ -123,7 +123,7 @@ class BaseView(object):
     def invalidate_connection_cache():
         """Empty connection objects cache"""
         for manager in cache_managers.values():
-            if manager.namespace_name in ['_aws_connection', '_euca_connection']:
+            if hasattr(manager, 'namespace_name') and manager.namespace_name in ['_aws_connection', '_euca_connection']:
                 manager.clear()
 
     @staticmethod

--- a/eucaconsole/views/images.py
+++ b/eucaconsole/views/images.py
@@ -65,7 +65,7 @@ class ImagesView(LandingPageView):
     @staticmethod
     def clear_images_cache():
         for manager in cache_managers.values():
-            if '_get_images_cache' in manager.namespace_name:
+            if hasattr(manager, 'namespace_name') and '_get_images_cache' in manager.namespace_name:
                 manager.clear()
 
 


### PR DESCRIPTION
Cache.namespace_name wasn't added to Beaker until 1.6, so add a check for the attribute to be safe.  Still need a workaround though, either a patched version of Beaker 1.5.4 or pin the version to at least 1.6.
