### PR TITLE
Require a minimum boto version, not a precise one

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -111,7 +111,7 @@ class sdist_with_git_version(sdist):
 
 requires = [
     'beaker >= 1.5.4',
-    'boto == 2.38.0',
+    'boto >= 2.38.0',
     'chameleon >= 2.5.3',
     'dogpile.cache >= 0.5.3',
     # taking this out since we need gevent1 for pkg install


### PR DESCRIPTION
Pull request #1405 made setup.py require boto 2.38.0 with an `==` comparison rather than a `>=`, which could make eucaconsole stop running entirely if a distro/EPEL/etc updates boto past that version.  That is probably not the experience we're looking for, so this commit switches that to `>=` instead.