### PR TITLE
GUI-938: Prevent 500 error on create snapshot page due to failed snapshot.id lookup

### DIFF
--- a/eucaconsole/static/js/pages/snapshot.js
+++ b/eucaconsole/static/js/pages/snapshot.js
@@ -75,7 +75,8 @@ angular.module('SnapshotPage', ['TagEditor'])
         };
         $scope.setFocus = function () {
             $(document).on('ready', function(){
-                $('.actions-menu').find('a').get(0).focus();
+                var actionsMenu = $('.actions-menu');
+                if (actionsMenu.length) actionsMenu.find('a').get(0).focus();
             });
             $(document).on('opened', '[data-reveal]', function () {
                 var modal = $(this);

--- a/eucaconsole/templates/snapshots/snapshot_view.pt
+++ b/eucaconsole/templates/snapshots/snapshot_view.pt
@@ -9,7 +9,7 @@
          ng-app="SnapshotPage" ng-controller="SnapshotPageCtrl"
          ng-init="initController('${request.route_path('snapshot_state_json', id=snapshot.id) if snapshot else ''}',
                  '${snapshot.status if snapshot else ''}', '${snapshot.progress if snapshot else ''}', ${volume_count},
-                 '${request.route_path('snapshot_images_json', id=snapshot.id)}')">
+                 '${request.route_path('snapshot_images_json', id=snapshot.id) if snapshot else ''}')">
         <metal:breadcrumbs metal:use-macro="layout.global_macros['breadcrumbs']">
             <metal:crumbs metal:fill-slot="crumbs">
                 <li><a href="${request.route_path('snapshots')}" i18n:translate="">Snapshots</a></li>


### PR DESCRIPTION
Also prevent JS error in setFocus method when actions menu lookup fails.

Fixes https://eucalyptus.atlassian.net/browse/GUI-938
