### PR TITLE
GUI-822: Fix typo for group id filter when fetching security group by id on the detail page

### DIFF
--- a/eucaconsole/views/securitygroups.py
+++ b/eucaconsole/views/securitygroups.py
@@ -205,7 +205,7 @@ class SecurityGroupView(TaggedItemView):
         if group_param is None or group_param == 'new':
             return None  # If missing, we're going to return an empty security group form
         if group_param.startswith('sg-'):
-            security_groups = self.conn.get_all_security_groups(filters={'group_id': [group_param]})
+            security_groups = self.conn.get_all_security_groups(filters={'group-id': [group_param]})
             security_group = security_groups[0] if security_groups else None
         else:  # Try name lookup
             security_groups = self.conn.get_all_security_groups(filters={'group-name': [group_param]})


### PR DESCRIPTION
Note that 'group_id' works, but 'group-id' is what's in the AWS docs
