### PR TITLE
GUI-1551: Escape double curly braces in image description field on image details page

### DIFF
--- a/eucaconsole/forms/images.py
+++ b/eucaconsole/forms/images.py
@@ -33,6 +33,7 @@ from wtforms import validators
 from ..constants.images import EUCA_IMAGE_OWNER_ALIAS_CHOICES, AWS_IMAGE_OWNER_ALIAS_CHOICES
 
 from ..i18n import _
+from ..views import BaseView
 from . import BaseSecureForm, TextEscapedField
 
 
@@ -56,7 +57,7 @@ class ImageForm(BaseSecureForm):
         self.description.error_msg = self.desc_error_msg
 
         if image is not None:
-            self.description.data = image.description
+            self.description.data = BaseView.escape_braces(image.description)
 
 
 class DeregisterImageForm(BaseSecureForm):

--- a/eucaconsole/views/images.py
+++ b/eucaconsole/views/images.py
@@ -439,7 +439,7 @@ class ImageView(TaggedItemView, ImageBundlingMixin):
 
             if self.image and self.is_owned_by_user is True:
                 # Update the Image Description
-                description = self.request.params.get('description', '')
+                description = BaseView.unescape_braces(self.request.params.get('description', ''))
                 if self.image.description != description:
                     if self.cloud_type == 'aws' and description == '':
                         description = "-"

--- a/tests/auth/test_changepassword.py
+++ b/tests/auth/test_changepassword.py
@@ -59,7 +59,6 @@ class EucaChangePasswordTestCase(BaseTestCase):
     new_password = 'newpass'
     duration = 3600
 
-
     def test_euca_authentication_failure(self):
         kwargs = dict(account=self.account, user=self.username, passwd=self.current_password,
                       new_passwd=self.new_password, duration=self.duration)

--- a/tests/images/test_images.py
+++ b/tests/images/test_images.py
@@ -36,7 +36,7 @@ from eucaconsole.forms.images import ImageForm
 from eucaconsole.views import TaggedItemView
 from eucaconsole.views.images import ImagesView, ImageView
 
-from tests import BaseViewTestCase, BaseFormTestCase
+from tests import BaseViewTestCase, BaseFormTestCase, Mock
 
 
 class ImagesViewTests(BaseViewTestCase):
@@ -78,4 +78,15 @@ class ImageFormTestCase(BaseFormTestCase):
     def test_secure_form(self):
         self.has_field('csrf_token')
 
+
+class ImageFormDescriptionTestCase(BaseFormTestCase):
+    form_class = ImageForm
+    request = testing.DummyRequest()
+    image = Mock()
+    image.description = '{{ 1 + 2 }}'
+    form = form_class(request, image=image)
+
+    def test_angular_expression_escaping_on_image_update_form(self):
+        self.assertNotEqual(self.form.description.data, '{{ 1 + 2 }}')
+        self.assertEqual(self.form.description.data, '&#123;&#123; 1 + 2 &#125;&#125;')
 


### PR DESCRIPTION
Fixes https://eucalyptus.atlassian.net/browse/GUI-1551