### PR TITLE
GUI-1662: Remove errant padding-top to fix alignment of read-only fields on detail pages

### DIFF
--- a/eucaconsole/static/css/eucaconsole.css
+++ b/eucaconsole/static/css/eucaconsole.css
@@ -2878,7 +2878,7 @@ form .error .chosen-container .chosen-single { border-color: darkred; background
 .row.controls-wrapper .field select { margin-bottom: 0.3rem; margin-top: 0.3rem; padding-top: 6px; padding-bottom: 6px; }
 .row.controls-wrapper .field textarea { margin-top: 0.3rem; }
 .row.controls-wrapper.readonly { margin-top: 0; margin-bottom: 0; }
-.row.controls-wrapper.readonly label { padding-top: 0; position: relative; right: -12px; }
+.row.controls-wrapper.readonly label { position: relative; right: -12px; }
 .row.controls-wrapper.readonly .value { padding-bottom: 6px; }
 .row.controls-wrapper.inline { margin-bottom: 4px; }
 .row.controls-wrapper.inline label { right: -6px; }

--- a/eucaconsole/static/sass/eucaconsole.scss
+++ b/eucaconsole/static/sass/eucaconsole.scss
@@ -724,7 +724,6 @@ form {
         margin-top: 0;
         margin-bottom: 0;
         label {
-            padding-top: 0;
             position: relative;
             right: -12px;
         }


### PR DESCRIPTION
Fixes https://eucalyptus.atlassian.net/browse/GUI-1662

Tested on latest Firefox, Safari, Chrome, IE 10, and IE 11