### PR TITLE
GUI-1770: Broaden CSP by using default-src instead of script-src

### DIFF
--- a/eucaconsole/tweens.py
+++ b/eucaconsole/tweens.py
@@ -67,8 +67,8 @@ class CTHeadersTweenFactory(object):
             'X-FRAME-OPTIONS': 'SAMEORIGIN',
             'CACHE-CONTROL': 'NO-CACHE',
             'PRAGMA': 'NO-CACHE',
-            'CONTENT-SECURITY-POLICY': "script-src 'self'",
-            'X-CONTENT-SECURITY-POLICY': "script-src 'self'",
+            'CONTENT-SECURITY-POLICY': "default-src 'self'",
+            'X-CONTENT-SECURITY-POLICY': "default-src 'self'",
         },
     }
 

--- a/tests/tweens/test_tweens.py
+++ b/tests/tweens/test_tweens.py
@@ -94,8 +94,8 @@ class TestCTHeaders(unittest.TestCase):
         headers = CTFactory.header_map['text/html']
         self.assertTrue('CONTENT-SECURITY-POLICY' in headers.keys())
         self.assertTrue('X-CONTENT-SECURITY-POLICY' in headers.keys())  # IE requires header prefix
-        self.assertEquals(headers.get('CONTENT-SECURITY-POLICY'), "script-src 'self'")
-        self.assertEquals(headers.get('X-CONTENT-SECURITY-POLICY'), "script-src 'self'")
+        self.assertEquals(headers.get('CONTENT-SECURITY-POLICY'), "default-src 'self'")
+        self.assertEquals(headers.get('X-CONTENT-SECURITY-POLICY'), "default-src 'self'")
 
 
 class TestHTTPSTween(unittest.TestCase):


### PR DESCRIPTION
Implements https://eucalyptus.atlassian.net/browse/GUI-1770