### PR TITLE
GUI-1977 Limit tags length to 70 characters, ellipses, add full conte…

### DIFF
--- a/eucaconsole/templates/snapshots/snapshots.pt
+++ b/eucaconsole/templates/snapshots/snapshots.pt
@@ -63,11 +63,11 @@
                 </div>
                 <div ng-show="item.description">
                     <span class="label" title="Description" i18n:attributes="title" data-tooltip="">DE</span>
-                    {{ item.description | limitTo: 128 }}
+                    {{ item.description | ellipsis: 50 }}
                 </div>
                 <div ng-show="item.tags">
                     <span class="label" title="Tags" i18n:attributes="title" data-tooltip="">TA</span>
-                    <span title="{{ item.tags }}">{{ item.tags | ellipsis: 25}}</span>
+                    <span title="{{ item.tags }}">{{ item.tags | ellipsis: 50}}</span>
                 </div>
             </div>
             <div metal:fill-slot="tile_footer" tal:omit-tag="">

--- a/eucaconsole/templates/snapshots/snapshots.pt
+++ b/eucaconsole/templates/snapshots/snapshots.pt
@@ -67,7 +67,7 @@
                 </div>
                 <div ng-show="item.tags">
                     <span class="label" title="Tags" i18n:attributes="title" data-tooltip="">TA</span>
-                    <span title="{{ item.tags }}">{{ item.tags | ellipsis: 70}}</span>
+                    <span title="{{ item.tags }}">{{ item.tags | ellipsis: 25}}</span>
                 </div>
             </div>
             <div metal:fill-slot="tile_footer" tal:omit-tag="">

--- a/eucaconsole/templates/snapshots/snapshots.pt
+++ b/eucaconsole/templates/snapshots/snapshots.pt
@@ -67,7 +67,7 @@
                 </div>
                 <div ng-show="item.tags">
                     <span class="label" title="Tags" i18n:attributes="title" data-tooltip="">TA</span>
-                    {{ item.tags | limitTo: 128 }}
+                    <span title="{{ item.tags }}">{{ item.tags | ellipsis: 70}}</span>
                 </div>
             </div>
             <div metal:fill-slot="tile_footer" tal:omit-tag="">


### PR DESCRIPTION
https://eucalyptus.atlassian.net/browse/GUI-1977

To test, add a tag to an existing or new snapshot with content greater than 70 characters.
See the content truncated with ellipses.  Hover over the truncated tag; see full content of tag in browser-native tool-tip.