### PR TITLE
GUI-795: Use Angular ng-pristine/ng-dirty approach for disabling Save Changes button

### DIFF
--- a/eucaconsole/static/js/widgets/securitygroup_rules.js
+++ b/eucaconsole/static/js/widgets/securitygroup_rules.js
@@ -131,6 +131,7 @@ angular.module('SecurityGroupRules', [])
             $event.preventDefault();
             $scope.rulesArray.splice(index, 1);
             $scope.syncRules();
+            $scope.resourceForm && $scope.resourceForm.$setDirty();
         };
         // Adjust the IP Protocol atrributes for specical cases
         $scope.adjustIpProtocol = function () {

--- a/eucaconsole/static/js/widgets/tag_editor.js
+++ b/eucaconsole/static/js/widgets/tag_editor.js
@@ -60,6 +60,7 @@ angular.module('TagEditor', ['ngSanitize'])
             $event.preventDefault();
             $scope.tagsArray.splice(index, 1);
             $scope.syncTags();
+            $scope.resourceForm && $scope.resourceForm.$setDirty();
         };
         $scope.addTag = function ($event) {
             $event.preventDefault();

--- a/eucaconsole/templates/securitygroups/securitygroup_view.pt
+++ b/eucaconsole/templates/securitygroups/securitygroup_view.pt
@@ -45,7 +45,7 @@
                         </li>
                     </metal:actions>
                 </metal:block>
-                <form tal:attributes="action form_action" method="post" data-abide="abide">
+                <form tal:attributes="action form_action" method="post" data-abide="abide" name="resourceForm">
                     ${structure:securitygroup_form['csrf_token']}
                     <h6 i18n:translate="">Security group</h6>
                     <div tal:condition="not security_group" tal:omit-tag="">
@@ -68,7 +68,8 @@
                     ${panel('tag_editor', tags=sgroup_tags, leftcol_width=3, rightcol_width=9)}
                     <hr />
                     <div>
-                        <button type="submit" class="button" id="save-securitygroup-btn">
+                        <button type="submit" class="button" id="save-securitygroup-btn"
+                                ng-disabled="!resourceForm.$dirty">
                             <span tal:condition="security_group" i18n:translate="">Save Changes</span>
                             <span tal:condition="not security_group" i18n:translate="">
                                 Create Security Group


### PR DESCRIPTION
...on resource detail pages, experimenting on security group page first.

References https://eucalyptus.atlassian.net/browse/GUI-795
