### PR TITLE
GUI-889: Prevent instance detail page from breaking when a security group or key pair name has a single quote

### DIFF
--- a/eucaconsole/static/js/pages/instance.js
+++ b/eucaconsole/static/js/pages/instance.js
@@ -19,14 +19,12 @@ angular.module('InstancePage', ['TagEditor'])
         $scope.isTransitional = function (state) {
             return $scope.transitionalStates.indexOf(state) !== -1;
         };
-        $scope.initController = function (jsonEndpoint, ipaddressEndpoint, consoleEndpoint, state, id, group_name, key_name, public_ip, public_dns_name, platform, has_elastic_ip) {
+        $scope.initController = function (jsonEndpoint, ipaddressEndpoint, consoleEndpoint, state, id, public_ip, public_dns_name, platform, has_elastic_ip) {
             $scope.instanceStateEndpoint = jsonEndpoint;
             $scope.instanceIPAddressEndpoint = ipaddressEndpoint;
             $scope.consoleOutputEndpoint = consoleEndpoint;
             $scope.instanceState = state;
             $scope.instanceID = id;
-            $scope.groupName = group_name;
-            $scope.keyName = key_name;
             $scope.instancePublicIP = public_ip;
             $scope.publicDNS = public_dns_name;
             $scope.platform = platform;

--- a/eucaconsole/templates/instances/instance_view.pt
+++ b/eucaconsole/templates/instances/instance_view.pt
@@ -9,9 +9,8 @@
              ng-init="initController('${request.route_path('instance_state_json', id=instance.id)}',
                                      '${request.route_path('instance_ip_address_json', id=instance.id)}',
                                      '${request.route_path('instance_console_output_json', id=instance.id)}',
-                                     '${instance.state}', '${instance.id}', '${instance_security_group}',
-                                     '${instance.key_name}', '${instance.ip_address}', '${instance.public_dns_name}',
-                                     '${instance.platform}', '${has_elastic_ip}')">
+                                     '${instance.state}', '${instance.id}', '${instance.ip_address}',
+                                     '${instance.public_dns_name}', '${instance.platform}', '${has_elastic_ip}')">
         <metal:breadcrumbs metal:use-macro="layout.global_macros['breadcrumbs']">
             <metal:crumbs metal:fill-slot="crumbs">
                 <li><a href="${request.route_path('instances')}" i18n:translate="">Instances</a></li>


### PR DESCRIPTION
Fixes https://eucalyptus.atlassian.net/browse/GUI-889
