### PR TITLE
GUI-1885 improve image param checking in aws templates

### DIFF
--- a/eucaconsole/forms/__init__.py
+++ b/eucaconsole/forms/__init__.py
@@ -491,7 +491,9 @@ class CFSampleTemplateManager(object):
         euca_templates = []
         for dir_name, subdir_list, filelist in os.walk(self.template_dir):
             for file_item in filelist:
-                name = file_item[:file_item.index('.')]
+                name = file_item
+                if file_item.find('.') > -1:
+                    name = file_item[:file_item.find('.')]
                 euca_templates.append((name, file_item))
             if len(euca_templates) > 0:
                 templates.append((dir_name, dir_name[dir_name.rindex('/')+1:], euca_templates))

--- a/eucaconsole/static/js/pages/stack_wizard.js
+++ b/eucaconsole/static/js/pages/stack_wizard.js
@@ -339,6 +339,9 @@ angular.module('StackWizard', ['TagEditor', 'EucaConsoleUtils', 'localytics.dire
                         $scope.paramModels[param.name] = param.default;
                     });
                     $scope.checkRequiredInput();
+                    $timeout(function() {
+                        $(document).foundation('tooltip', 'reflow');
+                    }, 1000);
                 }
             }).
             error(function (oData, status) {

--- a/eucaconsole/templates/stacks/stack_wizard.pt
+++ b/eucaconsole/templates/stacks/stack_wizard.pt
@@ -119,7 +119,7 @@
                                             <!-- all the tips get the same selector(class). Trying to use data-options -->
                                             <!-- helps, but that's broken https://github.com/zurb/foundation/issues/6349 -->
                                             <span data-options="selector: param-tip{{$index}};"
-                                                ng-attr-title="{{item.description}}">
+                                                data-tooltip="" ng-attr-title="{{item.description}}">
                                                 <i class="helptext-icon"></i>
                                             </span>
                                         </label>

--- a/eucaconsole/views/stacks.py
+++ b/eucaconsole/views/stacks.py
@@ -367,7 +367,9 @@ class StackWizardView(BaseView):
                 (template_url, template_name, parsed) = self.parse_store_template()
                 if 'Resources' not in parsed:
                     raise JSONError(message=_(u'Invalid CloudFormation Template, Resources not found'), status=400)
-                exception_list = StackWizardView.identify_aws_template(parsed)
+                exception_list = []
+                if self.request.params.get('inputtype') != 'sample':
+                    exception_list = StackWizardView.identify_aws_template(parsed)
                 if len(exception_list) > 0:
                     # massage for the browser
                     service_list = []
@@ -739,6 +741,13 @@ class StackWizardView(BaseView):
             if type(item) is dict and 'ImageId' in item.keys():
                 img_item = item['ImageId']
                 if 'Ref' not in img_item.keys():
+                    # check for emi lookup in map
+                    if 'Fn::FindInMap' in img_item.keys():
+                        map_name = img_item['Fn::FindInMap'][0]
+                        if parsed['Mappings'] and parsed['Mappings'][map_name]:
+                            img_map = parsed['Mappings'][map_name]
+                            if json.dumps(img_map).find('emi-') > -1:
+                                return
                     ret.append({
                         'name': 'ImageId',
                         'type': 'Parameter',


### PR DESCRIPTION
ignore image params when FindInMap is found and referenced map contains any emi- reference. Also don't perform aws check on sample templates

https://eucalyptus.atlassian.net/browse/GUI-1885