### PR TITLE
GUI-1590 handle smart-refresh better with multiple getItems() callers

### DIFF
--- a/eucaconsole/static/js/pages/landingpage.js
+++ b/eucaconsole/static/js/pages/landingpage.js
@@ -10,6 +10,7 @@ angular.module('LandingPage', ['CustomFilters', 'ngSanitize', 'MagicSearch'])
         $http.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
         $scope.items = [];
         $scope.itemsLoading = true;
+        $scope.runningSmartRefresh = false;
         $scope.unfilteredItems = [];
         $scope.filterKeys = [];
         $scope.sortBy = '';
@@ -140,7 +141,7 @@ angular.module('LandingPage', ['CustomFilters', 'ngSanitize', 'MagicSearch'])
                     'aws-region', $('#region-dropdown').children('li[data-selected="True"]').children('a').attr('id'));
             }
         };
-        $scope.getItems = function () {
+        $scope.getItems = function (okToRefresh) {
             var csrf_token = $('#csrf_token').val();
             var data = "csrf_token="+csrf_token;
             $http({method:'POST', url:$scope.jsonEndpoint, data:data,
@@ -157,7 +158,13 @@ angular.module('LandingPage', ['CustomFilters', 'ngSanitize', 'MagicSearch'])
                 });
                 // Auto-refresh items if any are in a transitional state
                 if ($scope.transitionalRefresh && transitionalCount > 0) {
-                    $timeout(function() { $scope.getItems(); }, 5000);  // Poll every 5 seconds
+                    if ($scope.runningSmartRefresh == false || okToRefresh !== undefined) {
+                        $scope.runningSmartRefresh = true;
+                        $timeout(function() { $scope.getItems(true); }, 5000);  // Poll every 5 seconds
+                    }
+                }
+                else {
+                    $scope.runningSmartRefresh = false;
                 }
                 // Emit 'itemsLoaded' signal when items[] is updated
                 $timeout(function() {

--- a/eucaconsole/static/js/pages/landingpage.js
+++ b/eucaconsole/static/js/pages/landingpage.js
@@ -158,7 +158,7 @@ angular.module('LandingPage', ['CustomFilters', 'ngSanitize', 'MagicSearch'])
                 });
                 // Auto-refresh items if any are in a transitional state
                 if ($scope.transitionalRefresh && transitionalCount > 0) {
-                    if ($scope.runningSmartRefresh == false || okToRefresh !== undefined) {
+                    if (!$scope.runningSmartRefresh || okToRefresh !== undefined) {
                         $scope.runningSmartRefresh = true;
                         $timeout(function() { $scope.getItems(true); }, 5000);  // Poll every 5 seconds
                     }


### PR DESCRIPTION
handle smart-refresh better with multiple getItems() callers

https://eucalyptus.atlassian.net/browse/GUI-1590

The changes are these:

add state variable to indicate smart refresh is already happening, so we can avoid starting a new one.
reset that variable when no state requiring smart refresh is in the table
pass optional value into getItems() so that we can know when it was called from existing smart refresh timeout
This works well. It refreshes properly with no filters. As filters are added, the single refresh timeout is the only one running and the new filters are used. If the transient item is filtered out, smart refresh halts after the next cycle. If a transient item is brought back in by a filter change, smart refresh initiates properly again. This change fixes the mult-fetch problem seen prior.