### PR TITLE
GUI-1171: Simplify markup and cleanup CSS for health status tile on dashboard

### DIFF
--- a/eucaconsole/static/css/pages/dashboard.css
+++ b/eucaconsole/static/css/pages/dashboard.css
@@ -54,11 +54,9 @@
 
 #roles .icon { background-image: url(../../img/svg/icon_IAM_roles.svg); }
 
-/* Small screen */
 #service-unknown { margin-top: 13px; }
 
-#service-up i { color: #03405f; font-size: 16pt; text-align: left; }
-
-#service-down i { color: red; font-size: 16pt; text-align: left; }
-
-#status { font-size: 11pt; text-align: left; font-style: normal; font-weight: normal; color: #6a737b; margin-top: 9px; margin-bottom: 0; }
+#health .statusrow { font-size: 11pt; text-align: left; color: #6a737b; margin-top: 10px; line-height: 1.4rem; }
+#health .statusrow .status { position: relative; left: 8px; }
+#health .statusrow i.service-up { color: #03405f; font-size: 16pt; text-align: left; }
+#health .statusrow i.service-down { color: red; font-size: 16pt; text-align: left; }

--- a/eucaconsole/static/sass/pages/dashboard.scss
+++ b/eucaconsole/static/sass/pages/dashboard.scss
@@ -156,39 +156,33 @@ $tile-row-height: 24px;
 #groups .icon { background-image: url(../../img/svg/IAM_group.svg); }
 #roles .icon { background-image: url(../../img/svg/icon_IAM_roles.svg); }
 
-// --- Media queries
-// --------------------
-//
-
-
-/* Small screen */
-@media screen and (max-width: 480px) {
-
-}
 
 #service-unknown {
     margin-top: 13px;
 }
 
 
-#service-up i {
-    color:$euca-darkblue;
-    font-size: 16pt;
-    text-align: left;
-}
-
-#service-down i {
-    color:red;
-    font-size: 16pt;
-    text-align: left;
-}
-
-#status {
-    font-size: 11pt;
-    text-align: left;
-    font-style: normal;
-    font-weight: normal;
-    color: $euca-grey;
-    margin-top: 9px;
-    margin-bottom: 0;
+// Health status tile
+#health {
+    .statusrow {
+        font-size: 11pt;
+        text-align: left;
+        color: $euca-grey;
+        margin-top: 10px;
+        line-height: 1.4rem;
+        .status {
+            position: relative;
+            left: 8px;
+        }
+        i.service-up {
+            color:$euca-darkblue;
+            font-size: 16pt;
+            text-align: left;
+        }
+        i.service-down {
+            color:red;
+            font-size: 16pt;
+            text-align: left;
+        }
+    }
 }

--- a/eucaconsole/templates/dashboard.pt
+++ b/eucaconsole/templates/dashboard.pt
@@ -243,21 +243,15 @@
                             <metal:block metal:use-macro="layout.global_macros['dashaction']" />
                             <i class="icon"><em><span class="dots" ng-show="health.length == 0">&nbsp;</span></em></i>
                             <div class="content">
-                                 <div ng-repeat="service in health">
-                                    <div class="row controls-wrapper readonly">
-                                        <div class="small-9 columns">
-                                            <label id="status">{{ service.name }}</label>
-                                        </div>
-                                        <div class="small-3 columns right" id="service-unknown" ng-show="service.status==''">
-                                            <span class="dots">&nbsp;</span>
-                                        </div>
-                                        <div class="small-3 columns right" id="service-up" ng-show="service.status=='up'">
-                                            <i class="fi-check tick" title="Service is up" i18n:translate="title" data-tooltip=""></i>
-                                        </div>
-                                        <div class="small-3 columns right" id="service-down" ng-show="service.status=='down'">
-                                            <i class="fi-x tick" title="Service is not responding" i18n:translate="title" data-tooltip=""></i>
-                                        </div>
-                                    </div>
+                                 <div ng-repeat="service in health" class="statusrow">
+                                     <span class="status">{{ service.name }}</span>
+                                     <span class="right">
+                                         <span class="dots" ng-show="service.status == ''">&nbsp;</span>
+                                         <i class="fi-check tick service-up" title="Service is up"
+                                            i18n:translate="title" data-tooltip="" ng-show="service.status == 'up'"></i>
+                                         <i class="fi-x tick service-down" title="Service is not responding"
+                                            i18n:translate="title" data-tooltip="" ng-show="service.status=='down'"></i>
+                                     </span>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
...preventing status rows from appearing as links.  Remove unused media query.

Fixes https://eucalyptus.atlassian.net/browse/GUI-1171
