### PR TITLE
GUI-2016 Utilize existing service to deliver suggested device mapping…

### DIFF
--- a/eucaconsole/forms/instances.py
+++ b/eucaconsole/forms/instances.py
@@ -325,8 +325,11 @@ class AttachVolumeForm(BaseSecureForm):
         self.volume_id.error_msg = self.volume_error_msg
         self.device.error_msg = self.device_error_msg
         self.set_volume_choices()
+
         if self.instance is not None:
-            self.device.data = AttachVolumeForm.suggest_next_device_name(request, instance)
+            cloud_type = request.session.get('cloud_type')
+            mappings = instance.block_device_mapping
+            self.device.data = AttachVolumeForm.suggest_next_device_name(cloud_type, mappings)
 
     def set_volume_choices(self):
         """Populate volume field with volumes available to attach"""

--- a/eucaconsole/forms/instances.py
+++ b/eucaconsole/forms/instances.py
@@ -341,20 +341,17 @@ class AttachVolumeForm(BaseSecureForm):
         self.volume_id.choices = choices
 
     @staticmethod
-    def suggest_next_device_name(request, instance):
-        cloud_type = request.session.get('cloud_type')
+    def suggest_next_device_name(cloud_type, mappings):
         if cloud_type == 'euca':
             dev_root = '/dev/vd'
             start_char = 99
         else:
             dev_root = '/dev/sd'
             start_char = 102
-        mappings = instance.block_device_mapping
+
         for i in range(0, 10):   # Test names with char 'f' to 'p'
             dev_name = dev_root+str(unichr(start_char+i))
-            try:
-                mappings[dev_name]
-            except KeyError:
+            if dev_name not in mappings:
                 return dev_name
         return 'error'
 

--- a/eucaconsole/static/js/widgets/bdmapping_editor.js
+++ b/eucaconsole/static/js/widgets/bdmapping_editor.js
@@ -41,8 +41,15 @@ angular.module('BlockDeviceMappingEditor', ['EucaConsoleUtils'])
                     Notify.failure(errorMsg);
                   });
             });
+
             $scope.$watch('newSize', function () {
                 $scope.checkValidInput();
+            });
+
+            $http.get("/instances/new/nextdevice/json").then(function (oData) {
+                if(oData.data && oData.data.results) {
+                    $scope.newMappingPath = oData.data.results;
+                }
             });
         };
         $scope.checkValidInput = function () {

--- a/eucaconsole/views/instances.py
+++ b/eucaconsole/views/instances.py
@@ -878,7 +878,12 @@ class InstanceStateView(BaseInstanceView):
     @view_config(route_name='instance_nextdevice_json', renderer='json', request_method='GET')
     def instance_nextdevice_json(self):
         """Return current instance state"""
-        return dict(results=AttachVolumeForm.suggest_next_device_name(self.request, self.instance))
+        cloud_type = self.request.session.get('cloud_type')
+        if self.instance is not None:
+            mappings = self.instance.block_device_mapping
+        else:
+            mappings = {}
+        return dict(results=AttachVolumeForm.suggest_next_device_name(cloud_type, mappings))
 
     @view_config(route_name='instance_console_output_json', renderer='json', request_method='GET')
     def instance_console_output_json(self):

--- a/tests/instances/test_instances.py
+++ b/tests/instances/test_instances.py
@@ -171,13 +171,15 @@ class AttachVolumeDeviceEucalyptusTestCase(BaseFormTestCase):
     def test_initial_attach_device_on_eucalyptus(self):
         instance = Mock()
         instance.block_device_mapping = {}
-        device = self.form_class.suggest_next_device_name(self.request, instance)
+        cloud_type = self.request.session.get('cloud_type')
+        device = self.form_class.suggest_next_device_name(cloud_type, instance.block_device_mapping)
         self.assertEqual(device, '/dev/vdc')
 
     def test_next_attach_device_on_eucalyptus(self):
         instance = Mock()
         instance.block_device_mapping = {'/dev/vdc': 'foo'}
-        device = self.form_class.suggest_next_device_name(self.request, instance)
+        cloud_type = self.request.session.get('cloud_type')
+        device = self.form_class.suggest_next_device_name(cloud_type, instance.block_device_mapping)
         self.assertEqual(device, '/dev/vdd')
 
 
@@ -192,13 +194,15 @@ class AttachVolumeDeviceAWSTestCase(BaseFormTestCase):
     def test_initial_attach_device_on_aws(self):
         instance = Mock()
         instance.block_device_mapping = {}
-        device = self.form_class.suggest_next_device_name(self.request, instance)
+        cloud_type = self.request.session.get('cloud_type')
+        device = self.form_class.suggest_next_device_name(cloud_type, instance.block_device_mapping)
         self.assertEqual(device, '/dev/sdf')
 
     def test_next_attach_device_on_aws(self):
         instance = Mock()
         instance.block_device_mapping = {'/dev/sdf': 'foo'}
-        device = self.form_class.suggest_next_device_name(self.request, instance)
+        cloud_type = self.request.session.get('cloud_type')
+        device = self.form_class.suggest_next_device_name(cloud_type, instance.block_device_mapping)
         self.assertEqual(device, '/dev/sdg')
 
 


### PR DESCRIPTION
https://eucalyptus.atlassian.net/browse/GUI-2016

Addresses bug by reusing an existing service.  Modified the service slightly to loosen the coupling just a bit and introduce a usage pattern where a new path may be recommended for an instance without an ID - a new instance.