### PR TITLE
GUI-946: Display evaluation period as minutes in create alarm dialog

### DIFF
--- a/eucaconsole/forms/alarms.py
+++ b/eucaconsole/forms/alarms.py
@@ -78,15 +78,15 @@ class CloudWatchAlarmCreateForm(BaseSecureForm):
             validators.InputRequired(message=statistic_error_msg),
         ],
     )
-    threshold_error_msg = _(u'Trigger threshold is required')
+    threshold_error_msg = _(u'Trigger threshold amount is required')
     threshold = wtforms.IntegerField(
         label=_(u'Trigger threshold'),
         validators=[
             validators.InputRequired(message=threshold_error_msg),
         ],
     )
-    period_help_text = _(u'Length of measurement period in seconds.')
-    period_error_msg = _(u'Period length is required')
+    period_help_text = _(u'Length of measurement period in minutes.')
+    period_error_msg = _(u'Period length is required and must be a whole number greater than zero')
     period = wtforms.IntegerField(
         label=_(u'Period length'),
         validators=[
@@ -129,7 +129,7 @@ class CloudWatchAlarmCreateForm(BaseSecureForm):
 
     def set_initial_data(self):
         self.evaluation_periods.data = 1
-        self.period.data = 120
+        self.period.data = 5
 
         if self.scaling_group is not None:
             self.scaling_group_name.data = self.scaling_group.name

--- a/eucaconsole/templates/dialogs/create_alarm_dialog.pt
+++ b/eucaconsole/templates/dialogs/create_alarm_dialog.pt
@@ -97,7 +97,8 @@
                             ${structure:alarm_form['comparison']}
                         </div>
                         <div class="small-3 columns">
-                            ${structure:alarm_form.threshold(**{'placeholder': 'amount...', 'type': 'number'})}
+                            ${structure:alarm_form.threshold(**{'placeholder': 'amount...', 'type': 'number', 'required': 'required', 'pattern': layout.integer_gt_zero_pattern})}
+                            <small class="error">${alarm_form.threshold.error_msg}</small>
                         </div>
                         <div class="small-6 columns">
                             <div class="unit-label">{{ unitLabel }}</div>
@@ -119,8 +120,9 @@
                     </div>
                     <div>
                         <span i18n:translate="">with each measurement lasting</span>
-                        ${structure:alarm_form.period(**{'type': 'number', 'min': 30, 'step': 30})}
-                        <span i18n:translate="">seconds</span>
+                        ${structure:alarm_form.period(**{'type': 'number', 'min': 1, 'step': 1, 'required': 'required', 'pattern': layout.integer_gt_zero_pattern})}
+                        <span i18n:translate="">minutes</span><br />
+                        <small class="error">${alarm_form.period.error_msg}</small>
                     </div>
                 </div>
             </div>

--- a/eucaconsole/views/alarms.py
+++ b/eucaconsole/views/alarms.py
@@ -92,7 +92,7 @@ class CloudWatchAlarmsView(LandingPageView):
                 statistic = self.request.params.get('statistic')
                 comparison = self.request.params.get('comparison')
                 threshold = self.request.params.get('threshold')
-                period = self.request.params.get('period')
+                period = int(self.request.params.get('period', 5)) * 60  # Convert to seconds
                 evaluation_periods = self.request.params.get('evaluation_periods')
                 unit = self.request.params.get('unit')
                 description = self.request.params.get('description', '')


### PR DESCRIPTION
Also add client-side validation for trigger threshold (amount) field per GUI-934

Fixes https://eucalyptus.atlassian.net/browse/GUI-946 and https://eucalyptus.atlassian.net/browse/GUI-934
