### PR TITLE
GUI-1687: Fix S3 file upload behavior broken by Angular and Foundation updates

### DIFF
--- a/eucaconsole/static/js/pages/bucket_contents.js
+++ b/eucaconsole/static/js/pages/bucket_contents.js
@@ -32,7 +32,7 @@ angular.module('BucketContentsPage', ['LandingPage', 'EucaConsoleUtils'])
             $scope.putKeysUrl = options.put_keys_url;
             $scope.makeObjectPublicUrl = options.make_object_public_url;
             // set upload button target based on media query
-            if (window.matchMedia(Foundation.media_queries.small).matches === false) {
+            if (Foundation.utils.is_medium_up()) {
                 $('#upload-file-btn').attr('target', '_blank');
             }
             $scope.updatePasteValues();

--- a/eucaconsole/static/js/pages/bucket_details.js
+++ b/eucaconsole/static/js/pages/bucket_details.js
@@ -18,7 +18,7 @@ angular.module('BucketDetailsPage', ['S3SharingPanel', 'EucaConsoleUtils'])
             $scope.handleUnsavedChanges();
             $scope.handleUnsavedSharingEntry($scope.bucketDetailsForm);
             // set upload button target based on media query
-            if (window.matchMedia(Foundation.media_queries.small).matches === false) {
+            if (Foundation.utils.is_medium_up()) {
                 $('#upload-file-action').attr('target', '_blank');
             }
         };

--- a/eucaconsole/static/js/pages/bucket_upload.js
+++ b/eucaconsole/static/js/pages/bucket_upload.js
@@ -129,7 +129,7 @@ angular.module('UploadFilePage', ['S3SharingPanel', 'S3MetadataEditor'])
             $scope.cancel();
         };
         $scope.cancel = function () {
-            if (window.matchMedia(Foundation.media_queries.small).matches === false) {
+            if (Foundation.utils.is_medium_up()) {
                 window.close();
             }
             else {

--- a/eucaconsole/static/js/pages/bucket_upload.js
+++ b/eucaconsole/static/js/pages/bucket_upload.js
@@ -41,7 +41,7 @@ angular.module('UploadFilePage', ['S3SharingPanel', 'S3MetadataEditor'])
             $scope.$on('s3:sharingPanelAclUpdated', function () {
                 $scope.hasChangesToBeSaved = true;
             });
-            $scope.$watch('files', function (newVals) {
+            $scope.$watchCollection('files', function (newVals) {
                 $('#size-error').css('display', 'none');
                 $scope.isNotValid = false;
                 if (newVals.length > 0) {
@@ -105,7 +105,9 @@ angular.module('UploadFilePage', ['S3SharingPanel', 'S3MetadataEditor'])
                         var parentWindow = window.opener;
                         $('#upload-files-modal').foundation('reveal', 'close');
                         $scope.hasChangesToBeSaved = false;
-                        parentWindow.postMessage('s3:fileUploaded', '*');
+                        if (parentWindow) {
+                            parentWindow.postMessage('s3:fileUploaded', '*');
+                        }
                         $scope.cancel();
                     }
                     if ($scope.uploading === true) {


### PR DESCRIPTION
Fixes https://eucalyptus.atlassian.net/browse/GUI-1687

Tested on Safari 8 (OS X Yosemite), Firefox 37 (OS X), and IE 11.

Note that IE 11 displays errant behavior for the post-upload action, and this PR (or the Angular/Foundation updates) neither caused nor fixes the new issue tracked in https://eucalyptus.atlassian.net/browse/GUI-1690