### PR TITLE
GUI-1160 Prevent the Internal Server Error page by checking the return value of g...

### DIFF
--- a/eucaconsole/views/scalinggroups.py
+++ b/eucaconsole/views/scalinggroups.py
@@ -72,7 +72,7 @@ class DeleteScalingGroupMixin(object):
                         else:
                             if not str(instance._state).startswith('terminated') and not str(instance._state).startswith('shutting-down'):
                                 is_all_shutdown = False
-                    time.sleep(3)
+                    time.sleep(5)
                 count += 1
         return
 
@@ -133,7 +133,10 @@ class ScalingGroupsView(LandingPageView, DeleteScalingGroupMixin):
 
     def get_scaling_group_by_name(self, name):
         names = [name]
-        return self.autoscale_conn.get_all_groups(names)[0] if self.autoscale_conn else []
+        scaling_groups = self.autoscale_conn.get_all_groups(names) if self.autoscale_conn else []
+        if scaling_groups:
+            return scaling_groups[0]
+        return [] 
 
     @staticmethod
     def get_sort_keys():


### PR DESCRIPTION
...et_scaling_groups call

Extend the wait time to 3 mins

https://eucalyptus.atlassian.net/browse/GUI-1160

This is not a complete solution for GUI-1160, but this patch is needed to prevent Internal server error page from occurring when trying to delete the scaling group that has already been deleted. See the ticket above for the issue, but do not close the ticket. It's been moved to 4.2.
