### PR TITLE
GUI-953: Style help content pulled in from include files.  Remove help icon from landing pages

### DIFF
--- a/eucaconsole/static/css/eucaconsole.css
+++ b/eucaconsole/static/css/eucaconsole.css
@@ -1486,6 +1486,10 @@ textarea.policy-area { width: 100%; min-height: 30rem; font-family: Courier, "co
 .help-padding { display: block; height: 2.5rem; }
 
 .help-content { font-size: 0.9rem; margin-bottom: 1.5rem; }
+.help-content h1 { font-size: 1.2rem; }
+.help-content h2 { font-size: 1.1rem; }
+.help-content .p, .help-content .section { line-height: 1.4rem; }
+.help-content .topictitle1 { margin-top: 1rem; }
 .help-content p { margin-bottom: 0.5rem; }
 .help-content ol { list-style-position: inside; }
 .help-content ol li { text-indent: -1rem; margin-left: 1rem; }

--- a/eucaconsole/static/css/pages/alarms.css
+++ b/eucaconsole/static/css/pages/alarms.css
@@ -11,7 +11,7 @@
 .clear-link { color: #777777; }
 .clear-link:hover { color: #8dc943; }
 
-#breadcrumbs .icon-block { display: inline-block; }
+#breadcrumbs .icon-block { display: none; }
 
 #primary-buttons .button { padding: 8px 3rem; }
 

--- a/eucaconsole/static/css/pages/groups.css
+++ b/eucaconsole/static/css/pages/groups.css
@@ -11,7 +11,7 @@
 .clear-link { color: #777777; }
 .clear-link:hover { color: #8dc943; }
 
-#breadcrumbs .icon-block { display: inline-block; }
+#breadcrumbs .icon-block { display: none; }
 
 #primary-buttons .button { padding: 8px 3rem; }
 

--- a/eucaconsole/static/css/pages/images.css
+++ b/eucaconsole/static/css/pages/images.css
@@ -11,7 +11,7 @@
 .clear-link { color: #777777; }
 .clear-link:hover { color: #8dc943; }
 
-#breadcrumbs .icon-block { display: inline-block; }
+#breadcrumbs .icon-block { display: none; }
 
 #primary-buttons .button { padding: 8px 3rem; }
 

--- a/eucaconsole/static/css/pages/instance.css
+++ b/eucaconsole/static/css/pages/instance.css
@@ -11,7 +11,7 @@
 .clear-link { color: #777777; }
 .clear-link:hover { color: #8dc943; }
 
-#breadcrumbs .icon-block { display: inline-block; }
+#breadcrumbs .icon-block { display: none; }
 
 #primary-buttons .button { padding: 8px 3rem; }
 

--- a/eucaconsole/static/css/pages/instances.css
+++ b/eucaconsole/static/css/pages/instances.css
@@ -11,7 +11,7 @@
 .clear-link { color: #777777; }
 .clear-link:hover { color: #8dc943; }
 
-#breadcrumbs .icon-block { display: inline-block; }
+#breadcrumbs .icon-block { display: none; }
 
 #primary-buttons .button { padding: 8px 3rem; }
 

--- a/eucaconsole/static/css/pages/ipaddresses.css
+++ b/eucaconsole/static/css/pages/ipaddresses.css
@@ -9,7 +9,7 @@
 .clear-link { color: #777777; }
 .clear-link:hover { color: #8dc943; }
 
-#breadcrumbs .icon-block { display: inline-block; }
+#breadcrumbs .icon-block { display: none; }
 
 #primary-buttons .button { padding: 8px 3rem; }
 

--- a/eucaconsole/static/css/pages/keypairs.css
+++ b/eucaconsole/static/css/pages/keypairs.css
@@ -9,7 +9,7 @@
 .clear-link { color: #777777; }
 .clear-link:hover { color: #8dc943; }
 
-#breadcrumbs .icon-block { display: inline-block; }
+#breadcrumbs .icon-block { display: none; }
 
 #primary-buttons .button { padding: 8px 3rem; }
 

--- a/eucaconsole/static/css/pages/launchconfigs.css
+++ b/eucaconsole/static/css/pages/launchconfigs.css
@@ -9,7 +9,7 @@
 .clear-link { color: #777777; }
 .clear-link:hover { color: #8dc943; }
 
-#breadcrumbs .icon-block { display: inline-block; }
+#breadcrumbs .icon-block { display: none; }
 
 #primary-buttons .button { padding: 8px 3rem; }
 

--- a/eucaconsole/static/css/pages/scalinggroup.css
+++ b/eucaconsole/static/css/pages/scalinggroup.css
@@ -11,7 +11,7 @@
 .clear-link { color: #777777; }
 .clear-link:hover { color: #8dc943; }
 
-#breadcrumbs .icon-block { display: inline-block; }
+#breadcrumbs .icon-block { display: none; }
 
 #primary-buttons .button { padding: 8px 3rem; }
 

--- a/eucaconsole/static/css/pages/scalinggroups.css
+++ b/eucaconsole/static/css/pages/scalinggroups.css
@@ -11,7 +11,7 @@
 .clear-link { color: #777777; }
 .clear-link:hover { color: #8dc943; }
 
-#breadcrumbs .icon-block { display: inline-block; }
+#breadcrumbs .icon-block { display: none; }
 
 #primary-buttons .button { padding: 8px 3rem; }
 

--- a/eucaconsole/static/css/pages/securitygroups.css
+++ b/eucaconsole/static/css/pages/securitygroups.css
@@ -9,7 +9,7 @@
 .clear-link { color: #777777; }
 .clear-link:hover { color: #8dc943; }
 
-#breadcrumbs .icon-block { display: inline-block; }
+#breadcrumbs .icon-block { display: none; }
 
 #primary-buttons .button { padding: 8px 3rem; }
 

--- a/eucaconsole/static/css/pages/snapshots.css
+++ b/eucaconsole/static/css/pages/snapshots.css
@@ -11,7 +11,7 @@
 .clear-link { color: #777777; }
 .clear-link:hover { color: #8dc943; }
 
-#breadcrumbs .icon-block { display: inline-block; }
+#breadcrumbs .icon-block { display: none; }
 
 #primary-buttons .button { padding: 8px 3rem; }
 

--- a/eucaconsole/static/css/pages/user.css
+++ b/eucaconsole/static/css/pages/user.css
@@ -11,7 +11,7 @@
 .clear-link { color: #777777; }
 .clear-link:hover { color: #8dc943; }
 
-#breadcrumbs .icon-block { display: inline-block; }
+#breadcrumbs .icon-block { display: none; }
 
 #primary-buttons .button { padding: 8px 3rem; }
 

--- a/eucaconsole/static/css/pages/users.css
+++ b/eucaconsole/static/css/pages/users.css
@@ -11,7 +11,7 @@
 .clear-link { color: #777777; }
 .clear-link:hover { color: #8dc943; }
 
-#breadcrumbs .icon-block { display: inline-block; }
+#breadcrumbs .icon-block { display: none; }
 
 #primary-buttons .button { padding: 8px 3rem; }
 

--- a/eucaconsole/static/css/pages/volume.css
+++ b/eucaconsole/static/css/pages/volume.css
@@ -11,7 +11,7 @@
 .clear-link { color: #777777; }
 .clear-link:hover { color: #8dc943; }
 
-#breadcrumbs .icon-block { display: inline-block; }
+#breadcrumbs .icon-block { display: none; }
 
 #primary-buttons .button { padding: 8px 3rem; }
 

--- a/eucaconsole/static/css/pages/volumes.css
+++ b/eucaconsole/static/css/pages/volumes.css
@@ -11,7 +11,7 @@
 .clear-link { color: #777777; }
 .clear-link:hover { color: #8dc943; }
 
-#breadcrumbs .icon-block { display: inline-block; }
+#breadcrumbs .icon-block { display: none; }
 
 #primary-buttons .button { padding: 8px 3rem; }
 

--- a/eucaconsole/static/sass/eucaconsole.scss
+++ b/eucaconsole/static/sass/eucaconsole.scss
@@ -531,6 +531,14 @@ textarea.policy-area {
 .help-content {
     font-size: 0.9rem;
     margin-bottom: 1.5rem;
+    h1 { font-size: 1.2rem; }
+    h2 { font-size: 1.1rem; }
+    .p, .section {
+        line-height: 1.4rem;
+    }
+    .topictitle1 {
+        margin-top: 1rem;
+    }
     p {
         margin-bottom: 0.5rem;
     }

--- a/eucaconsole/static/sass/includes/_landingpage.scss
+++ b/eucaconsole/static/sass/includes/_landingpage.scss
@@ -62,7 +62,7 @@ $dropdown-border-color: $euca-green;
 
 #breadcrumbs {
     .icon-block {
-        display: inline-block;
+        display: none;
     }
 }
 


### PR DESCRIPTION
Fixes https://eucalyptus.atlassian.net/browse/GUI-953 and https://eucalyptus.atlassian.net/browse/GUI-962
