### PR TITLE
GUI-973: Better location for default nginx access/error logs

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -29,8 +29,8 @@ http {
     ### Logging Settings
     ##
 
-    access_log /var/log/eucalyptus-console/nginx_access.log;
-    error_log /var/log/eucalyptus-console/nginx_error.log;
+    access_log /var/log/eucaconsole_nginx_access.log;
+    error_log /var/log/eucaconsole_nginx_error.log;
 
     ### Gzip Settings
     ##


### PR DESCRIPTION
Fixes https://eucalyptus.atlassian.net/browse/GUI-973
