### PR TITLE
GUI-1198 Clear the flag when reopening the create keypair modal on the launch con...

### DIFF
--- a/eucaconsole/static/js/pages/launchconfig_wizard.js
+++ b/eucaconsole/static/js/pages/launchconfig_wizard.js
@@ -371,6 +371,15 @@ angular.module('LaunchConfigWizard', ['ImagePicker', 'BlockDeviceMappingEditor',
             $scope.summarySection.find('.step1').removeClass('hide');
             $scope.checkRequiredInput();
         });
+        $scope.showCreateKeypairModal = function() {
+            $scope.showKeyPairMaterial = false;
+            var form = $('#launch-config-form');
+            var invalid_attr = 'data-invalid';
+            form.removeAttr(invalid_attr);
+            $(invalid_attr, form).removeAttr(invalid_attr);
+            $('.error', form).not('small').removeClass('error');
+            $scope.keyPairModal.foundation('reveal', 'open');
+        };
         $scope.downloadKeyPair = function ($event, downloadUrl) {
             $event.preventDefault();
             var form = $($event.target);

--- a/eucaconsole/templates/launchconfigs/launchconfig_wizard.pt
+++ b/eucaconsole/templates/launchconfigs/launchconfig_wizard.pt
@@ -106,7 +106,7 @@
                                 <div class="row">
                                     <div class="small-8 columns right" id="create-keypair-link">
                                         <span class="or" i18n:translate="">Or: </span>
-                                        <a data-reveal-id="create-keypair-modal" i18n:translate="">Create key pair</a>
+                                        <a ng-click="showCreateKeypairModal()" i18n:translate="">Create key pair</a>
                                     </div>
                                 </div>
                             </div>


### PR DESCRIPTION
...fig wizard
https://eucalyptus.atlassian.net/browse/GUI-1198

The function $scope.showCreateKeypairModal() was copied to match what's in place for the instance launch wizard.
