### PR TITLE
GUI-1022: Prevent error validation notice for policy name field when a canned policy is selected in the IAM policy generator

### DIFF
--- a/eucaconsole/static/js/pages/iam_policy_wizard.js
+++ b/eucaconsole/static/js/pages/iam_policy_wizard.js
@@ -154,11 +154,14 @@ angular.module('IAMPolicyWizard', ['EucaConsoleUtils'])
             $('.tabs').find('a').on('click', function (evt) {
                 var tabLinkId = $(evt.target).closest('a').attr('id');
                 Modernizr.localstorage && localStorage.setItem($scope.lastSelectedTabKey, tabLinkId);
-                if (tabLinkId === 'custom-policy-tab' && $scope.policyStatements.length) {
-                    // Load selected policy statements if switching back to custom policy tab
-                    $timeout(function() {
-                        $scope.updatePolicy();
-                    }, 100);
+                if (tabLinkId === 'custom-policy-tab') {
+                    $scope.setPolicyName('custom');
+                    if ($scope.policyStatements.length) {
+                        // Load selected policy statements if switching back to custom policy tab
+                        $timeout(function () {
+                            $scope.updatePolicy();
+                        }, 100);
+                    }
                 }
             });
             $('#' + lastSelectedTab).click();
@@ -221,13 +224,11 @@ angular.module('IAMPolicyWizard', ['EucaConsoleUtils'])
                 'custom': 'CustomAccessPolicy'
             };
             $scope.policyName = typeNameMapping[policyType] + '-' + $scope.urlParams['id'] + '-' + $scope.timestamp;
-            if (policyType === 'custom') {
-                // Prevent lingering validation error on policy name field
-                $timeout(function() {
-                    $('#name').trigger('focus');
-                    $('.CodeMirror').find('textarea').focus();
-                }, 200);
-            }
+            // Prevent lingering validation error on policy name field
+            $timeout(function() {
+                $('#name').trigger('focus');
+                $('.CodeMirror').find('textarea').focus();
+            }, 100);
         };
         $scope.handlePolicyFileUpload = function () {
             $('#policy_file').on('change', function(evt) {

--- a/eucaconsole/templates/policies/iam_policy_wizard.pt
+++ b/eucaconsole/templates/policies/iam_policy_wizard.pt
@@ -39,7 +39,7 @@
                         </a>
                     </dd>
                     <dd>
-                        <a id="custom-policy-tab" href="#step2">
+                        <a id="custom-policy-tab" href="#step2" ng-click="selectPolicy('custom')">
                             <b i18n:translate="">Create a custom policy</b>
                         </a>
                     </dd>


### PR DESCRIPTION
Fixes https://eucalyptus.atlassian.net/browse/GUI-1022
