### PR TITLE
GUI-1465: Use proper filter for VPC ID when fetching subnets in form choices manager

### DIFF
--- a/eucaconsole/forms/__init__.py
+++ b/eucaconsole/forms/__init__.py
@@ -417,7 +417,7 @@ class ChoicesManager(object):
         vpc_subnet_list = vpc_subnets or []
         if not vpc_subnet_list and self.conn is not None:
             if vpc_id:
-                vpc_subnet_list = self.conn.get_all_subnets(filters={'vpcId': [vpc_id]})
+                vpc_subnet_list = self.conn.get_all_subnets(filters={'vpc-id': [vpc_id]})
             else:
                 vpc_subnet_list = self.conn.get_all_subnets()
         for vpc in vpc_subnet_list:

--- a/eucaconsole/views/scalinggroups.py
+++ b/eucaconsole/views/scalinggroups.py
@@ -359,7 +359,7 @@ class ScalingGroupView(BaseScalingGroupView, DeleteScalingGroupMixin):
                 if vpc_subnet:
                     this_subnet = vpc_subnet[0]
                     if this_subnet and this_subnet.vpc_id:
-                        this_vpc = self.vpc_conn.get_all_vpcs(vpc_ids=this_subnet.vpc_id)
+                        this_vpc = self.vpc_conn.get_all_vpcs(vpc_ids=[this_subnet.vpc_id])
                         if this_vpc:
                             return this_vpc[0]
         return None


### PR DESCRIPTION
… Also modify VPCs fetch for scaling group page to pass a list to match what Boto documents for the get_all_vpcs() call.

Fixes https://eucalyptus.atlassian.net/browse/GUI-1465
