### PR TITLE
GUI-361: Hide Name tag from tag editor on instance, volume, and snapshot detail pages

### DIFF
--- a/eucaconsole/static/js/widgets/tag_editor.js
+++ b/eucaconsole/static/js/widgets/tag_editor.js
@@ -17,14 +17,28 @@ angular.module('TagEditor', ['ngSanitize'])
         $scope.tagInputs = $scope.tagEditor.find('.taginput');
         $scope.tagsTextarea = $scope.tagEditor.find('textarea#tags');
         $scope.tagsArray = [];
+        $scope.showNameTag = true;
+        $scope.visibleTagsCount = 0;
         $scope.syncTags = function () {
             var tagsObj = {};
             $scope.tagsArray.forEach(function(tag) {
                 tagsObj[tag.name] = tag.value;
             });
             $scope.tagsTextarea.val(JSON.stringify(tagsObj));
+            // Update visible tags count, ignoring "Name" tag when present.
+            $scope.updateVisibleTagsCount();
         };
-        $scope.initTags = function(tagsJson) {
+        $scope.updateVisibleTagsCount = function () {
+            if ($scope.showNameTag) {
+                $scope.visibleTagsCount = $scope.tagsArray.length;
+            } else {
+                // Adjust count if "Name" tag is in tagsArray
+                $scope.visibleTagsCount = $.map($scope.tagsArray, function (item) {
+                    if (item.name !== 'Name') { return item; }
+                }).length;
+            }
+        };
+        $scope.initTags = function(tagsJson, showNameTag) {
             // Parse tags JSON and convert to a list of tags.
             var tagsObj = JSON.parse(tagsJson);
             Object.keys(tagsObj).forEach(function(key) {
@@ -35,19 +49,16 @@ angular.module('TagEditor', ['ngSanitize'])
                     });
                 }
             });
+            $scope.showNameTag = showNameTag;
             $scope.syncTags();
         };
         $scope.getSafeTitle = function (tag) {
             return $sanitize(tag.name + ' = ' + tag.value);
         };
-        $scope.removeTag = function (index, $event, tag) {
+        $scope.removeTag = function (index, $event) {
             $event.preventDefault();
             $scope.tagsArray.splice(index, 1);
             $scope.syncTags();
-            // Clear Name input field if Name tag is removed
-            if (tag.name === 'Name') {
-                $('input#name').val('');
-            }
         };
         $scope.addTag = function ($event) {
             $event.preventDefault();

--- a/eucaconsole/templates/instances/instance_view.pt
+++ b/eucaconsole/templates/instances/instance_view.pt
@@ -239,7 +239,7 @@
                         </div>
                     </div>
                     <hr />
-                    ${panel('tag_editor', tags=instance.tags)}
+                    ${panel('tag_editor', tags=instance.tags, show_name_tag=False)}
                     <hr />
                     <div>
                         <button type="submit" class="button" id="save-changes-btn" ng-click="submitSaveChanges($event)">

--- a/eucaconsole/templates/panels/tag_editor.pt
+++ b/eucaconsole/templates/panels/tag_editor.pt
@@ -1,21 +1,25 @@
 
 <!--! Tag editor -->
 <div id="tag-editor" class="row controls-wrapper" ng-app="TagEditor"
-     ng-controller="TagEditorCtrl" ng-init="initTags('${tags_json}')">
+     ng-controller="TagEditorCtrl" ng-init="initTags('${tags_json}', ${str(show_name_tag).lower()})">
+    <style type="text/css" tal:condition="not show_name_tag">
+        .tagentry.Name { display: none; }
+    </style>
     <div class="columns"><h6 i18n:translate="">Tags</h6></div>
-    <div class="columns field">
+    <div class="columns field" ng-cloak="">
         <div class="items">
-            <span class="label radius secondary tagentry" ng-repeat="tag in tagsArray" ng-cloak="cloak">
+            <span class="label radius secondary tagentry {{ tag.name === 'Name' ? 'Name' : '' }}"
+                  ng-repeat="tag in tagsArray" ng-cloak="cloak">
                 <span title="{{ getSafeTitle(tag) }}"><!--! XSS Heads up!  Don't enable Foundation tooltips here -->
                     {{ tag.name | ellipsis: 20 }} <em>=</em> {{ tag.value | ellipsis: 40 }}
                 </span>
-                <a href="#" class="remove" ng-click="removeTag($index, $event, tag)"
+                <a href="#" class="remove" ng-click="removeTag($index, $event)"
                    title="Remove tag"><i class="fi-x"></i></a>
             </span>
         </div>
         <div class="add-label">
-            <span i18n:translate="" ng-show="tagsArray.length">Add another tag</span><span
-                  ng-show="tagsArray.length == 0" i18n:translate="">Add a tag</span>:
+            <span i18n:translate="" ng-show="visibleTagsCount">Add another tag</span><span
+                  ng-show="visibleTagsCount == 0" i18n:translate="">Add a tag</span>:
         </div>
         <div class="row tagentry controls-wrapper" ng-show="tagsArray.length &lt; 10">
             <div>
@@ -37,7 +41,12 @@
             </div>
         </div>
         <div ng-show="tagsArray.length &gt;= 10">
-            <p i18n:translate="">You may not add more than ten tags to a resource</p>
+            <p i18n:translate="">
+                <span i18n:translate="">You may not add more than ten tags to a resource.</span>
+                <span tal:condition="not show_name_tag" ng-show="visibleTagsCount &lt; tagsArray.length" i18n:translate="">
+                    Note that one of your tags is the "Name" tag, which isn't displayed here.
+                </span>
+            </p>
         </div>
         <!--! Add class="debug" to textarea to view tags data posted by form -->
         <textarea id="tags" name="tags" class="hidden"></textarea>

--- a/eucaconsole/templates/snapshots/snapshot_view.pt
+++ b/eucaconsole/templates/snapshots/snapshot_view.pt
@@ -102,7 +102,7 @@
                         ${panel('form_field', field=snapshot_form['description'], **html_attrs)}
                     </div>
                     <hr />
-                    ${panel('tag_editor', tags=snapshot_tags)}
+                    ${panel('tag_editor', tags=snapshot_tags, show_tag_name=False)}
                     <hr  />
                     <div ng-show="snapshotStatus == 'deleted'">
                         <span i18n:translate="">Snapshot was successfully deleted.</span>

--- a/eucaconsole/templates/volumes/volume_view.pt
+++ b/eucaconsole/templates/volumes/volume_view.pt
@@ -117,7 +117,7 @@
                         <div class="small-8 columns value">${volume_create_time.strftime(layout.date_format)}</div>
                     </div>
                     <hr />
-                    ${panel('tag_editor', tags=volume_tags)}
+                    ${panel('tag_editor', tags=volume_tags, show_name_tag=False)}
                     <hr />
                     <div>
                         <button type="submit" class="button">

--- a/eucaconsole/views/panels.py
+++ b/eucaconsole/views/panels.py
@@ -79,13 +79,19 @@ def form_field_row(context, request, field=None, reverse=False, leftcol_width=4,
     )
 
 @panel_config('tag_editor', renderer='../templates/panels/tag_editor.pt')
-def tag_editor(context, request, tags=None, leftcol_width=4, rightcol_width=8):
+def tag_editor(context, request, tags=None, leftcol_width=4, rightcol_width=8, show_name_tag=True):
     """ Tag editor panel.
         Usage example (in Chameleon template): ${panel('tag_editor', tags=security_group.tags)}
     """
     tags = tags or {}
     tags_json = json.dumps(tags)
-    return dict(tags=tags, tags_json=tags_json, leftcol_width=leftcol_width, rightcol_width=rightcol_width)
+    return dict(
+        tags=tags,
+        tags_json=tags_json,
+        leftcol_width=leftcol_width,
+        rightcol_width=rightcol_width,
+        show_name_tag=show_name_tag,
+    )
 
 
 @panel_config('user_editor', renderer='../templates/panels/user_editor.pt')


### PR DESCRIPTION
Implements remaining item for https://eucalyptus.atlassian.net/browse/GUI-361

Notes:
- The tag editor panel now accepts a "show_name_tag" param to allow selective display of the Name tag on a page-by-page basis.  
- The Name tag is hidden on the instance, volume, and snapshot detail pages, since those pages now allow editing of the Name tag via a form field.  
- If the Name tag is hidden and the resource has a Name in the input field, the "You may not add more than ten tags to a resource" message is appended with an additional note to prevent confusion when only 9 tags are displayed in the tag editor area.
