### PR TITLE
GUI-1189: Unescape braces in scaling group and security group filter choices on instance landing page

### DIFF
--- a/eucaconsole/views/instances.py
+++ b/eucaconsole/views/instances.py
@@ -307,14 +307,15 @@ class InstancesJsonView(LandingPageView):
             filters.update({'instance-type': instance_type_param})
         security_group_param = self.request.params.getall('security_group')
         if security_group_param:
-            filters.update({'group-name': security_group_param})
+            filters.update({'group-name': [self.unescape_braces(sg) for sg in security_group_param]})
         root_device_type_param = self.request.params.getall('root_device_type')
         if root_device_type_param:
             filters.update({'root-device-type': root_device_type_param})
         # Don't filter by these request params in Python, as they're included in the "filters" params sent to the CLC
         # Note: the choices are from attributes in InstancesFiltersForm
         ignore_params = [
-            'availability_zone', 'instance_type', 'state', 'security_group', 'scaling_group', 'root_device_type', 'roles']
+            'availability_zone', 'instance_type', 'state', 'security_group',
+            'scaling_group', 'root_device_type', 'roles']
         filtered_items = self.filter_items(self.get_items(filters=filters), ignore=ignore_params)
         if self.request.params.get('scaling_group'):
             filtered_items = self.filter_by_scaling_group(filtered_items)
@@ -365,7 +366,7 @@ class InstancesJsonView(LandingPageView):
             autoscaling_tag = item.tags.get('aws:autoscaling:groupName')
             if autoscaling_tag:
                 for scaling_group in self.request.params.getall('scaling_group'):
-                    if autoscaling_tag == scaling_group:
+                    if autoscaling_tag == self.unescape_braces(scaling_group):
                         filtered_items.append(item)
         return filtered_items
 


### PR DESCRIPTION
Fixes https://eucalyptus.atlassian.net/browse/GUI-1189
