### PR TITLE
GUI-2037: Convert "unhealthy" to "out of service" in zone/subnet tiles on ELB Instances page

### DIFF
--- a/eucaconsole/static/css/widgets/instance_selector.css
+++ b/eucaconsole/static/css/widgets/instance_selector.css
@@ -7,7 +7,7 @@
 
 .status.pending { background-color: #822980; }
 
-.status.stopped { background-color: #990000; }
+.status.stopped, .status.Error { background-color: #990000; }
 
 .status.stopping { background-color: #ff6666; }
 

--- a/eucaconsole/static/html/directives/instance_selector.html
+++ b/eucaconsole/static/html/directives/instance_selector.html
@@ -37,11 +37,9 @@
                     </span>
                 </td>
                 <td class="status">
-                    <span class="label radius status {{ instanceHealthMapping[instance.id].state || instance.status }}"
-                          data-tooltip="">
+                    <span class="label radius status {{ instanceHealthMapping[instance.id].state || instance.status }}">
                         {{ healthStatusNames[instanceHealthMapping[instance.id].state] || instance.status }}
                     </span>
-                    <span class="busy" ng-show="instance.transitional">&nbsp;</span>
                 </td>
                 <td>
                     {{ instanceHealthMapping[instance.id].description }}

--- a/eucaconsole/static/sass/widgets/instance_selector.scss
+++ b/eucaconsole/static/sass/widgets/instance_selector.scss
@@ -17,7 +17,7 @@ $instance-status-color-terminating: lightgrey;
 // Tile/table view
 .status.running { background-color: $instance-status-color-running; }
 .status.pending { background-color: $instance-status-color-pending; }
-.status.stopped { background-color: $instance-status-color-stopped; }
+.status.stopped, .status.Error { background-color: $instance-status-color-stopped; }
 .status.stopping { background-color: $instance-status-color-stopping; }
 .status.terminated { background-color: $instance-status-color-terminated; }
 .status.shutting-down { background-color: $instance-status-color-terminating; }

--- a/eucaconsole/templates/elbs/elb_instances.pt
+++ b/eucaconsole/templates/elbs/elb_instances.pt
@@ -101,7 +101,7 @@
                                     <span i18n:translate="">All healthy</span>
                                 </div>
                                 <div class="footer status unhealthy" ng-show="zone.unhealthyInstanceCount > 0">
-                                    {{ zone.unhealthyInstanceCount }} <span i18n:translate="">unhealthy</span>
+                                    {{ zone.unhealthyInstanceCount }} <span i18n:translate="">out of service</span>
                                 </div>
                             </div>
                         </div>
@@ -175,7 +175,7 @@
                                     <span i18n:translate="">All healthy</span>
                                 </div>
                                 <div class="footer status unhealthy" ng-show="subnet.unhealthyInstanceCount > 0">
-                                    {{ subnet.unhealthyInstanceCount }} <span i18n:translate="">unhealthy</span>
+                                    {{ subnet.unhealthyInstanceCount }} <span i18n:translate="">out of service</span>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
…also fix background color of labels for instances in stopped state when listed in ELB instance selector, and remove errant tooltip on ELB instance status hover.

Fixes https://eucalyptus.atlassian.net/browse/GUI-2037