### PR TITLE
GUI-1608: Reference instance IP rather than FQDN in Connect to Instance dialog's SSH instructions

### DIFF
--- a/eucaconsole/static/js/pages/instances.js
+++ b/eucaconsole/static/js/pages/instances.js
@@ -44,6 +44,7 @@ angular.module('InstancesPage', ['LandingPage', 'EucaConsoleUtils'])
             }
             $scope.instanceID = instance['id'];
             $scope.instanceName = instance['name'];
+            $scope.instancePublicIP = instance['ip_address'];
             $scope.rootDevice = instance['root_device'];
             $scope.groupName = securityGroupName;
             $scope.securityGroups = securityGroups;

--- a/eucaconsole/templates/dialogs/instance_dialogs.pt
+++ b/eucaconsole/templates/dialogs/instance_dialogs.pt
@@ -150,7 +150,7 @@
                     </li>
                     <li>
                         <span i18n:translate="">Connect to your instance via its public IP address by running the following command:</span><br/>
-                        <strong>ssh -i {{ keyName }}.pem root@{{ publicDNS }}</strong>
+                        <strong>ssh -i {{ keyName }}.pem root@{{ instancePublicIP }}</strong>
                     </li>
                 </ol>
             </div>

--- a/eucaconsole/views/instances.py
+++ b/eucaconsole/views/instances.py
@@ -326,6 +326,7 @@ class InstancesView(LandingPageView, BaseInstanceView):
             return HTTPFound(location=self.location)
         return self.render_dict
 
+
 class InstancesJsonView(LandingPageView):
     def __init__(self, request):
         super(InstancesJsonView, self).__init__(request)
@@ -701,7 +702,7 @@ class InstanceView(TaggedItemView, BaseInstanceView):
         if self.instance and self.associate_ip_form.validate():
             with boto_error_handler(self.request, self.location):
                 new_ip = self.request.params.get('ip_address')
-                address=self.get_ip_address(new_ip)
+                address = self.get_ip_address(new_ip)
                 if address and address.allocation_id:
                     self.conn.associate_address(self.instance.id, new_ip, allocation_id=address.allocation_id)
                 else:


### PR DESCRIPTION
Fixes https://eucalyptus.atlassian.net/browse/GUI-1608