### PR TITLE
GUI-1944 allow for dns login request to raise exceptions related to auth failures

### DIFF
--- a/eucaconsole/models/auth.py
+++ b/eucaconsole/models/auth.py
@@ -274,7 +274,10 @@ class EucaAuthenticator(object):
         # and if that also fails, let that error raise up
         try:
             return self._authenticate_(account, user, passwd, new_passwd, timeout, duration)
-        except urllib2.URLError:
+        except urllib2.URLError as err:
+            # handle case where dns attempt was good, but user unauthorized
+            if err.msg == 'Unauthorized' or err.msg == 'Forbidden':
+                raise err
             self.dns_enabled = False
             return self._authenticate_(account, user, passwd, new_passwd, timeout, duration)
 


### PR DESCRIPTION
allow for dns login request to raise exceptions related to auth failures

https://eucalyptus.atlassian.net/browse/GUI-1944