### PR TITLE
GUI-1643: Disallow non-ASCII chars in security group description for API compatibility

### DIFF
--- a/eucaconsole/forms/securitygroups.py
+++ b/eucaconsole/forms/securitygroups.py
@@ -37,14 +37,19 @@ from . import BaseSecureForm, ChoicesManager, TextEscapedField, ASCII_WITHOUT_SL
 
 class SecurityGroupForm(BaseSecureForm):
     """Security Group form
-       Note: no need to add a 'tags' field.  Use the tag_editor panel (in a template) instead
+       Constraints for VPC security group name/desc: a-z, A-Z, 0-9, spaces, and ._-:/()#,@[]+=;{}!$*
+       See http://docs.aws.amazon.com/cli/latest/reference/ec2/create-security-group.html
     """
     name_error_msg = ASCII_WITHOUT_SLASHES_NOTICE
     name = wtforms.TextField(
         label=_(u'Name'),
         validators=[validators.DataRequired(message=name_error_msg)],
     )
-    desc_error_msg = _(u'Description is required')
+    sgroup_description_pattern = r'^[a-zA-Z0-9\s\._\-:\/\(\)#,@\[\]\+=;\{\}!\$\*]+$'
+    DESCRIPTION_RESTRICTION_NOTICE = _(
+        u'Description is required, must be between 1 and 255 characters, and may only contain '
+        u'letters, numbers, spaces, and select special characters')
+    desc_error_msg = DESCRIPTION_RESTRICTION_NOTICE
     description = wtforms.TextAreaField(
         label=_(u'Description'),
         validators=[
@@ -60,7 +65,6 @@ class SecurityGroupForm(BaseSecureForm):
         self.name.error_msg = self.name_error_msg  # Used for Foundation Abide error message
         self.description.error_msg = self.desc_error_msg  # Used for Foundation Abide error message
         self.vpc_choices_manager = ChoicesManager(conn=vpc_conn)
-        region = request.session.get('region')
         self.cloud_type = request.session.get('cloud_type', 'euca')
         from ..views import BaseView
         self.is_vpc_supported = BaseView.is_vpc_supported(request)

--- a/eucaconsole/templates/securitygroups/securitygroup_view.pt
+++ b/eucaconsole/templates/securitygroups/securitygroup_view.pt
@@ -58,7 +58,7 @@
                         <div class="small-9 columns field inline breakword">${security_group_name}</div>
                     </div>
                     <div tal:condition="not security_group" tal:omit-tag="">
-                        ${panel('form_field', field=securitygroup_form['description'], ng_attrs={'model': 'securityGroupDescription'}, leftcol_width=3, rightcol_width=9)}
+                        ${panel('form_field', field=securitygroup_form['description'], ng_attrs={'model': 'securityGroupDescription'}, leftcol_width=3, rightcol_width=9, **{'pattern': securitygroup_form.sgroup_description_pattern})}
                     </div>
                     <div class="row controls-wrapper readonly" tal:condition="security_group and security_group.description">
                         <div class="small-3 columns"><label i18n:translate="">Description</label></div>

--- a/tests/securitygroups/test_securitygroups.py
+++ b/tests/securitygroups/test_securitygroups.py
@@ -30,6 +30,8 @@ Security Group tests
 See http://docs.pylonsproject.org/projects/pyramid/en/latest/narr/testing.html
 
 """
+import re
+
 from pyramid import testing
 
 from eucaconsole.forms.securitygroups import SecurityGroupForm, SecurityGroupDeleteForm
@@ -106,6 +108,20 @@ class SecurityGroupFormTestCase(BaseFormTestCase):
         self.assertTrue(hasattr(self.form.name.flags, 'required'))
         self.assertTrue('required' in fieldrow.get('html_attrs').keys())
         self.assertTrue(fieldrow.get('html_attrs').get('maxlength') is not None)
+
+    def test_description_constraint(self):
+        valid_pattern = self.form.sgroup_description_pattern
+        matches = (
+            (u'foo123', True),
+            (u'foo_123', True),
+            (u'foo-123', True),
+            (u'foo*123', True),
+            (u'foo+123', True),
+            (u'foo&123', False),
+            (u'fooÅ', False),
+        )
+        for pattern, valid in matches:
+            self.assertEqual(bool(re.match(valid_pattern, pattern)), valid)
 
 
 class DeleteFormTestCase(BaseFormTestCase):


### PR DESCRIPTION
Fixes https://eucalyptus.atlassian.net/browse/GUI-1643

Security group name/description restrictions are documented at http://docs.aws.amazon.com/cli/latest/reference/ec2/create-security-group.html