### PR TITLE
GUI-1525 On AWS, the 'Default' option in the Termination policies needs to be at ...

### DIFF
--- a/eucaconsole/views/scalinggroups.py
+++ b/eucaconsole/views/scalinggroups.py
@@ -353,6 +353,10 @@ class ScalingGroupView(BaseScalingGroupView, DeleteScalingGroupMixin):
         else:
             self.scaling_group.availability_zones = ''
         self.scaling_group.termination_policies = self.request.params.getall('termination_policies')
+        # on AWS, the option 'Default' must appear at the end of the list
+        if 'Default' in self.scaling_group.termination_policies:
+            self.scaling_group.termination_policies.remove('Default')
+            self.scaling_group.termination_policies.append('Default')
         self.scaling_group.max_size = self.request.params.get('max_size', 1)
         self.scaling_group.min_size = self.request.params.get('min_size', 0)
         self.scaling_group.health_check_type = self.request.params.get('health_check_type')


### PR DESCRIPTION
...the end of the list when updating the scaling group

https://eucalyptus.atlassian.net/browse/GUI-1525