### PR TITLE
GUI-1154: Set custom policy name only when a policy statement is selected...

### DIFF
--- a/eucaconsole/static/js/pages/iam_policy_wizard.js
+++ b/eucaconsole/static/js/pages/iam_policy_wizard.js
@@ -160,8 +160,11 @@ angular.module('IAMPolicyWizard', [])
             $('.tabs').find('a').on('click', function (evt) {
                 var tabLinkId = $(evt.target).closest('a').attr('id');
                 Modernizr.localstorage && localStorage.setItem($scope.lastSelectedTabKey, tabLinkId);
-                if (tabLinkId === 'custom-policy-tab') {
-                    $scope.setPolicyName('custom');
+                if (tabLinkId === 'custom-policy-tab' && $scope.policyStatements.length) {
+                    // Load selected policy statements if switching back to custom policy tab
+                    $timeout(function() {
+                        $scope.updatePolicy();
+                    }, 100);
                 }
             });
             $('#' + lastSelectedTab).click();
@@ -224,6 +227,13 @@ angular.module('IAMPolicyWizard', [])
                 'custom': 'CustomAccessPolicy'
             };
             $scope.policyName = typeNameMapping[policyType] + '-' + $scope.urlParams['id'] + '-' + $scope.timestamp;
+            if (policyType === 'custom') {
+                // Prevent lingering validation error on policy name field
+                $timeout(function() {
+                    $('#name').trigger('focus');
+                    $('.CodeMirror').find('textarea').focus();
+                }, 200);
+            }
         };
         $scope.handlePolicyFileUpload = function () {
             $('#policy_file').on('change', function(evt) {
@@ -256,6 +266,7 @@ angular.module('IAMPolicyWizard', [])
             $scope.setPolicyName(policyType);
         };
         $scope.updatePolicy = function() {
+            $scope.setPolicyName('custom');
             $scope.handEdited = false;
             $scope.policyStatements = [];
             // Add namespace (allow/deny all) statements


### PR DESCRIPTION
... and restore selected policy statements when switching back to custom policy tab after a canned policy is selected.

Fixes https://eucalyptus.atlassian.net/browse/GUI-1154
