### PR TITLE
GUI-882: Remove unused validate/encrypt session keys from console.ini

### DIFF
--- a/conf/console.default.ini
+++ b/conf/console.default.ini
@@ -63,8 +63,6 @@ pyramid.includes =
 session.type = cookie
 session.key = eucaconsole_session
 session.keyini = /etc/eucaconsole/session-keys.ini
-session.validate_key = QD8uAeiOxePxU7xjcpfhjJSaiwX3GQ3bVqMV279ieAqgNSbT
-session.encrypt_key = C7yjNtRb3YGW0PhPUkh1tzGiYa7LaGeo9ehq2WuQrWzTExmFgPPJjk441UjKECMA
 session.httponly = true
 # Secure session implies SSL setup
 session.secure = false


### PR DESCRIPTION
Fixes https://eucalyptus.atlassian.net/browse/GUI-882
