### PR TITLE
GUI-1262: Add padding below property/value pairs on detail pages

### DIFF
--- a/eucaconsole/static/css/eucaconsole.css
+++ b/eucaconsole/static/css/eucaconsole.css
@@ -1535,6 +1535,7 @@ form .error .chosen-container .chosen-single { border-color: darkred; background
 .row.controls-wrapper .field textarea { margin-top: 0.3rem; }
 .row.controls-wrapper.readonly { margin-top: 0; margin-bottom: 0; }
 .row.controls-wrapper.readonly label { padding-top: 0; position: relative; right: -12px; }
+.row.controls-wrapper.readonly .value { padding-bottom: 6px; }
 .row.controls-wrapper.inline { margin-bottom: 4px; }
 .row.controls-wrapper.inline label { right: -6px; }
 

--- a/eucaconsole/static/sass/eucaconsole.scss
+++ b/eucaconsole/static/sass/eucaconsole.scss
@@ -704,6 +704,9 @@ form {
             position: relative;
             right: -12px;
         }
+        .value {
+            padding-bottom: 6px;
+        }
     }
     &.inline {
         margin-bottom: 4px;

--- a/eucaconsole/templates/instances/instance_view.pt
+++ b/eucaconsole/templates/instances/instance_view.pt
@@ -249,7 +249,7 @@
                     </div>
                     <div class="row controls-wrapper readonly">
                         <div class="small-4 columns"><label i18n:translate="">Image name</label></div>
-                        <div tal:condition="image" class="small-8 columns value">${image.name}</div>
+                        <div tal:condition="image" class="small-8 columns value breakword">${image.name}</div>
                     </div>
                     <div class="row controls-wrapper readonly">
                         <div class="small-4 columns"><label i18n:translate="">Image manifest</label></div>


### PR DESCRIPTION
Also includes a fix to wrap a long image name on the instance detail page.

https://eucalyptus.atlassian.net/browse/GUI-1262
