### PR TITLE
GUI-1914 fixed showing of next-button after aws template we can't use detected

### DIFF
--- a/eucaconsole/static/js/pages/stack_wizard.js
+++ b/eucaconsole/static/js/pages/stack_wizard.js
@@ -322,6 +322,7 @@ angular.module('StackWizard', ['TagEditor', 'EucaConsoleUtils', 'localytics.dire
                         $scope.templateUrl = undefined;
                         $scope.templateIdent = undefined;
                         $scope.description = '';
+                        $scope.isNotValid = true;
                         return;
                     }
                     if (results.parameter_list && results.parameter_list.length) {


### PR DESCRIPTION
fixed showing of next-button after aws template we can't use detected

https://eucalyptus.atlassian.net/browse/GUI-1914