### PR TITLE
GUI-361: Clear Name input field when the Name tag is removed from the key/value pairs

### DIFF
--- a/eucaconsole/static/js/widgets/tag_editor.js
+++ b/eucaconsole/static/js/widgets/tag_editor.js
@@ -40,10 +40,14 @@ angular.module('TagEditor', ['ngSanitize'])
         $scope.getSafeTitle = function (tag) {
             return $sanitize(tag.name + ' = ' + tag.value);
         };
-        $scope.removeTag = function (index, $event) {
+        $scope.removeTag = function (index, $event, tag) {
             $event.preventDefault();
             $scope.tagsArray.splice(index, 1);
             $scope.syncTags();
+            // Clear Name input field if Name tag is removed
+            if (tag.name === 'Name') {
+                $('input#name').val('');
+            }
         };
         $scope.addTag = function ($event) {
             $event.preventDefault();

--- a/eucaconsole/templates/panels/tag_editor.pt
+++ b/eucaconsole/templates/panels/tag_editor.pt
@@ -9,7 +9,7 @@
                 <span title="{{ getSafeTitle(tag) }}"><!--! XSS Heads up!  Don't enable Foundation tooltips here -->
                     {{ tag.name | ellipsis: 20 }} <em>=</em> {{ tag.value | ellipsis: 40 }}
                 </span>
-                <a href="#" class="remove" ng-click="removeTag($index, $event)"
+                <a href="#" class="remove" ng-click="removeTag($index, $event, tag)"
                    title="Remove tag"><i class="fi-x"></i></a>
             </span>
         </div>


### PR DESCRIPTION
Requiring the user to clear the Name input field and the Name tag is asking too much to remove the name for an instance, volume, and snapshot.  This pull request clears the Name input field for those resources when the Name tag is removed from the existing list of tags.

References latter comments in https://eucalyptus.atlassian.net/browse/GUI-361
