### PR TITLE
GUI-1261: Limit char length of image name on instances landing page 

### DIFF
--- a/eucaconsole/static/css/pages/instances.css
+++ b/eucaconsole/static/css/pages/instances.css
@@ -115,6 +115,8 @@
 .table th, .table td { padding: 4px 7px; }
 .table .label { margin: 0 0 0 0; }
 
+.tile { height: 244px; max-height: 244px; }
+
 #terminate-instances-btn { margin-left: 1rem; border: none; }
 
 .connect-center { text-align: center; }

--- a/eucaconsole/static/sass/pages/instances.scss
+++ b/eucaconsole/static/sass/pages/instances.scss
@@ -23,6 +23,7 @@ $instance-status-color-terminating: lightgrey;
 .status.shutting-down { background-color: $instance-status-color-terminating; }
 
 
+$instance-tile-height-adjustment: 24px;
 
 // Table view
 .table {
@@ -33,6 +34,13 @@ $instance-status-color-terminating: lightgrey;
         margin: 0 0 0 0;
     }
 }
+
+// tile view
+.tile {
+    height: $tile-height + $instance-tile-height-adjustment;
+    max-height: $tile-height + $instance-tile-height-adjustment;
+}
+
 
 #terminate-instances-btn {
     margin-left: 1rem;

--- a/eucaconsole/templates/images/image_view.pt
+++ b/eucaconsole/templates/images/image_view.pt
@@ -61,7 +61,7 @@
                                     <label i18n:translate="" tal:condition="layout.cloud_type == 'euca'">EMI name</label>
                                     <label i18n:translate="" tal:condition="layout.cloud_type == 'aws'">AMI name</label>
                                 </div>
-                                <div class="small-8 columns value">${image.name if image.name else ''}</div>
+                                <div class="small-8 columns value breakword">${image.name if image.name else ''}</div>
                             </div>
                             <div tal:condition="not is_owned_by_user">
                                 <div class="row controls-wrapper readonly">

--- a/eucaconsole/templates/images/images.pt
+++ b/eucaconsole/templates/images/images.pt
@@ -71,7 +71,10 @@
                 <div>
                     <span class="label" title="EMI Name" i18n:attributes="title" data-tooltip="" tal:condition="layout.cloud_type == 'euca'">EM</span>
                     <span class="label" title="AMI Name" i18n:attributes="title" data-tooltip="" tal:condition="layout.cloud_type == 'aws'">AM</span>
-                    {{ item.name }}
+                    {{ item.name | limitTo: 64 }}
+                    <span ng-show="item.name.length &gt; 64"
+                          data-tooltip="tooltip" class="label round has-tip ellipsis"
+                          title="{{ sanitizeContent(item.name) }}">...</span>
                 </div>
                 <div ng-show="item.platform_name">
                     <span class="label" title="Platform" i18n:attributes="title" data-tooltip="">PL</span>

--- a/eucaconsole/templates/instances/instances.pt
+++ b/eucaconsole/templates/instances/instances.pt
@@ -91,7 +91,12 @@
                 </div>
                 <div>
                     <span class="label" title="Root device" i18n:attributes="title" data-tooltip="">IM</span>
-                    <a ng-href="/images/{{ item.image_id }}">{{ item.image_name || item.image_id }}</a>
+                    <a ng-href="/images/{{ item.image_id }}">
+                        {{ item.image_name | limitTo: 64 || item.image_id }}
+                        <span ng-show="item.image_name &amp;&amp; item.image_name.length &gt; 64"
+                              data-tooltip="tooltip" class="label round has-tip ellipsis"
+                              title="{{ sanitizeContent(item.image_name) }}">...</span>
+                    </a>
                 </div>
                 <div>
                     <span class="label" title="IP address" i18n:attributes="title" data-tooltip="">IP</span>


### PR DESCRIPTION
…(and images landing page) to avoid obscuring content in tile view.  Wrap long image name on image detail page.

Fixes https://eucalyptus.atlassian.net/browse/GUI-1261
