### PR TITLE
Disable SSLv3 in nginx.conf

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -46,6 +46,7 @@ http {
         server_name  localhost;
 
         # SSL configuration
+        ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
         # listen 443 ssl;
         # ssl_certificate /path/to/ssl/pem_file;
         # ssl_certificate_key /path/to/ssl/certificate_key;


### PR DESCRIPTION
Restrict to TLS, per nginx documentation at http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_protocols

https://eucalyptus.atlassian.net/browse/GUI-1372
