### PR TITLE
GUI-1976: Better handling of missing error message when the ufshost is unreachable on login attempts

### DIFF
--- a/eucaconsole/models/auth.py
+++ b/eucaconsole/models/auth.py
@@ -276,7 +276,8 @@ class EucaAuthenticator(object):
             return self._authenticate_(account, user, passwd, new_passwd, timeout, duration)
         except urllib2.URLError as err:
             # handle case where dns attempt was good, but user unauthorized
-            if err.msg == 'Unauthorized' or err.msg == 'Forbidden':
+            error_msg = getattr(err, 'msg', None)
+            if error_msg and error_msg == 'Unauthorized' or error_msg == 'Forbidden':
                 raise err
             self.dns_enabled = False
             return self._authenticate_(account, user, passwd, new_passwd, timeout, duration)


### PR DESCRIPTION
Fixes https://eucalyptus.atlassian.net/browse/GUI-1976