### PR TITLE
GUI-1643: Specify which characters are valid in security group description

### DIFF
--- a/eucaconsole/forms/securitygroups.py
+++ b/eucaconsole/forms/securitygroups.py
@@ -36,7 +36,7 @@ from . import BaseSecureForm, ChoicesManager, TextEscapedField, ASCII_WITHOUT_SL
 
 
 class SecurityGroupForm(BaseSecureForm):
-    """Security Group form
+    """Security Group create/edit form
        Constraints for VPC security group name/desc: a-z, A-Z, 0-9, spaces, and ._-:/()#,@[]+=;{}!$*
        See http://docs.aws.amazon.com/cli/latest/reference/ec2/create-security-group.html
     """
@@ -48,8 +48,9 @@ class SecurityGroupForm(BaseSecureForm):
     sgroup_description_pattern = r'^[a-zA-Z0-9\s\._\-:\/\(\)#,@\[\]\+=;\{\}!\$\*]+$'
     DESCRIPTION_RESTRICTION_NOTICE = _(
         u'Description is required, must be between 1 and 255 characters, and may only contain '
-        u'letters, numbers, spaces, and select special characters')
-    desc_error_msg = DESCRIPTION_RESTRICTION_NOTICE
+        u'letters, numbers, spaces, and the following characters:')
+    special_chars = u'._-:/()#,@[]+=;{}!$*'
+    desc_error_msg = u'{0} {1}'.format(DESCRIPTION_RESTRICTION_NOTICE, special_chars)
     description = wtforms.TextAreaField(
         label=_(u'Description'),
         validators=[

--- a/eucaconsole/templates/dialogs/create_securitygroup_dialog.pt
+++ b/eucaconsole/templates/dialogs/create_securitygroup_dialog.pt
@@ -6,8 +6,8 @@
         <form method="post" data-abide="abide" id="create-securitygroup-form"
               ng-submit="handleSecurityGroupCreate($event, '${request.route_path('securitygroup_create')}')">
             ${structure:securitygroup_form['csrf_token']}
-            ${panel('form_field', field=securitygroup_form['name'], ng_attrs={'model': 'newSecurityGroupName'}, leftcol_width=3, rightcol_width=9)}
-            ${panel('form_field', field=securitygroup_form['description'], ng_attrs={'model': 'newSecurityGroupDesc'}, leftcol_width=3, rightcol_width=9)}
+            ${panel('form_field', field=securitygroup_form['name'], ng_attrs={'model': 'newSecurityGroupName'}, leftcol_width=3, rightcol_width=9, **{'pattern': layout.ascii_without_slashes_pattern})}
+            ${panel('form_field', field=securitygroup_form['description'], ng_attrs={'model': 'newSecurityGroupDesc'}, leftcol_width=3, rightcol_width=9, **{'pattern': securitygroup_form.sgroup_description_pattern})}
             <div tal:condition="is_vpc_supported" ng-cloak="">
                 <div ng-show="instanceVPC == undefined">
                     ${panel('form_field', field=securitygroup_form['securitygroup_vpc_network'], ng_attrs={'model': 'securityGroupVPC'}, leftcol_width=3, rightcol_width=9)}


### PR DESCRIPTION
Also add validation constraint to create security group dialog on launch wizards.

References https://eucalyptus.atlassian.net/browse/GUI-1643