### PR TITLE
GUI-1318: Prevent unexpected alert dialog when switching between manual and canned ACL option in sharing panel...

### DIFF
--- a/eucaconsole/static/js/pages/bucket_details.js
+++ b/eucaconsole/static/js/pages/bucket_details.js
@@ -68,7 +68,7 @@ angular.module('BucketDetailsPage', ['S3SharingPanel'])
         $scope.handleUnsavedSharingEntry = function (form) {
             // Display warning when there's an unsaved Sharing Panel entry
             form.on('submit', function (event) {
-                var accountInputField = form.find('#share_account');
+                var accountInputField = form.find('#share_account:visible');
                 if (accountInputField.length && accountInputField.val() != '') {
                     event.preventDefault();
                     $scope.isSubmitted = false;

--- a/eucaconsole/static/js/pages/bucket_item_details.js
+++ b/eucaconsole/static/js/pages/bucket_item_details.js
@@ -49,7 +49,7 @@ angular.module('BucketItemDetailsPage', ['S3SharingPanel', 'S3MetadataEditor'])
         $scope.handleUnsavedSharingEntry = function (form) {
             // Display warning when there's an unsaved Sharing Panel entry
             form.on('submit', function (event) {
-                var accountInputField = form.find('#share_account');
+                var accountInputField = form.find('#share_account:visible');
                 if (accountInputField.length && accountInputField.val() != '') {
                     event.preventDefault();
                     $scope.isSubmitted = false;

--- a/eucaconsole/static/js/pages/bucket_upload.js
+++ b/eucaconsole/static/js/pages/bucket_upload.js
@@ -58,7 +58,7 @@ angular.module('UploadFilePage', ['S3SharingPanel', 'S3MetadataEditor'])
         $scope.handleUnsavedSharingEntry = function (form) {
             // Display warning when there's an unsaved Sharing Panel entry
             form.on('submit', function (event) {
-                var accountInputField = form.find('#share_account');
+                var accountInputField = form.find('#share_account:visible');
                 if (accountInputField.length && accountInputField.val() != '') {
                     event.preventDefault();
                     $scope.isSubmitted = false;


### PR DESCRIPTION
...when the account ID input field is populated.

Fixes https://eucalyptus.atlassian.net/browse/GUI-1318
