### PR TITLE
GUI-930: Hide actions drop-down menu when opening delete snapshot modal

### DIFF
--- a/eucaconsole/static/js/pages/snapshot.js
+++ b/eucaconsole/static/js/pages/snapshot.js
@@ -101,6 +101,7 @@ angular.module('SnapshotPage', ['TagEditor'])
             $scope.images = undefined;
             $scope.getSnapshotImages($scope.imagesURL);
             modal.foundation('reveal', 'open');
+            modal.find('h3').click();
         };
         $scope.getSnapshotImages = function (url) {
             $http.get(url).success(function(oData) {


### PR DESCRIPTION
…on the snapshot detail page.

Fixes https://eucalyptus.atlassian.net/browse/GUI-930
