### PR TITLE
GUI-1694: Support unicode chars in scaling policy name

### DIFF
--- a/eucaconsole/templates/scalinggroups/scalinggroup_policies.pt
+++ b/eucaconsole/templates/scalinggroups/scalinggroup_policies.pt
@@ -35,8 +35,9 @@
                 <div class="tile item policy" tal:repeat="policy policies">
                     <div class="header" tal:define="policy_name layout.escape_braces(policy.name)">
                         <strong><a class="title">${policy_name}</a></strong>
-                        <a class="tiny secondary button dropdown right" data-dropdown="item-dropdown_${policy_ids[policy.name]}" ><i class="grid-action"></i></a>
-                        <ul id="item-dropdown_${policy_ids[policy.name]}" class="f-dropdown" data-dropdown-content="" >
+                        <a class="tiny secondary button dropdown right"
+                           data-dropdown="item-dropdown_${policy_ids[policy.name.encode('UTF-8')]}" ><i class="grid-action"></i></a>
+                        <ul id="item-dropdown_${policy_ids[policy.name.encode('UTF-8')]}" class="f-dropdown" data-dropdown-content="" >
                             <li><a i18n:translate="" ng-click="revealDeleteModal('${policy.name}')">Delete policy</a></li>
                         </ul>
                     </div>

--- a/eucaconsole/templates/scalinggroups/scalinggroup_policy.pt
+++ b/eucaconsole/templates/scalinggroups/scalinggroup_policy.pt
@@ -32,10 +32,10 @@
                     ${panel('form_field', field=policy_form['adjustment_type'], leftcol_width=3, rightcol_width=9)}
                     ${panel('form_field', field=policy_form['cooldown'], ng_attrs={'model': 'coolDown'}, leftcol_width=3, rightcol_width=9)}
                     <div class="row controls-wrapper">
-                        <div class="small-3 columns">
+                        <div class="large-2 small-3 columns">
                             <label class="right"><span i18n:translate="">Alarm</span>&nbsp;<span class="req">*</span></label>
                         </div>
-                        <div class="small-9 columns">
+                        <div class="large-10 small-9 columns">
                             <select name="alarm" ng-model="$parent.alarm" style="margin-bottom: 0.5rem;"
                                     ng-options="k as v for (k, v) in $parent.alarmChoices">
                                 <option value="" i18n:translate="">select alarm...</option>

--- a/eucaconsole/views/scalinggroups.py
+++ b/eucaconsole/views/scalinggroups.py
@@ -516,7 +516,8 @@ class ScalingGroupPoliciesView(BaseScalingGroupView):
             self.scaling_group = self.get_scaling_group()
             self.policies = self.get_policies(self.scaling_group)
             for policy in self.policies:
-                policy_ids[policy.name] = md5(policy.name).hexdigest()[:8]
+                policy_name = policy.name.encode('UTF-8')
+                policy_ids[policy_name] = md5(policy_name).hexdigest()[:8]
             self.alarms = self.get_alarms()
         self.create_form = ScalingGroupPolicyCreateForm(
             self.request, scaling_group=self.scaling_group, alarms=self.alarms, formdata=self.request.params or None)


### PR DESCRIPTION
Also fix alignment of alarm field on Create Scaling Policy page.

Fixes https://eucalyptus.atlassian.net/browse/GUI-1694
