### PR TITLE
GUI-1994, GUI-1993 better shared bucket error handling, better double-slash handling.

### DIFF
--- a/eucaconsole/views/buckets.py
+++ b/eucaconsole/views/buckets.py
@@ -346,7 +346,8 @@ class BucketContentsView(LandingPageView, BucketMixin):
         ]
         # if shared bucket, we'd like to check permissions and send back to buckets page if none
         try:
-            self.s3_conn.get_bucket(self.bucket_name).list(prefix='notlikely')
+            if self.s3_conn:
+                self.s3_conn.get_bucket(self.bucket_name).list(prefix='notlikely')
         except BotoServerError as err:
             # 404: not found
             if err.status == 404:
@@ -846,10 +847,10 @@ class BucketItemDetailsView(BaseView, BucketMixin):
         self.bucket = bucket
         self.bucket_item_acl = bucket_item_acl
         self.s3_conn = self.get_connection(conn_type='s3')
-        self.s3_conn.suppress_consec_slashes = False
         with boto_error_handler(request):
             if self.s3_conn and self.bucket is None:
                 self.bucket = BucketContentsView.get_bucket(request, self.s3_conn)
+                self.s3_conn.suppress_consec_slashes = False
             request.subpath = self.get_subpath(self.bucket.name)
             self.bucket_name = self.bucket.name
             self.bucket_item = self.get_bucket_item()

--- a/eucaconsole/views/buckets.py
+++ b/eucaconsole/views/buckets.py
@@ -346,14 +346,17 @@ class BucketContentsView(LandingPageView, BucketMixin):
         ]
         # if shared bucket, we'd like to check permissions and send back to buckets page if none
         try:
-            bucket_items = self.s3_conn.get_bucket(self.bucket_name).list(prefix='notlikely')
+            self.s3_conn.get_bucket(self.bucket_name).list(prefix='notlikely')
         except BotoServerError as err:
             # 404: not found
             if err.status == 404:
                 msg = _(u'Bucket does not exist')
             # 403: forbidden
             if err.status == 403:
-                msg = _(u'You do not have the required permissions to perform this operation. Please contact your cloud administrator to request an updated access policy.')
+                msg = _(
+                    u'You do not have the required permissions to perform this operation. '
+                    u'Please contact your cloud administrator to request an updated access policy.'
+                )
             self.request.session.flash(msg, queue=Notification.ERROR)
             return HTTPFound(location=self.request.route_path('buckets'))
         json_route_path = self.request.route_path('bucket_contents', name=self.bucket_name, subpath=self.subpath)


### PR DESCRIPTION
catch errors in bucket access for shared buckets,
override boto's double-slash default behavior for bucket item details page

https://eucalyptus.atlassian.net/browse/GUI-1993
https://eucalyptus.atlassian.net/browse/GUI-1994