### PR TITLE
GUI-996: Use more specific labels for scaling policies on scaling group pages

### DIFF
--- a/eucaconsole/static/html/help/console_scaling_group_detail_policies.html
+++ b/eucaconsole/static/html/help/console_scaling_group_detail_policies.html
@@ -20,18 +20,18 @@
 
     
     <div class="topic task nested1" id="general">
-        <h2 class="title topictitle2">Policies</h2>
+        <h2 class="title topictitle2">Scaling Policies</h2>
 
         <p class="shortdesc">This tab allows you to view and manage scaling policies associated with the auto
             scaling group.</p>
 
         <div class="topic task nested2" id="scaling_group_detail_policies_add">
-            <h3 class="title topictitle3">Add a policy</h3>
+            <h3 class="title topictitle3">Add a scaling policy</h3>
 
             <div class="body taskbody">
                 <div class="li step p">
-                        <span class="ph cmd">Click the <span class="ph uicontrol">Add a policy</span> icon to display the
-                                <span class="ph uicontrol">Create scaling policy</span> dialog.</span>
+                        <span class="ph cmd">Click the <span class="ph uicontrol">Add a scaling policy</span> icon to display the
+                                <span class="ph uicontrol">Create scaling policy</span> page.</span>
                     </div>
 
             </div>

--- a/eucaconsole/templates/scalinggroups/scalinggroup_instances.pt
+++ b/eucaconsole/templates/scalinggroups/scalinggroup_instances.pt
@@ -22,7 +22,7 @@
         <div class="large-8 columns">
             <dl class="tabs" id="scalinggroup-subnav">
                 <dd><a href="${request.route_path('scalinggroup_view', id=scaling_group.name)}" i18n:translate="">General</a></dd>
-                <dd><a href="${request.route_path('scalinggroup_policies', id=scaling_group.name)}" i18n:translate="">Policies</a></dd>
+                <dd><a href="${request.route_path('scalinggroup_policies', id=scaling_group.name)}" i18n:translate="">Scaling Policies</a></dd>
                 <dd class="active"><a href="#">Instances</a></dd>
             </dl>
             <div class="panel gridwrapper no-title">

--- a/eucaconsole/templates/scalinggroups/scalinggroup_policies.pt
+++ b/eucaconsole/templates/scalinggroups/scalinggroup_policies.pt
@@ -22,14 +22,14 @@
         <div class="large-8 columns">
             <dl class="tabs" id="scalinggroup-subnav">
                 <dd><a href="${request.route_path('scalinggroup_view', id=scaling_group.name)}" i18n:translate="">General</a></dd>
-                <dd class="active"><a href="#" i18n:translate="">Policies</a></dd>
+                <dd class="active"><a href="#" i18n:translate="">Scaling Policies</a></dd>
                 <dd><a href="${request.route_path('scalinggroup_instances', id=scaling_group.name)}">Instances</a></dd>
             </dl>
             <div class="panel gridwrapper no-title">
                 <div class="tile add" id="add-policy">
                     <a href="${request.route_path('scalinggroup_policy_new', id=scaling_group.name)}">
                         <div class="plus">+</div>
-                        <div i18n:translate="">Add a policy</div>
+                        <div i18n:translate="">Add a scaling policy</div>
                     </a>
                 </div>
                 <div class="tile item policy" tal:repeat="policy policies">

--- a/eucaconsole/templates/scalinggroups/scalinggroup_policy.pt
+++ b/eucaconsole/templates/scalinggroups/scalinggroup_policy.pt
@@ -11,7 +11,7 @@
             <metal:crumbs metal:fill-slot="crumbs">
                 <li><a href="${request.route_path('scalinggroups')}" i18n:translate="">Scaling groups</a></li>
                 <li><a href="${request.route_path('scalinggroup_view', id=scaling_group.name)}">${scaling_group_name}</a></li>
-                <li class="current"><a href="#">Create policy</a></li>
+                <li class="current"><a href="#">Create scaling policy</a></li>
             </metal:crumbs>
         </metal:breadcrumbs>
         <!-- Notifications -->
@@ -52,7 +52,7 @@
                     </div>
                     <div>
                         <button type="submit" class="button" i18n:translate="" id="create-policy-btn" ng-disabled="isNotValid">
-                            Add Policy
+                            Create Scaling Policy
                         </button>
                         <a class="cancel-link" i18n:translate=""
                            href="${request.route_path('scalinggroup_view', id=scaling_group.name)}">Cancel</a>

--- a/eucaconsole/templates/scalinggroups/scalinggroup_view.pt
+++ b/eucaconsole/templates/scalinggroups/scalinggroup_view.pt
@@ -22,7 +22,7 @@
         <div class="large-7 columns">
             <dl class="tabs" id="scalinggroup-subnav">
                 <dd class="active"><a href="#" i18n:translate="">General</a></dd>
-                <dd><a href="${request.route_path('scalinggroup_policies', id=scaling_group.name)}" i18n:translate="">Policies</a></dd>
+                <dd><a href="${request.route_path('scalinggroup_policies', id=scaling_group.name)}" i18n:translate="">Scaling Policies</a></dd>
                 <dd><a href="${request.route_path('scalinggroup_instances', id=scaling_group.name)}" i18n:translate="">Instances</a></dd>
             </dl>
             <div class="panel has-actions">


### PR DESCRIPTION
Also update help text to reflect wording change.

Fixes https://eucalyptus.atlassian.net/browse/GUI-996
