### PR TITLE
GUI-1737: Replace i18n:translate with i18n:attributes where appropriate

### DIFF
--- a/eucaconsole/templates/dashboard.pt
+++ b/eucaconsole/templates/dashboard.pt
@@ -285,11 +285,11 @@
                                      <span class="right">
                                          <i ng-show="service.status == ''" class="busy" ></i>
                                          <i class="fi-check tick service-up" title="Service is up"
-                                            i18n:translate="title" data-tooltip="" ng-show="service.status == 'up'"></i>
+                                            i18n:attributes="title" data-tooltip="" ng-show="service.status == 'up'"></i>
                                          <i class="fi-x tick service-down" title="Service is not responding"
-                                            i18n:translate="title" data-tooltip="" ng-show="service.status=='down'"></i>
+                                            i18n:attributes="title" data-tooltip="" ng-show="service.status=='down'"></i>
                                          <i class="fi-prohibited tick service-denied" title="Access to this service denied"
-                                            i18n:translate="title" data-tooltip="" ng-show="service.status=='denied'"></i>
+                                            i18n:attributes="title" data-tooltip="" ng-show="service.status=='denied'"></i>
                                      </span>
                                 </div>
                             </div>

--- a/eucaconsole/templates/groups/group_view.pt
+++ b/eucaconsole/templates/groups/group_view.pt
@@ -131,7 +131,7 @@
                                     <div class="item-list">
                                         <span class="label radius secondar item" ng-repeat="user in groupUsers">
                                             <span> {{ user }} </span>
-                                            <a class="remove" title="Remove user from group" i18n:translate="title"
+                                            <a class="remove" title="Remove user from group" i18n:attributes="title"
                                                ng-click="removeUser(user)"><i class="fi-x"></i></a>
                                         </span>
                                     </div>

--- a/eucaconsole/templates/managecredentials.pt
+++ b/eucaconsole/templates/managecredentials.pt
@@ -104,7 +104,7 @@
                        ng-click="downloadKeys('${request.route_path('file_download')}')"
                        i18n:translate="">Download These Keys</a><br/>
                     <span class="subsection-label" i18n:translate="">Access keys</span><span class="helptext-icon" data-tooltip=""
-                                    title="These keys no longer be viewable once you leave this page." i18n:translate="title">?</span>:
+                          title="These keys no longer be viewable once you leave this page." i18n:attributes="title">?</span>:
                     <div>&nbsp;</div>
                     <div class="row controls-wrapper readonly">
                         <div class="small-3 columns">

--- a/eucaconsole/templates/roles/role_view.pt
+++ b/eucaconsole/templates/roles/role_view.pt
@@ -63,14 +63,16 @@
                                         <div class="ec2-block">
                                             <input type="radio" name="roletype" value="ec2" checked="checked" ng-model="roleType"/>
                                             <label><span i18n:translate="" class="ip-label">EC2 service</span></label>
-                                            <span data-tooltip="" title="Allows EC2 instances to call other services on your behalf" i18n:translate="title">
+                                            <span data-tooltip="" title="Allows EC2 instances to call other services on your behalf"
+                                                  i18n:attributes="title">
                                                 <i class="helptext-icon"></i>
                                             </span>
                                         </div>
                                         <div class="cross-acct-block">
                                             <input type="radio" name="roletype" value="xacct" ng-model="roleType"/>
                                             <label><span i18n:translate="" class="ip-label">Cross-account access</span></label>
-                                            <span data-tooltip="" title="Allows Users from an account you specify (regardless of owner) to access this account. If specified, the external ID must be entered in addition to the account ID before a user from that account can access this account. This field is only used when you are granting access to an account that you do not own." i18n:translate="title">
+                                            <span data-tooltip="" i18n:attributes="title"
+                                                  title="Allows Users from an account you specify (regardless of owner) to access this account. If specified, the external ID must be entered in addition to the account ID before a user from that account can access this account. This field is only used when you are granting access to an account that you do not own.">
                                                 <i class="helptext-icon"></i>
                                             </span>
                                             <div id="xacct-section" ng-cloak="">

--- a/eucaconsole/templates/stacks/stack_wizard.pt
+++ b/eucaconsole/templates/stacks/stack_wizard.pt
@@ -62,7 +62,7 @@
                                     <label i18n:translate="">Use sample template</label>
                                     <div id="sample-template-div" ng-show="inputtype=='sample'">
                                         <select chosen="" id="sample-template" name="sample-template"
-                                            ng-model="templateSample" i18n:translate="data-placeholder"
+                                            ng-model="templateSample" i18n:attributes="data-placeholder"
                                             data-placeholder="Select a template"
                                             ng-options="option.label group by option.group for option in templates track by option.name">
                                         </select>
@@ -109,22 +109,22 @@
                                         <!-- all the tips get the same selector(class). Trying to use data-options -->
                                         <!-- helps, but that's broken https://github.com/zurb/foundation/issues/6349 -->
                                         <span data-options="selector: param-tip{{$index}};"
-                                            ng-attr-title='{{item.description}}'>
+                                            ng-attr-title="{{item.description}}">
                                             <i class="helptext-icon"></i>
                                         </span>
                                     </label>
                                 </div>
                                 <div class="small-9 columns field">
                                     <input type="text" name="{{ item.name }}" id="{{ item.name }}"
-                                        value='{{ item.default }}' ng-hide="item.options"
-                                        min='{{ item.min }}' max='{{ item.max }}' pattern='{{ item.regex }}'
+                                        value="{{ item.default }}" ng-hide="item.options"
+                                        min="{{ item.min }}" max="{{ item.max }}" pattern="{{ item.regex }}"
                                         ng-model="paramModels[item.name]" ng-change="checkRequiredInput()"/>
-                                    <small class='error' ng-hide="">{{ item.constraint }}</small>
+                                    <small class="error" ng-hide="">{{ item.constraint }}</small>
                                     <div ng-show="item.options">
                                         <select chosen="" name="{{ item.name }}" id="{{ item.name }}" 
                                             search-contains="true" width="100"
-                                            value='{{ item.default }}'
-                                            i18n:translate="data-placeholder"
+                                            value="{{ item.default }}"
+                                            i18n:attributes="data-placeholder"
                                             data-placeholder="Select an option"
                                             ng-model="paramModels[item.name]" ng-change="checkRequiredInput()"
                                             ng-options="option[0] for option in item.options track by option[1]">


### PR DESCRIPTION
Also minor HTML attribute cleanup to use double quotes for consistency.

Fixes https://eucalyptus.atlassian.net/browse/GUI-1737