### PR TITLE
GUI-1192: Use TextEscapedField for Tags input field on landing pages that allow filtering by tags

### DIFF
--- a/eucaconsole/forms/images.py
+++ b/eucaconsole/forms/images.py
@@ -33,7 +33,7 @@ from wtforms import validators
 from ..constants.images import EUCA_IMAGE_OWNER_ALIAS_CHOICES, AWS_IMAGE_OWNER_ALIAS_CHOICES
 
 from ..i18n import _
-from . import BaseSecureForm
+from . import BaseSecureForm, TextEscapedField
 
 
 class ImageForm(BaseSecureForm):
@@ -73,7 +73,7 @@ class ImagesFiltersForm(BaseSecureForm):
     platform = wtforms.SelectMultipleField(label=_(u'Platform'))
     root_device_type = wtforms.SelectMultipleField(label=_(u'Root device type'))
     architecture = wtforms.SelectMultipleField(label=_(u'Architecture'))
-    tags = wtforms.TextField(label=_(u'Tags'))
+    tags = TextEscapedField(label=_(u'Tags'))
 
     def __init__(self, request, cloud_type='euca', **kwargs):
         super(ImagesFiltersForm, self).__init__(request, **kwargs)

--- a/eucaconsole/forms/instances.py
+++ b/eucaconsole/forms/instances.py
@@ -316,7 +316,7 @@ class InstancesFiltersForm(BaseSecureForm):
     root_device_type = wtforms.SelectMultipleField(label=_(u'Root device type'))
     security_group = wtforms.SelectMultipleField(label=_(u'Security group'))
     scaling_group = wtforms.SelectMultipleField(label=_(u'Scaling group'))
-    tags = wtforms.TextField(label=_(u'Tags'))
+    tags = TextEscapedField(label=_(u'Tags'))
     roles = wtforms.SelectMultipleField(label=_(u'Roles'))
 
     def __init__(self, request, ec2_conn=None, autoscale_conn=None, iam_conn=None, cloud_type='euca', **kwargs):

--- a/eucaconsole/forms/scalinggroups.py
+++ b/eucaconsole/forms/scalinggroups.py
@@ -35,7 +35,7 @@ from wtforms.widgets import html_params, HTMLString, Select
 from markupsafe import escape
 
 from ..i18n import _
-from . import BaseSecureForm, ChoicesManager
+from . import BaseSecureForm, ChoicesManager, TextEscapedField
 
 
 class NgNonBindableOptionSelect(Select):
@@ -384,7 +384,7 @@ class ScalingGroupsFiltersForm(BaseSecureForm):
     """Form class for filters on landing page"""
     launch_config_name = wtforms.SelectMultipleField(label=_(u'Launch configuration'))
     availability_zones = wtforms.SelectMultipleField(label=_(u'Availability zone'))
-    tags = wtforms.TextField(label=_(u'Tags'))
+    tags = TextEscapedField(label=_(u'Tags'))
 
     def __init__(self, request, ec2_conn=None, autoscale_conn=None, **kwargs):
         super(ScalingGroupsFiltersForm, self).__init__(request, **kwargs)

--- a/eucaconsole/forms/securitygroups.py
+++ b/eucaconsole/forms/securitygroups.py
@@ -32,7 +32,7 @@ import wtforms
 from wtforms import validators
 
 from ..i18n import _
-from . import BaseSecureForm
+from . import BaseSecureForm, TextEscapedField
 
 
 class SecurityGroupForm(BaseSecureForm):
@@ -73,4 +73,4 @@ class SecurityGroupDeleteForm(BaseSecureForm):
 
 class SecurityGroupsFiltersForm(BaseSecureForm):
     """Form class for filters on landing page"""
-    tags = wtforms.TextField(label=_(u'Tags'))
+    tags = TextEscapedField(label=_(u'Tags'))

--- a/eucaconsole/forms/snapshots.py
+++ b/eucaconsole/forms/snapshots.py
@@ -108,7 +108,7 @@ class RegisterSnapshotForm(BaseSecureForm):
 class SnapshotsFiltersForm(BaseSecureForm):
     """Form class for filters on landing page"""
     status = wtforms.SelectMultipleField(label=_(u'Status'))
-    tags = wtforms.TextField(label=_(u'Tags'))
+    tags = TextEscapedField(label=_(u'Tags'))
 
     def __init__(self, request, **kwargs):
         super(SnapshotsFiltersForm, self).__init__(request, **kwargs)

--- a/eucaconsole/forms/volumes.py
+++ b/eucaconsole/forms/volumes.py
@@ -198,7 +198,7 @@ class VolumesFiltersForm(BaseSecureForm):
     """Form class for filters on landing page"""
     zone = wtforms.SelectMultipleField(label=_(u'Availability zones'))
     status = wtforms.SelectMultipleField(label=_(u'Status'))
-    tags = wtforms.TextField(label=_(u'Tags'))
+    tags = TextEscapedField(label=_(u'Tags'))
 
     def __init__(self, request, conn=None, **kwargs):
         super(VolumesFiltersForm, self).__init__(request, **kwargs)

--- a/eucaconsole/views/__init__.py
+++ b/eucaconsole/views/__init__.py
@@ -455,10 +455,9 @@ class LandingPageView(BaseView):
                     filtered_items.append(item)
         return filtered_items
 
-    @staticmethod
-    def match_tags(item=None, tags=None, autoscale=False):
+    def match_tags(self, item=None, tags=None, autoscale=False):
         for tag in tags:
-            tag = tag.strip()
+            tag = self.unescape_braces(tag.strip())
             if autoscale:  # autoscaling tags are a list of Tag boto.ec2.autoscale.tag.Tag objects
                 if item.tags:
                     for as_tag in item.tags:


### PR DESCRIPTION
…and unescape tag keys/values for filters form before performing the filtering server-side.

Fixes https://eucalyptus.atlassian.net/browse/GUI-1192
