### PR TITLE
Fix __version__ handling

### DIFF
--- a/eucaconsole/version.py
+++ b/eucaconsole/version.py
@@ -40,7 +40,7 @@ if '__file__' in globals():
         git.wait()
         git.stderr.read()
         if git.returncode == 0:
-            __version__ = git.stdout.read().strip()
+            __version__ = git.stdout.read().strip().lstrip('v')
             if type(__version__).__name__ == 'bytes':
                 __version__ = __version__.decode()
     except:

--- a/setup.py
+++ b/setup.py
@@ -141,7 +141,7 @@ message_extractors = {'eucaconsole': [
 
 setup(
     name='eucaconsole',
-    version='4.0.1',
+    version=__version__,
     description='Eucalyptus Management Console',
     long_description=README,
     classifiers=[


### PR DESCRIPTION
This commit removes the leading 'v' from the version string when it is drawn directly from git.  It also makes setup() start using that as the program's version instead of an independently-specified string.
