### PR TITLE
GUI-2031: Prevent empty data message from lingering when chart data is returned on duration modification

### DIFF
--- a/eucaconsole/static/css/pages/cloudwatch_charts.css
+++ b/eucaconsole/static/css/pages/cloudwatch_charts.css
@@ -14,7 +14,7 @@
 
 .chart-wrapper h6 { color: #5a5a5a; margin-bottom: 0; padding: 8px 0 4px 8px; border: 1px solid #cccccc; border-bottom: none; }
 .chart-wrapper h6 .busy { margin-left: 1rem; color: #6a737b; max-width: 1rem; max-height: 1rem; }
-.chart-wrapper .empty-message-wrapper { position: relative; }
+.chart-wrapper .empty-message-wrapper { height: 300px; border: 1px solid #ccc; border-top: none; position: relative; }
 .chart-wrapper .empty-message { position: absolute; margin-top: 6rem; padding: 1rem; line-height: 1.2rem; }
 .chart-wrapper svg { width: 100%; height: 300px; border: 1px solid #ccc; border-top: none; }
 .chart-wrapper svg .nv-lineChart path.nv-point { stroke-opacity: 1 !important; fill-opacity: 1 !important; }

--- a/eucaconsole/static/js/pages/cloudwatch_charts.js
+++ b/eucaconsole/static/js/pages/cloudwatch_charts.js
@@ -74,6 +74,7 @@ angular.module('CloudWatchCharts', ['EucaConsoleUtils'])
     }
 
     function refreshCharts() {
+        vm.emptyMessages = {};
         vm.emptyChartCount = 0;
         // Broadcast message to CW charts directive controller to refresh
         $scope.$broadcast('cloudwatch:refreshCharts');
@@ -164,6 +165,10 @@ angular.module('CloudWatchCharts', ['EucaConsoleUtils'])
                 parentCtrl.emptyMessages[scope.metric] = scope.empty;
                 parentCtrl.emptyChartCount += 1;
                 return true;
+            }
+            if (largeChart && emptyResultsCount === results.length) {
+                // Remove existing chart when there are no results in large chart modal to avoid lingering empty msg
+                d3.select('#' + chartElemId).selectAll("svg > *").remove();
             }
             var unit = oData.unit || scope.unit;
             var yformatter = '.0f';

--- a/eucaconsole/static/sass/pages/cloudwatch_charts.scss
+++ b/eucaconsole/static/sass/pages/cloudwatch_charts.scss
@@ -57,6 +57,9 @@
         }
     }
     .empty-message-wrapper {
+        height: 300px;
+        border: 1px solid $euca-lightgrey;
+        border-top: none;
         position: relative;
     }
     .empty-message {

--- a/eucaconsole/templates/elbs/elb_monitoring.pt
+++ b/eucaconsole/templates/elbs/elb_monitoring.pt
@@ -50,10 +50,11 @@
                     <ul class="small-block-grid-1 medium-block-grid-2 large-block-grid-3">
                         <li class="chart-wrapper" ng-repeat="chart in chartsCtrl.chartsList" ng-cloak="">
                             <h6>{{ chartsCtrl.metricTitleMapping[chart.metric] }}<i class="busy"></i></h6>
-                            <div ng-if="chartsCtrl.emptyMessages[chart.metric]" class="empty-message-wrapper">
+                            <div ng-show="chartsCtrl.emptyMessages[chart.metric]" class="empty-message-wrapper">
                                 <div class="empty-message">{{ chartsCtrl.emptyMessages[chart.metric] }}</div>
                             </div>
-                            <svg cloudwatch-chart="" id="cwchart-{{ chart.metric }}" class="cwchart"
+                            <svg ng-show="!chartsCtrl.emptyMessages[chart.metric]"
+                                 cloudwatch-chart="" id="cwchart-{{ chart.metric }}" class="cwchart"
                                  ids="${elb_name}" idtype="LoadBalancerName" metric="{{ chart.metric }}"
                                  duration="{{ chartsCtrl.duration }}" unit="{{ chart.unit }}" namespace="ELB"
                                  statistic="{{ chart.statistic || 'Average' }}" empty="{{ chart.empty_msg }}">

--- a/eucaconsole/templates/instances/instance_monitoring.pt
+++ b/eucaconsole/templates/instances/instance_monitoring.pt
@@ -86,10 +86,11 @@
                     </div>
                     <li class="chart-wrapper" ng-repeat="chart in chartsCtrl.chartsList" ng-cloak="">
                         <h6>{{ chartsCtrl.metricTitleMapping[chart.metric] }}<i class="busy"></i></h6>
-                        <div ng-if="chartsCtrl.emptyMessages[chart.metric]" class="empty-message-wrapper">
+                        <div ng-show="chartsCtrl.emptyMessages[chart.metric]" class="empty-message-wrapper">
                             <div class="empty-message">{{ chartsCtrl.emptyMessages[chart.metric] }}</div>
                         </div>
-                        <svg cloudwatch-chart="" id="cwchart-{{ chart.metric }}" class="cwchart"
+                        <svg ng-show="!chartsCtrl.emptyMessages[chart.metric]"
+                             cloudwatch-chart="" id="cwchart-{{ chart.metric }}" class="cwchart"
                              ids="${instance.id}" idtype="InstanceId" metric="{{ chart.metric }}"
                              duration="{{ chartsCtrl.duration }}" unit="{{ chart.unit }}"
                              statistic="Average" empty="{{ chart.empty_msg }}">


### PR DESCRIPTION
Also prevent old chart from lingering in large chart modal when transitioning to empty chart message on duration change.

Fixes https://eucalyptus.atlassian.net/browse/GUI-2031