### PR TITLE
GUI-1958 Set rewrite target to $hostname instead of $server_name.

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -44,7 +44,7 @@ http {
     server {
         listen 80 default;
         server_name localhost;
-        rewrite     ^ https://$server_name$request_uri? permanent;
+        rewrite     ^ https://$hostname$request_uri? permanent;
     }
 
     server {


### PR DESCRIPTION
Since $server_name is, by default, set to localhost, update the rewrite directive to point to $hostname instead.  The administrator could, however, specify $server_name explicitly if needs be.  This seems more flexible.  We may want to document this.