### PR TITLE
GUI-1304: Refactor routes to include the bucket name as a matched URL param

### DIFF
--- a/eucaconsole/routes.py
+++ b/eucaconsole/routes.py
@@ -184,20 +184,20 @@ urls = [
     # Contents/detail pages
     Route(name='bucket_new', pattern='/buckets/new'),
     Route(name='bucket_create', pattern='/buckets/create'),
-    Route(name='bucket_contents', pattern='/bucketcontents/*subpath'),
-    Route(name='bucket_keys', pattern='/bucketkeys/*subpath'),
     Route(name='bucket_details', pattern='/buckets/{name}/details'),
     Route(name='bucket_objects_count_versioning_json', pattern='/buckets/{name}/objectscount.json'),
     Route(name='bucket_update', pattern='/buckets/{name}/update'),
     Route(name='bucket_delete', pattern='/buckets/{name}/delete'),
     Route(name='bucket_delete_keys', pattern='/buckets/{name}/delete_keys'),
     Route(name='bucket_update_versioning', pattern='/buckets/{name}/updateversioning'),
+    Route(name='bucket_contents', pattern='/buckets/{name}/contents/*subpath'),
+    Route(name='bucket_keys', pattern='/buckets/{name}/keys/*subpath'),
     Route(name='bucket_item_details', pattern='/buckets/{name}/itemdetails/*subpath'),
     Route(name='bucket_item_update', pattern='/buckets/{name}/itemupdate/*subpath'),
     Route(name='bucket_put_item', pattern='/buckets/{name}/putitem/*subpath'),
     Route(name='bucket_create_folder', pattern='/buckets/{name}/createfolder/*subpath'),
     Route(name='bucket_upload', pattern='/buckets/{name}/upload/*subpath'),
-    Route(name='bucket_sign_req', pattern='/bucketsignreq/{name}/*subpath'),
+    Route(name='bucket_sign_req', pattern='/buckets/{name}/signreq/*subpath'),
 
 
     # Security Groups #####

--- a/eucaconsole/static/js/pages/bucket_contents.js
+++ b/eucaconsole/static/js/pages/bucket_contents.js
@@ -148,10 +148,10 @@ angular.module('BucketContentsPage', ['LandingPage', 'EucaConsoleUtils'])
                     Notify.failure("some kind of error");
                 });
         };
-        $scope.saveKey = function (path, key) {
+        $scope.saveKey = function (bucket_name, key) {
             var id = $('.open').attr('id');  // hack to close action menu
             $('#table-'+id).trigger('click');
-            Modernizr.localstorage && localStorage.setItem('copy-object-buffer', path+'/'+key);
+            Modernizr.localstorage && localStorage.setItem('copy-object-buffer', bucket_name + '/' + key);
         };
         $scope.$on('itemsLoaded', function($event, items) {
             $scope.items = items;

--- a/eucaconsole/static/js/pages/bucket_upload.js
+++ b/eucaconsole/static/js/pages/bucket_upload.js
@@ -76,7 +76,7 @@ angular.module('UploadFilePage', ['S3SharingPanel', 'S3MetadataEditor'])
             $scope.progress = 0;
             $scope.total = $scope.files.length;
             $scope.uploadFile();
-        }
+        };
         $scope.uploadFile = function($event) {
             var file = $scope.files[$scope.progress];
             var fd = new FormData()

--- a/eucaconsole/templates/buckets/bucket_contents.pt
+++ b/eucaconsole/templates/buckets/bucket_contents.pt
@@ -12,22 +12,25 @@
             <metal:crumbs metal:fill-slot="crumbs">
                 <li><a href="${request.route_path('buckets')}">Buckets</a></li>
                 <li>
-                    <a href="${request.route_path('bucket_contents', subpath=bucket_name)}"
+                    <a href="${request.route_path('bucket_contents', name=bucket_name, subpath='')}"
                        i18n:translate="">${bucket_name}</a>
                 </li>
-                <li tal:repeat="folder request.subpath[1:]" class="${'current' if repeat.folder.end else ''}">
+                <li tal:repeat="folder request.subpath" class="${'current' if repeat.folder.end else ''}">
                     <a tal:condition="repeat.folder.end" ng-non-bindable="">${folder}</a>
-                    <a href="${request.route_path('bucket_contents', subpath='/'.join(request.subpath[:repeat.folder.index+2]))}"
+                    <a href="${request.route_path('bucket_contents', name=bucket_name, subpath=request.subpath[:repeat.folder.index+1])}"
                        ng-non-bindable="" tal:condition="not repeat.folder.end">${folder}</a>
                 </li>
             </metal:crumbs>
         </metal:breadcrumbs>
         <!-- Notifications -->
         <metal:block metal:use-macro="layout.global_macros['notifications']" />
-        <h3 id="pagetitle"><strong i18n:translate="" ng-non-bindable="">${request.subpath[-1]}</strong></h3>
+        <h3 id="pagetitle"><strong i18n:translate="" ng-non-bindable="">
+            ${request.subpath[-1] if request.subpath else bucket_name }
+        </strong></h3>
         <div metal:use-macro="layout.global_macros['landing_page_datagrid']">
             <div metal:fill-slot="new_button">
-                <a class="button" id="upload-file-btn" i18n:translate="" href="${request.route_path('bucket_upload', name=bucket_name, subpath=request.subpath[1:])}">
+                <a class="button" id="upload-file-btn" i18n:translate=""
+                   href="${request.route_path('bucket_upload', name=bucket_name, subpath=request.subpath)}">
                     Upload File(s)
                 </a>
                 &nbsp;&nbsp;
@@ -82,7 +85,7 @@
                         <a i18n:translate="" ng-href="{{ item.download_url }}">Download</a>
                     </li>
                     <li ng-show="!item.is_folder">
-                        <a i18n:translate="" ng-click="saveKey('${bucket_name}', item.name)">Copy object</a>
+                        <a i18n:translate="" ng-click="saveKey('${bucket_name}', item.full_key_name)">Copy object</a>
                     </li>
                     <li ng-show="item.is_folder && hasCopyItem()">
                         <a i18n:translate="" ng-click="doPaste('${bucket_name}', item)">Paste object</a>
@@ -131,7 +134,7 @@
                                 <a i18n:translate="" ng-href="{{ item.download_url }}">Download</a>
                             </li>
                             <li ng-show="!item.is_folder">
-                                <a i18n:translate="" ng-click="saveKey('${display_path}', item.name)">Copy object</a>
+                                <a i18n:translate="" ng-click="saveKey('${bucket_name}', item.full_key_name)">Copy object</a>
                             </li>
                             <li ng-show="item.is_folder && hasCopyItem()">
                                 <a i18n:translate="" ng-click="doPaste('${bucket_name}', item)">Paste object</a>

--- a/eucaconsole/templates/buckets/bucket_item_details.pt
+++ b/eucaconsole/templates/buckets/bucket_item_details.pt
@@ -11,17 +11,14 @@
             <metal:crumbs metal:fill-slot="crumbs">
                 <li><a href="${request.route_path('buckets')}">Buckets</a></li>
                 <li>
-                    <a href="${request.route_path('bucket_contents', subpath=bucket_name)}"
+                    <a href="${request.route_path('bucket_contents', name=bucket_name, subpath='')}"
                        i18n:translate="">${bucket_name}</a>
                 </li>
-                <div tal:repeat="path_item request.subpath" tal:omit-tag="">
-                    <li tal:define="idx repeat.path_item.index"
-                        class="${'current' if repeat.path_item.end else ''}">
-                        <a tal:condition="repeat.path_item.end" ng-non-bindable="">${path_item}</a>
-                        <a href="${request.route_path('bucket_contents', subpath='/{0}/{1}'.format(bucket_name, '/'.join(request.subpath[:idx+1])))}"
-                           ng-non-bindable="" tal:condition="not repeat.path_item.end">${path_item}</a>
-                    </li>
-                </div>
+                <li tal:repeat="folder request.subpath" class="${'current' if repeat.folder.end else ''}">
+                    <a tal:condition="repeat.folder.end" ng-non-bindable="">${folder}</a>
+                    <a href="${request.route_path('bucket_contents', name=bucket_name, subpath=request.subpath[:repeat.folder.index+1])}"
+                       ng-non-bindable="" tal:condition="not repeat.folder.end">${folder}</a>
+                </li>
             </metal:crumbs>
         </metal:breadcrumbs>
         <!-- Notifications -->

--- a/eucaconsole/templates/buckets/bucket_upload.pt
+++ b/eucaconsole/templates/buckets/bucket_upload.pt
@@ -16,12 +16,12 @@
             <metal:crumbs metal:fill-slot="crumbs">
                 <li><a href="${request.route_path('buckets')}" i18n:translate="">Buckets</a></li>
                 <li>
-                    <a href="${request.route_path('bucket_contents', subpath=bucket_name)}"
+                    <a href="${request.route_path('bucket_contents', name=bucket_name, subpath='')}"
                        i18n:translate="">${bucket_name}</a>
                 </li>
                 <li tal:repeat="folder request.subpath" class="${'current' if repeat.folder.end else ''}">
                     <a tal:condition="repeat.folder.end" ng-non-bindable="">${folder}</a>
-                    <a href="${request.route_path('bucket_contents', subpath=bucket_name+'/'+'/'.join(request.subpath[:repeat.folder.index+1]))}"
+                    <a href="${request.route_path('bucket_contents', name=bucket_name, subpath='/'.join(request.subpath[:repeat.folder.index+1]))}"
                        ng-non-bindable="" tal:condition="not repeat.folder.end">${folder}</a>
                 </li>
                 <li class="current"><a href="#" i18n:translate="">Upload file</a></li>
@@ -32,7 +32,9 @@
         <h3 id="pagetitle" i18n:translate="">Upload file</h3>
         <div class="large-7 columns">
             <div class="panel">
-                <form id="upload-file-form" data-abide="abide" ng-cloak="" action="${request.route_path('bucket_upload', name=bucket_name, subpath=request.subpath)}" method="POST" accept-charset="utf-8" enctype="multipart/form-data">
+                <form id="upload-file-form" data-abide="abide" ng-cloak=""
+                      action="${request.route_path('bucket_upload', name=bucket_name, subpath=request.subpath)}"
+                      method="POST" accept-charset="utf-8" enctype="multipart/form-data">
                     ${structure:upload_form['csrf_token']}
                     <h6 class='subheading-label' i18n:translate=''>Select file(s)</h6>
                     <input type="file" id="files" data-file="files" multiple="" name='files'>

--- a/eucaconsole/views/buckets.py
+++ b/eucaconsole/views/buckets.py
@@ -128,7 +128,7 @@ class BucketsJsonView(BaseView):
                 bucket_name = item.name
                 buckets.append(dict(
                     bucket_name=bucket_name,
-                    contents_url=self.request.route_path('bucket_contents', subpath=bucket_name),
+                    contents_url=self.request.route_path('bucket_contents', name=bucket_name, subpath=''),
                     details_url=self.request.route_path('bucket_details', name=bucket_name),
                     creation_date=item.creation_date,
                 ))
@@ -213,7 +213,7 @@ class BucketContentsView(LandingPageView):
         self.bucket_name = self.get_bucket_name(request)
         self.create_folder_form = CreateFolderForm(request, formdata=self.request.params or None)
         self.subpath = request.subpath
-        self.key_prefix = '/'.join(self.subpath[1:]) if len(self.subpath) > 0 else ''
+        self.key_prefix = '/'.join(self.subpath) if len(self.subpath) > 0 else ''
         self.render_dict = dict(
             bucket_name=self.bucket_name,
             create_folder_form=self.create_folder_form,
@@ -330,7 +330,7 @@ class BucketContentsView(LandingPageView):
         if folder_name and self.create_folder_form.validate():
             folder_name = folder_name.replace('/', '_')
             subpath = self.request.subpath
-            prefix = DELIMITER.join(subpath[1:])
+            prefix = DELIMITER.join(subpath)
             new_folder_key = '{0}/{1}/'.format(prefix, folder_name)
             location = self.request.route_path('bucket_contents', name=self.bucket_name, subpath=subpath)
             with boto_error_handler(self.request):
@@ -347,16 +347,14 @@ class BucketContentsView(LandingPageView):
     def get_controller_options_json(self):
         return BaseView.escape_json(json.dumps({
             'delete_keys_url': self.request.route_path('bucket_delete_keys', name=self.bucket_name),
-            'get_keys_url': self.request.route_path('bucket_keys', subpath=self.request.subpath),
+            'get_keys_url': self.request.route_path('bucket_keys', name=self.bucket_name, subpath=self.request.subpath),
             'key_prefix': self.key_prefix,
             'copy_object_url': self.request.route_path('bucket_put_item', name='_name_', subpath='_subpath_'),
         }))
 
     @staticmethod
     def get_bucket_name(request):
-        subpath = request.matchdict.get('subpath')
-        if len(subpath):
-            return subpath[0]
+        return request.matchdict.get('name')
 
     @staticmethod
     def get_unprefixed_key_name(key_name):
@@ -371,8 +369,7 @@ class BucketContentsView(LandingPageView):
 
     @staticmethod
     def get_bucket(request, s3_conn, bucket_name=None):
-        subpath = request.matchdict.get('subpath')
-        bucket_name = bucket_name or request.matchdict.get('name') or subpath[0]
+        bucket_name = bucket_name or request.matchdict.get('name')
         bucket = s3_conn.lookup(bucket_name, validate=False) if bucket_name else None
         if bucket is None:
             raise HTTPNotFound()
@@ -430,7 +427,7 @@ class BucketContentsJsonView(BaseView):
         if not(self.is_csrf_valid()):
             return JSONResponse(status=400, message="missing CSRF token")
         items = []
-        list_prefix = '{0}/'.format(DELIMITER.join(self.subpath[1:])) if len(self.subpath) > 1 else ''
+        list_prefix = '{0}/'.format(DELIMITER.join(self.subpath)) if self.subpath else ''
         params = dict(delimiter=DELIMITER)
         if list_prefix:
             params.update(dict(prefix=list_prefix))
@@ -457,6 +454,7 @@ class BucketContentsJsonView(BaseView):
                 )
             item.update(dict(
                 name=BucketContentsView.get_unprefixed_key_name(key.name),
+                full_key_name=key.name,
                 absolute_path=self.get_absolute_path(key.name),
                 details_url=self.request.route_path('bucket_item_details', name=self.bucket.name, subpath=key.name),
             ))
@@ -468,7 +466,7 @@ class BucketContentsJsonView(BaseView):
         if not(self.is_csrf_valid()):
             return JSONResponse(status=400, message="missing CSRF token")
         items = []
-        list_prefix = '{0}/'.format(DELIMITER.join(self.subpath[1:])) if len(self.subpath) > 1 else ''
+        list_prefix = '{0}/'.format(DELIMITER.join(self.subpath)) if len(self.subpath) > 1 else ''
         params = dict()
         if list_prefix:
             params.update(dict(prefix=list_prefix))
@@ -480,13 +478,14 @@ class BucketContentsJsonView(BaseView):
 
     def get_absolute_path(self, key_name):
         key_name = urllib.quote(key_name, '')
-        return '/bucketcontents/{0}/{1}'.format(self.bucket_name, key_name)
+        # NOTE: Need to hard-code the path here due to escaped key name
+        return '/buckets/{0}/contents/{1}'.format(self.bucket_name, key_name)
 
     def skip_item(self, key):
         """Skip item if it contains a folder path that doesn't match the current request subpath"""
         # Test if request subpath matches current folder
         if DELIMITER in key.name:
-            joined_subpath = DELIMITER.join(self.subpath[1:])
+            joined_subpath = DELIMITER.join(self.subpath)
             if key.name == '{0}{1}'.format(joined_subpath, DELIMITER):
                 return True
             else:
@@ -521,7 +520,7 @@ class BucketDetailsView(BaseView):
             versioning_status=self.versioning_status,
             update_versioning_action=self.get_versioning_update_action(self.versioning_status),
             logging_status=self.get_logging_status(),
-            bucket_contents_url=self.request.route_path('bucket_contents', subpath=self.bucket.name),
+            bucket_contents_url=self.request.route_path('bucket_contents', name=self.bucket.name, subpath=''),
             bucket_objects_count_url=self.request.route_path(
                 'bucket_objects_count_versioning_json', name=self.bucket.name)
         )
@@ -795,8 +794,8 @@ class BucketItemDetailsView(BaseView):
             self.bucket_item_name = new_name
 
     def get_cancel_link_url(self):
-        subpath = '{0}/{1}'.format(self.bucket_name, DELIMITER.join(self.request.subpath[:-1]))
-        return self.request.route_path('bucket_contents', subpath=subpath)
+        subpath = DELIMITER.join(self.request.subpath[:-1])
+        return self.request.route_path('bucket_contents', name=self.bucket_name, subpath=subpath)
 
     @staticmethod
     def get_last_modified_time(bucket_object):


### PR DESCRIPTION
... to allow the subpath to be a consistent prefix.

Implements https://eucalyptus.atlassian.net/browse/GUI-1304

Also includes the following changes…
- Fix Paste Object operation when Copy Object menu item is clicked from the bucket contents table view.
- Use consistent code for breadcrumbs across bucket contents and object details page.
