### PR TITLE
GUI-779: Invalidate images cache when an image is updated,

### DIFF
--- a/eucaconsole/views/images.py
+++ b/eucaconsole/views/images.py
@@ -214,6 +214,9 @@ class ImageView(TaggedItemView):
         if self.image_form.validate():
             self.update_tags()
 
+            # Clear images cache
+            ImagesView.invalidate_images_cache()
+
             location = self.request.route_path('image_view', id=self.image.id)
             msg = _(u'Successfully modified image')
             self.request.session.flash(msg, queue=Notification.SUCCESS)


### PR DESCRIPTION
... allowing filtering by newly-added tags to work on the images landing page.

Fixes https://eucalyptus.atlassian.net/browse/GUI-779
