### PR TITLE
GUI-808: Prevent empty content in delete launch config dialog

### DIFF
--- a/eucaconsole/static/js/pages/launchconfig.js
+++ b/eucaconsole/static/js/pages/launchconfig.js
@@ -6,7 +6,8 @@
 
 angular.module('LaunchConfigPage', [])
     .controller('LaunchConfigPageCtrl', function ($scope) {
-        $scope.initController = function () {
+        $scope.initController = function (inUse) {
+            $scope.launchConfigInUse = inUse;
             $scope.setWatch();
             $scope.setFocus();
         };

--- a/eucaconsole/templates/launchconfigs/launchconfig_view.pt
+++ b/eucaconsole/templates/launchconfigs/launchconfig_view.pt
@@ -1,7 +1,8 @@
 <metal:block use-macro="main_template">
 
 <div metal:fill-slot="main_content">
-    <div class="row" id="contentwrap" ng-app="LaunchConfigPage" ng-controller="LaunchConfigPageCtrl" ng-init="initController()">
+    <div class="row" id="contentwrap" ng-app="LaunchConfigPage" ng-controller="LaunchConfigPageCtrl"
+         ng-init="initController(${'true' if in_use else 'false'})">
         <metal:breadcrumbs metal:use-macro="layout.global_macros['breadcrumbs']">
             <metal:crumbs metal:fill-slot="crumbs">
                 <li><a href="${request.route_path('launchconfigs')}" i18n:translate="">Launch configurations</a></li>


### PR DESCRIPTION
... when opened from the launch config detail page for one that is in use by a scaling group.

Fixes https://eucalyptus.atlassian.net/browse/GUI-808
