### PR TITLE
GUI-839: Tag editor fixes for handling single quotes in tag keys or values

### DIFF
--- a/eucaconsole/static/js/widgets/autoscale_tag_editor.js
+++ b/eucaconsole/static/js/widgets/autoscale_tag_editor.js
@@ -22,6 +22,7 @@ angular.module('AutoScaleTagEditor', ['ngSanitize'])
         };
         $scope.initTags = function(tagsJson) {
             // Parse tags JSON and convert to a list of tags.
+            tagsJson = tagsJson.replace(/__apos__/g, "\'");
             var tagsArray = JSON.parse(tagsJson);
             tagsArray.forEach(function(tag) {
                 if (!tag['name'].match(/^aws:.*/)) {

--- a/eucaconsole/static/js/widgets/tag_editor.js
+++ b/eucaconsole/static/js/widgets/tag_editor.js
@@ -40,6 +40,7 @@ angular.module('TagEditor', ['ngSanitize'])
         };
         $scope.initTags = function(tagsJson, showNameTag) {
             // Parse tags JSON and convert to a list of tags.
+            tagsJson = tagsJson.replace(/__apos__/g, "\'");
             var tagsObj = JSON.parse(tagsJson);
             Object.keys(tagsObj).forEach(function(key) {
                 if (!key.match(/^aws:.*/)) {

--- a/eucaconsole/views/__init__.py
+++ b/eucaconsole/views/__init__.py
@@ -8,7 +8,6 @@ import simplejson as json
 import textwrap
 
 from contextlib import contextmanager
-from markupsafe import escape
 from urllib import urlencode
 from urlparse import urlparse
 
@@ -193,9 +192,7 @@ class TaggedItemView(BaseView):
 
         for key, value in tags.items():
             if not key.strip().startswith('aws:'):
-                safe_key = escape(key)
-                safe_value = escape(value)
-                self.tagged_obj.add_tag(safe_key, safe_value)
+                self.tagged_obj.add_tag(key, value)
 
     def remove_tags(self):
         for tagkey, tagvalue in self.tagged_obj.tags.items():
@@ -209,11 +206,10 @@ class TaggedItemView(BaseView):
 
     def update_name_tag(self, value):
         if self.tagged_obj is not None:
-            safe_value = escape(value)
-            if safe_value != self.tagged_obj.tags.get('Name'):
+            if value != self.tagged_obj.tags.get('Name'):
                 self.tagged_obj.remove_tag('Name')
-                if safe_value and not safe_value.startswith('aws:'):
-                    self.tagged_obj.add_tag('Name', safe_value)
+                if value and not value.startswith('aws:'):
+                    self.tagged_obj.add_tag('Name', value)
 
     @staticmethod
     def get_display_name(resource):

--- a/eucaconsole/views/panels.py
+++ b/eucaconsole/views/panels.py
@@ -84,7 +84,7 @@ def tag_editor(context, request, tags=None, leftcol_width=4, rightcol_width=8, s
         Usage example (in Chameleon template): ${panel('tag_editor', tags=security_group.tags)}
     """
     tags = tags or {}
-    tags_json = json.dumps(tags)
+    tags_json = json.dumps(tags).replace("\'", "__apos__")
     return dict(
         tags=tags,
         tags_json=tags_json,
@@ -123,7 +123,7 @@ def autoscale_tag_editor(context, request, tags=None, leftcol_width=2, rightcol_
             value=tag.value,
             propagate_at_launch=tag.propagate_at_launch,
         ))
-    tags_json = json.dumps(tags_list)
+    tags_json = json.dumps(tags_list).replace("\'", "__apos__")
     return dict(tags=tags, tags_json=tags_json, leftcol_width=leftcol_width, rightcol_width=rightcol_width)
 
 

--- a/eucaconsole/views/scalinggroups.py
+++ b/eucaconsole/views/scalinggroups.py
@@ -182,8 +182,8 @@ class BaseScalingGroupView(BaseView):
         for tag in tags_list:
             tags.append(Tag(
                 resource_id=scaling_group_name,
-                key=escape(tag.get('name')),
-                value=escape(tag.get('value')),
+                key=tag.get('name'),
+                value=tag.get('value'),
                 propagate_at_launch=tag.get('propagate_at_launch', False),
             ))
         return tags


### PR DESCRIPTION
- Fixes escaped single quote in tags and in select resource names (e.g. instance name)
- Prevent single quotes from breaking tag editor
- Save actual tag keys and values rather than the escaped ones

Fixes https://eucalyptus.atlassian.net/browse/GUI-839
