### PR TITLE
GUI-1110 - cancel now working on landing and detail pages.

### DIFF
--- a/eucaconsole/views/images.py
+++ b/eucaconsole/views/images.py
@@ -576,12 +576,12 @@ class ImageView(TaggedItemView, ImageBundlingMixin):
     def get_controller_options_json(self):
         if not self.image:
             return '{}'
-        id = self.image.fake_id or self.image.id
+        image_id = self.image.fake_id or self.image.id
         return BaseView.escape_json(json.dumps({
             'is_public': self.is_public,
             'image_launch_permissions': self.image_launch_permissions,
-            'image_state_json_url': self.request.route_path('image_state_json', id=id),
-            'image_cancel_url': self.request.route_path('image_cancel', id=id),
+            'image_state_json_url': self.request.route_path('image_state_json', id=image_id),
+            'image_cancel_url': self.request.route_path('image_cancel', id=image_id),
             'images_url': self.request.route_path('images'),
         }))
 


### PR DESCRIPTION
set up fake_id for all cases where we've created a fake image record for bundling IS instance. use fake_id for links in image view
