### PR TITLE
GUI-1642: Prevent non-ASCII chars and slashes for key pair name when created via launch wizards

### DIFF
--- a/eucaconsole/static/js/pages/instance_launch.js
+++ b/eucaconsole/static/js/pages/instance_launch.js
@@ -430,7 +430,8 @@ angular.module('LaunchInstance', ['TagEditor', 'BlockDeviceMappingEditor', 'Imag
         $scope.handleKeyPairCreate = function ($event, createUrl, downloadUrl) {
             $event.preventDefault();
             var form = $($event.target);
-            if ($scope.newKeyPairName.indexOf('/') !== -1 || $scope.newKeyPairName.indexOf('\\') !== -1) {
+            if (form.find('[name="name"]').attr('data-invalid') !== undefined) {
+                // prevent invalid (non-ASCII) chars and slashes in key pair name
                 return;
             }
             var formData = form.serialize();

--- a/eucaconsole/static/js/pages/launchconfig_wizard.js
+++ b/eucaconsole/static/js/pages/launchconfig_wizard.js
@@ -448,7 +448,8 @@ angular.module('LaunchConfigWizard', ['ImagePicker', 'BlockDeviceMappingEditor',
         $scope.handleKeyPairCreate = function ($event, createUrl, downloadUrl) {
             $event.preventDefault();
             var form = $($event.target);
-            if ($scope.newKeyPairName.indexOf('/') !== -1 || $scope.newKeyPairName.indexOf('\\') !== -1) {
+            if (form.find('[name="name"]').attr('data-invalid') !== undefined) {
+                // prevent invalid (non-ASCII) chars and slashes in key pair name
                 return;
             }
             var formData = form.serialize();

--- a/eucaconsole/templates/dialogs/create_keypair_dialog.pt
+++ b/eucaconsole/templates/dialogs/create_keypair_dialog.pt
@@ -8,7 +8,7 @@
         </p>
         <form method="post" data-abide="abide" id="create-keypair-form"
               ng-submit="handleKeyPairCreate($event, '${request.route_path('keypair_create')}', '${request.route_path('file_download')}')"
-              tal:define="html_attrs {'pattern': '^[^\/\\\]{1,255}$'};">
+              tal:define="html_attrs {'pattern': layout.ascii_without_slashes_pattern};">
             ${structure:keypair_form['csrf_token']}
             ${panel('form_field', field=keypair_form['name'], ng_attrs={'model': 'newKeyPairName'}, leftcol_width=3, rightcol_width=9, **html_attrs)}
             <hr />


### PR DESCRIPTION
Fixes https://eucalyptus.atlassian.net/browse/GUI-1642