### PR TITLE
GUI-842: Prevent single quote in instance name from breaking instance detail page

### DIFF
--- a/eucaconsole/static/js/pages/instance.js
+++ b/eucaconsole/static/js/pages/instance.js
@@ -19,13 +19,12 @@ angular.module('InstancePage', ['TagEditor'])
         $scope.isTransitional = function (state) {
             return $scope.transitionalStates.indexOf(state) !== -1;
         };
-        $scope.initController = function (jsonEndpoint, ipaddressEndpoint, consoleEndpoint, state, id, name, group_name, key_name, public_ip, public_dns_name, platform, has_elastic_ip) {
+        $scope.initController = function (jsonEndpoint, ipaddressEndpoint, consoleEndpoint, state, id, group_name, key_name, public_ip, public_dns_name, platform, has_elastic_ip) {
             $scope.instanceStateEndpoint = jsonEndpoint;
             $scope.instanceIPAddressEndpoint = ipaddressEndpoint;
             $scope.consoleOutputEndpoint = consoleEndpoint;
             $scope.instanceState = state;
             $scope.instanceID = id;
-            $scope.instance_name = name;
             $scope.groupName = group_name;
             $scope.keyName = key_name;
             $scope.instancePublicIP = public_ip;

--- a/eucaconsole/templates/instances/instance_view.pt
+++ b/eucaconsole/templates/instances/instance_view.pt
@@ -9,7 +9,7 @@
              ng-init="initController('${request.route_path('instance_state_json', id=instance.id)}',
                                      '${request.route_path('instance_ip_address_json', id=instance.id)}',
                                      '${request.route_path('instance_console_output_json', id=instance.id)}',
-                                     '${instance.state}', '${instance.id}', '${instance_name}', '${instance_security_group}',
+                                     '${instance.state}', '${instance.id}', '${instance_security_group}',
                                      '${instance.key_name}', '${instance.ip_address}', '${instance.public_dns_name}',
                                      '${instance.platform}', '${has_elastic_ip}')">
         <metal:breadcrumbs metal:use-macro="layout.global_macros['breadcrumbs']">


### PR DESCRIPTION
...when quote-in-name is entered from the launch instance wizard.  Fixed by removing unused instance_name scope variable.

Fixes https://eucalyptus.atlassian.net/browse/GUI-842
