### PR TITLE
GUI-1683: Display horizontal rule above storage area only for launch configs that have a BDM

### DIFF
--- a/eucaconsole/templates/launchconfigs/launchconfig_view.pt
+++ b/eucaconsole/templates/launchconfigs/launchconfig_view.pt
@@ -135,7 +135,7 @@
                     <div tal:condition="not image" style="text-align:center;">
                         <strong style="color:red;" i18n:translate="">Image not found</strong>
                     </div>
-                    <hr/>
+                    <hr tal:condition="launch_config.block_device_mappings" />
                     ${panel('bdmapping_editor', image=image, launch_config=launch_config, read_only=True)}
                 </form>
                 <div>&nbsp;</div>


### PR DESCRIPTION
Fixes https://eucalyptus.atlassian.net/browse/GUI-1683