### PR TITLE
GUI-1579: Don't pass addressing_type when launching VPC instances on Eucalyptus

### DIFF
--- a/eucaconsole/templates/instances/instance_launch.pt
+++ b/eucaconsole/templates/instances/instance_launch.pt
@@ -189,7 +189,7 @@
                                 ${structure:launch_form.monitoring_enabled(**{'ng-model': 'monitoringEnabled'})}
                                 ${launch_form['monitoring_enabled'].label}
                             </div>
-                            <div class="small-8 columns right" tal:condition="layout.cloud_type == 'euca'">
+                            <div class="small-8 columns right" tal:condition="layout.cloud_type == 'euca' and not is_vpc_supported">
                                 ${structure:launch_form.private_addressing(**{'ng-model': 'privateAddressing'})}
                                 ${launch_form['private_addressing'].label}
                             </div>

--- a/eucaconsole/views/instances.py
+++ b/eucaconsole/views/instances.py
@@ -1037,6 +1037,8 @@ class InstanceLaunchView(BaseInstanceView, BlockDeviceMappingItemView):
             monitoring_enabled = self.request.params.get('monitoring_enabled') == 'y'
             private_addressing = self.request.params.get('private_addressing') == 'y'
             addressing_type = 'private' if private_addressing else 'public'
+            if vpc_network is not None and self.cloud_type == 'euca':
+                addressing_type = None  # Don't pass addressing scheme if on Euca VPC
             bdmapping_json = self.request.params.get('block_device_mapping')
             block_device_map = self.get_block_device_map(bdmapping_json)
             role = self.request.params.get('role')
@@ -1204,6 +1206,8 @@ class InstanceLaunchMoreView(BaseInstanceView, BlockDeviceMappingItemView):
             monitoring_enabled = self.request.params.get('monitoring_enabled') == 'y'
             private_addressing = self.request.params.get('private_addressing') == 'y'
             addressing_type = 'private' if private_addressing else 'public'
+            if vpc_network is not None and self.cloud_type == 'euca':
+                addressing_type = None  # Don't pass addressing scheme if on Euca VPC
             if self.cloud_type == 'aws':  # AWS only supports public, so enforce that here
                 addressing_type = 'public'
             bdmapping_json = self.request.params.get('block_device_mapping')


### PR DESCRIPTION
EUCA-10308 modified how the addressing_type param is accepted, rejecting 'private' when a VPC instance is launch.  This fix accounts for the updated behavior.

https://eucalyptus.atlassian.net/browse/GUI-1579

Note: Do not merge this unless GUI-1579 is scoped for 4.1