### PR TITLE
GUI-129

### DIFF
--- a/eucaconsole/views/login.py
+++ b/eucaconsole/views/login.py
@@ -119,7 +119,8 @@ class LoginView(BaseView):
         host = self.request.registry.settings.get('sts.host', host)
         port = int(self.request.registry.settings.get('sts.port', port))
         validate_certs = asbool(self.request.registry.settings.get('connection.ssl.validation', False))
-        conn = AWSAuthConnection(None)
+        conn = AWSAuthConnection(None, aws_access_key_id='', aws_secret_access_key='')
+        
         ca_certs_file = conn.ca_certificates_file
         conn = None
         ca_certs_file = self.request.registry.settings.get('connection.ssl.certfile', ca_certs_file)
@@ -173,7 +174,7 @@ class LoginView(BaseView):
             package = base64.decodestring(package)
             aws_region = self.request.params.get('aws-region')
             validate_certs = asbool(self.request.registry.settings.get('connection.ssl.validation', False))
-            conn = AWSAuthConnection(None)
+            conn = AWSAuthConnection(None, aws_access_key_id='', aws_secret_access_key='')
             ca_certs_file = conn.ca_certificates_file
             conn = None
             ca_certs_file = self.request.registry.settings.get('connection.ssl.certfile', ca_certs_file)

--- a/tests/auth/test_changepassword.py
+++ b/tests/auth/test_changepassword.py
@@ -27,7 +27,8 @@
 Tests for change password forms
 
 """
-import socket
+from urllib2 import URLError
+
 from pyramid.testing import DummyRequest
 
 from eucaconsole.forms.login import EucaChangePasswordForm
@@ -62,5 +63,5 @@ class EucaChangePasswordTestCase(BaseTestCase):
     def test_euca_authentication_failure(self):
         kwargs = dict(account=self.account, user=self.username, passwd=self.current_password,
                       new_passwd=self.new_password, duration=self.duration)
-        self.assertRaises(socket.gaierror, self.auth.authenticate, **kwargs)
+        self.assertRaises(URLError, self.auth.authenticate, **kwargs)
 

--- a/tests/auth/test_login.py
+++ b/tests/auth/test_login.py
@@ -27,7 +27,6 @@
 Tests for login forms
 
 """
-import socket
 from urllib2 import HTTPError, URLError
 
 import boto
@@ -76,7 +75,7 @@ class EucaAuthTestCase(BaseTestCase):
 
     def test_euca_authentication_failure(self):
         kwargs = dict(account=self.account, user=self.username, passwd=self.password, duration=self.duration)
-        self.assertRaises(socket.gaierror, self.auth.authenticate, **kwargs)
+        self.assertRaises(URLError, self.auth.authenticate, **kwargs)
 
 
 class AWSAuthTestCase(BaseTestCase):


### PR DESCRIPTION
trick boto to not try loading auth from metadata, which happened in some cases. fixed unit tests
