### PR TITLE
GUI-906: Safer lookup of security group to prevent redirect loop on launch config detail page...

### DIFF
--- a/eucaconsole/views/launchconfigs.py
+++ b/eucaconsole/views/launchconfigs.py
@@ -200,9 +200,9 @@ class LaunchConfigView(BaseView):
             security_groups = []
             if groupids:
                 if groupids[0].startswith('sg-'):
-                    security_groups = self.ec2_conn.get_all_security_groups(group_ids=groupids)
+                    security_groups = self.ec2_conn.get_all_security_groups(filters={'group-id': groupids})
                 else:
-                    security_groups = self.ec2_conn.get_all_security_groups(groupnames=groupids)
+                    security_groups = self.ec2_conn.get_all_security_groups(filters={'group-name': groupids})
             return security_groups
         return []
 


### PR DESCRIPTION
...when the launch config's security group is deleted.

Fixes https://eucalyptus.atlassian.net/browse/GUI-906
