### PR TITLE
GUI-1464 In case of missing VPC network name, use the VPC network Id instead for ...

### DIFF
--- a/eucaconsole/static/js/pages/scalinggroup_wizard.js
+++ b/eucaconsole/static/js/pages/scalinggroup_wizard.js
@@ -180,6 +180,9 @@ angular.module('ScalingGroupWizard', ['AutoScaleTagEditor'])
                     var vpcNetworkNameArray = $(this).text().split(' ');
                     vpcNetworkNameArray.pop();
                     $scope.vpcNetworkName = vpcNetworkNameArray.join(' ');
+                    if ($scope.vpcNetworkName == '') {
+                        $scope.vpcNetworkName = $scope.vpcNetwork;
+                    }
                 } 
             });
         };


### PR DESCRIPTION
...display on the wizard summary
https://eucalyptus.atlassian.net/browse/GUI-1464
