### PR TITLE
GUI-1408: Strip double-quotes from ETag on S3/OSG object details page

### DIFF
--- a/eucaconsole/templates/buckets/bucket_item_details.pt
+++ b/eucaconsole/templates/buckets/bucket_item_details.pt
@@ -67,7 +67,7 @@
                     </div>
                     <div class="row controls-wrapper readonly">
                         <div class="small-4 columns"><label i18n:translate="">ETag</label></div>
-                        <div class="small-8 columns value">${bucket_item.etag}</div>
+                        <div class="small-8 columns value">${bucket_item.etag.replace('"', '')}</div>
                     </div>
                     <div class="row controls-wrapper readonly">
                         <div class="small-4 columns"><label i18n:translate="">Link</label></div>


### PR DESCRIPTION
Fixes https://eucalyptus.atlassian.net/browse/GUI-1408
