### PR TITLE
GUI-1889 added setting to selectively disable image caching on eucalyptus clouds (not aws)

### DIFF
--- a/conf/console.default.ini
+++ b/conf/console.default.ini
@@ -97,6 +97,8 @@ cache.extra_long_term.expire = 43200
 # for configuring SASL PLAIN auth
 #cache.username =
 #cache.password =
+# disable image caching on Eucalyptus if users frequently change images outside of console
+cache.images.disable = false
 
 ###########################
 # WSGI server configuration

--- a/eucaconsole/views/__init__.py
+++ b/eucaconsole/views/__init__.py
@@ -238,7 +238,10 @@ class BaseView(object):
             acct = ''
         ufshost = self.get_connection().host if self.cloud_type == 'euca' else ''
         try:
-            return self._get_images_cached_(owners, executors, ec2_region, acct, ufshost)
+            if self.cloud_type == 'euca' and asbool(self.request.registry.settings.get('cache.images.disable', False)):
+                return self._get_images_(owners, executors, ec2_region)
+            else:
+                return self._get_images_cached_(owners, executors, ec2_region, acct, ufshost)
         except pylibmc.Error:
             logging.warn('memcached not responding')
             return self._get_images_(owners, executors, ec2_region)


### PR DESCRIPTION
added setting to selectively disable image caching on eucalyptus clouds (not aws)

https://eucalyptus.atlassian.net/browse/GUI-1889