### PR TITLE
GUI-855: Add pid to images cache key, since each gunicorn worker has its own memory cache

### DIFF
--- a/eucaconsole/views/images.py
+++ b/eucaconsole/views/images.py
@@ -3,6 +3,7 @@
 Pyramid views for Eucalyptus and AWS images
 
 """
+import os
 import re
 
 from beaker.cache import cache_region, cache_managers
@@ -144,8 +145,8 @@ class ImagesJsonView(LandingPageView):
 
     def get_images(self, conn, owners, executors, region):
         """Get images, leveraging Beaker cache for long_term duration (3600 seconds)"""
-        cache_key = 'images_cache_{owners}_{executors}_{region}'.format(
-            owners=owners, executors=executors, region=region)
+        cache_key = 'images_cache_{owners}_{executors}_{region}_{pid}'.format(
+            owners=owners, executors=executors, region=region, pid=os.getpid())
 
         # Heads up!  Update cache key if we allow filters to be passed here
         @cache_region('long_term', cache_key)


### PR DESCRIPTION
Fixes https://eucalyptus.atlassian.net/browse/GUI-855

With this change, the memory usage of the WSGI server will likely increase significantly, so we'll need to keep an eye on memory usage if/when we merge this.  We may want to add a note in the workers setting of console.default.ini to warn of memory usage if the worker count is increased in the config.  The memory usage concern is most significant on the AWS side due to the large image sets there.
