### PR TITLE
GUI-939: Use Python's random module rather than os.urandom() for generating request.id

### DIFF
--- a/eucaconsole/tweens.py
+++ b/eucaconsole/tweens.py
@@ -23,12 +23,17 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import string
+
+from random import choice
+
 
 def setup_tweens(config):
     """Since tweens order is important this function will
     take care of proper ordering"""
 
     config.add_tween('eucaconsole.tweens.https_tween_factory')
+    config.add_tween('eucaconsole.tweens.request_id_tween_factory')
     config.add_tween('eucaconsole.tweens.CTHeadersTweenFactory')
 
 
@@ -37,6 +42,15 @@ def https_tween_factory(handler, registry):
         response = handler(request)
         if request.environ.get('HTTP_X_FORWARDED_PROTO') == 'https':
             request.scheme = 'https'
+        return response
+    return tween
+
+
+def request_id_tween_factory(handler, registry):
+    def tween(request):
+        chars = string.letters + string.digits
+        request.id = ''.join(choice(chars) for i in range(16))
+        response = handler(request)
         return response
     return tween
 

--- a/eucaconsole/views/__init__.py
+++ b/eucaconsole/views/__init__.py
@@ -29,7 +29,6 @@ Core views
 
 """
 import logging
-import os
 import simplejson as json
 import textwrap
 
@@ -158,7 +157,6 @@ class BaseView(object):
     @staticmethod
     def log_message(request, message, level='info'):
         prefix = ''
-        logging_id = os.urandom(16).encode('base64').rstrip('=\n')
         cloud_type = request.session.get('cloud_type', 'euca')
         if cloud_type == 'euca':
             account = request.session.get('account', '')
@@ -168,7 +166,7 @@ class BaseView(object):
             account = request.session.get('username_label', '')
             region = request.session.get('region')
             prefix = '{0}/{1}'.format(account, region)
-        log_message = "{prefix} [{id}]: {msg}".format(prefix=prefix, id=logging_id, msg=message)
+        log_message = "{prefix} [{id}]: {msg}".format(prefix=prefix, id=request.id, msg=message)
         if level == 'info':
             logging.info(log_message)
         elif level == 'error':

--- a/tests/tweens/test_tweens.py
+++ b/tests/tweens/test_tweens.py
@@ -104,3 +104,14 @@ class TestHTTPSTween(unittest.TestCase):
         tween(request)
         self.assertEqual(request.scheme, 'https')
 
+
+class TestRequestIDTween(unittest.TestCase):
+    def test_it(self):
+        from eucaconsole.tweens import request_id_tween_factory as factory
+        tween = factory(MockHandler(), None)
+
+        request = Mock(id=None)
+        request.session = dict(account='foo')
+        tween(request)
+        self.assertFalse(request.id is None)
+


### PR DESCRIPTION
Fixes https://eucalyptus.atlassian.net/browse/GUI-939
