### PR TITLE
GUI-1565: Remove misleading warning when session.secure = false and console is requested via HTTPS

### DIFF
--- a/conf/console.default.ini
+++ b/conf/console.default.ini
@@ -79,8 +79,8 @@ session.type = cookie
 session.key = eucaconsole_session
 session.keyini = /etc/eucaconsole/session-keys.ini
 session.httponly = true
-# Secure session implies an HTTPS reverse proxy (nginx or load balancer) is configured
-session.secure = true
+# session.secure = true implies an HTTPS reverse proxy (nginx or load balancer) is configured
+session.secure = false
 # Idle timeout (1800 sec = 30 min)
 session.timeout = 1800
 # Absolute timeout (43200 sec = 12 hours)

--- a/conf/console.default.ini
+++ b/conf/console.default.ini
@@ -79,8 +79,8 @@ session.type = cookie
 session.key = eucaconsole_session
 session.keyini = /etc/eucaconsole/session-keys.ini
 session.httponly = true
-# Secure session implies SSL setup
-session.secure = false
+# Secure session implies an HTTPS reverse proxy (nginx or load balancer) is configured
+session.secure = true
 # Idle timeout (1800 sec = 30 min)
 session.timeout = 1800
 # Absolute timeout (43200 sec = 12 hours)

--- a/eucaconsole/views/login.py
+++ b/eucaconsole/views/login.py
@@ -122,8 +122,6 @@ class LoginView(BaseView, PermissionCheckMixin):
         )
 
     def show_https_warning(self):
-        if any([self.https_proxy, self.https_scheme]) and not self.secure_session:
-            return True
         if self.secure_session and not (any([self.https_proxy, self.https_scheme])):
             return True
         return False


### PR DESCRIPTION
...also set session.secure = true in the default console.ini file

Fixes https://eucalyptus.atlassian.net/browse/GUI-1565