### PR TITLE
GUI-1190: Escape curly braces in instance choices on attach to instance dialog at the volume detail page

### DIFF
--- a/eucaconsole/forms/volumes.py
+++ b/eucaconsole/forms/volumes.py
@@ -171,13 +171,14 @@ class AttachForm(BaseSecureForm):
     def set_instance_choices(self):
         """Populate instance field with instances available to attach volume to"""
         if self.volume:
+            from ..views import BaseView
             choices = [BLANK_CHOICE]
             for instance in self.instances:
                 if instance.state in ["running", "stopped"] and self.volume.zone == instance.placement:
                     name_tag = instance.tags.get('Name')
                     extra = ' ({name})'.format(name=name_tag) if name_tag else ''
-                    vol_name = '{id}{extra}'.format(id=instance.id, extra=extra)
-                    choices.append((instance.id, vol_name))
+                    inst_name = '{id}{extra}'.format(id=instance.id, extra=extra)
+                    choices.append((instance.id, BaseView.escape_braces(inst_name)))
             if len(choices) == 1:
                 prefix = _(u'No available instances in availability zone')
                 msg = '{0} {1}'.format(prefix, self.volume.zone)

--- a/eucaconsole/views/volumes.py
+++ b/eucaconsole/views/volumes.py
@@ -74,7 +74,8 @@ class VolumesView(LandingPageView, BaseVolumeView):
         self.prefix = '/volumes'
         self.location = self.get_redirect_location('volumes')
         with boto_error_handler(request, self.location):
-            self.instances = self.conn.get_only_instances(filters={'instance-state-name':['running', 'stopped']}) if self.conn else []
+            self.instances = self.conn.get_only_instances(
+                filters={'instance-state-name': ['running', 'stopped']}) if self.conn else []
         self.delete_form = DeleteVolumeForm(self.request, formdata=self.request.params or None)
         self.attach_form = AttachForm(self.request, instances=self.instances, formdata=self.request.params or None)
         self.detach_form = DetachForm(self.request, formdata=self.request.params or None)


### PR DESCRIPTION
Fixes https://eucalyptus.atlassian.net/browse/GUI-1190
