### PR TITLE
GUI-1235: Fix placement of validation error messages for reversed input fields

### DIFF
--- a/eucaconsole/static/css/eucaconsole.css
+++ b/eucaconsole/static/css/eucaconsole.css
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 /* @fileOverview Koala application-wide Sass CSS styles */
 /* Sass Imports */
 /*! normalize.css v2.1.2 | MIT License | git.io/normalize */
@@ -1524,10 +1525,9 @@ form .error .chosen-container .chosen-single { border-color: darkred; background
 .row.controls-wrapper label { padding-top: 4px; font-weight: bold; text-align: right; line-height: 1rem; }
 .row.controls-wrapper label select, .row.controls-wrapper label input, .row.controls-wrapper label .chosen-container { text-align: left; }
 .row.controls-wrapper label.nowrap { white-space: nowrap; }
-.row.controls-wrapper label.reverse { display: inline-block; text-align: left; position: relative; left: 1.5rem; }
+.row.controls-wrapper label.reverse { display: inline-block; text-align: left; position: relative; left: -1rem; }
 .row.controls-wrapper .helptext-icon.reverse { position: relative; left: 1.5rem; }
-.row.controls-wrapper div.reverse { position: relative; }
-.row.controls-wrapper div.reverse input { position: absolute; right: -2rem; top: 5px; }
+.row.controls-wrapper .reverse .error { white-space: nowrap; }
 .row.controls-wrapper .checkbox-row { margin-left: 1rem; }
 .row.controls-wrapper .field input { display: inline-block; margin-bottom: 0.3rem; }
 .row.controls-wrapper .field select { margin-bottom: 0.3rem; margin-top: 0.3rem; padding-top: 6px; padding-bottom: 6px; }

--- a/eucaconsole/static/sass/eucaconsole.scss
+++ b/eucaconsole/static/sass/eucaconsole.scss
@@ -664,18 +664,15 @@ form {
         display: inline-block;
         text-align: left;
         position: relative;
-        left: 1.5rem;
+        left: -1rem;
     }
     .helptext-icon.reverse {
         position: relative;
         left: 1.5rem;
     }
-    div.reverse {
-        position: relative;
-        input {
-            position: absolute;
-            right: -2rem;
-            top: 5px;
+    .reverse {
+        .error {
+            white-space: nowrap;
         }
     }
     .checkbox-row {


### PR DESCRIPTION
Primarily for quota inputs on various IAM pages.

Fixes https://eucalyptus.atlassian.net/browse/GUI-1235
