### PR TITLE
GUI-426: Use Beaker 1.5.4-compatible method to invalidate images cache 

### DIFF
--- a/eucaconsole/views/images.py
+++ b/eucaconsole/views/images.py
@@ -63,9 +63,9 @@ class ImagesView(LandingPageView):
         ]
 
     @staticmethod
-    def clear_images_cache():
+    def invalidate_images_cache():
         for manager in cache_managers.values():
-            if hasattr(manager, 'namespace_name') and '_get_images_cache' in manager.namespace_name:
+            if '_get_images_cache' in manager.namespace.namespace:
                 manager.clear()
 
 

--- a/eucaconsole/views/snapshots.py
+++ b/eucaconsole/views/snapshots.py
@@ -98,7 +98,7 @@ class SnapshotsView(LandingPageView):
                 prefix = _(u'Successfully registered snapshot')
                 msg = '{prefix} {id}'.format(prefix=prefix, id=snapshot_id)
                 # Clear images cache
-                ImagesView.clear_images_cache()
+                ImagesView.invalidate_images_cache()
                 location = self.request.route_path('image_view', id=image_id)
                 self.request.session.flash(msg, queue=Notification.SUCCESS)
             return HTTPFound(location=location)
@@ -282,7 +282,7 @@ class SnapshotView(TaggedItemView):
                     for img in self.images_registered:
                         img.deregister()
                     # Clear images cache
-                    ImagesView.clear_images_cache()
+                    ImagesView.invalidate_images_cache()
                 self.snapshot.delete()
                 prefix = _(u'Successfully deleted snapshot')
                 msg = '{prefix} {name}'.format(prefix=prefix, name=snapshot_name)
@@ -313,7 +313,7 @@ class SnapshotView(TaggedItemView):
                 prefix = _(u'Successfully registered snapshot')
                 msg = '{prefix} {id}'.format(prefix=prefix, id=snapshot_id)
                 # Clear images cache
-                ImagesView.clear_images_cache()
+                ImagesView.invalidate_images_cache()
                 self.request.session.flash(msg, queue=Notification.SUCCESS)
             return HTTPFound(location=location)
         return self.render_dict


### PR DESCRIPTION
…when a snapshot is registered as an image.

Fixes https://eucalyptus.atlassian.net/browse/GUI-426
