### PR TITLE
GUI-1669: Defer to Foundation to set input field height and line height

### DIFF
--- a/eucaconsole/static/css/eucaconsole.css
+++ b/eucaconsole/static/css/eucaconsole.css
@@ -1,4 +1,3 @@
-@charset "UTF-8";
 /* @fileOverview Koala application-wide Sass CSS styles */
 /* Sass Imports */
 /*! normalize.css v2.1.2 | MIT License | git.io/normalize */
@@ -1758,7 +1757,7 @@ form input[type=password] { font-family: Arial, Helvetica, sans-serif !important
 form select, form textarea { background-color: #eef7e3; }
 form .req { color: darkred; }
 form .row .inline-label { line-height: 2rem; }
-form .row input[type='text'], form .row input[type='password'] { margin: 0 0 0 0; height: 2rem; line-height: 2rem; }
+form .row input[type='text'], form .row input[type='password'] { margin: 0 0 0 0; }
 form .row input[type='number'] { width: 3rem; }
 form .columns input { max-width: 100%; }
 form a.remove.circle { position: relative; left: 8px; top: -2px; }

--- a/eucaconsole/static/sass/eucaconsole.scss
+++ b/eucaconsole/static/sass/eucaconsole.scss
@@ -652,8 +652,6 @@ form {
         input {
             &[type='text'], &[type='password'] {
                 margin: 0 0 0 0;
-                height: $euca-input-field-height;
-                line-height: $euca-input-field-height;
             }
             &[type='number'] {
                 width: 3rem;


### PR DESCRIPTION
Fixes https://eucalyptus.atlassian.net/browse/GUI-1669

Tested on IE 10 and 11 (Windows 7 64-bit).
Spot-checked on Safari 8, Firefox 37, and Chrome 42 on Mac OS 10.10