### PR TITLE
GUI-2084: Fix display of metric-relevant units in Create Alarm dialog

### DIFF
--- a/eucaconsole/views/scalinggroups.py
+++ b/eucaconsole/views/scalinggroups.py
@@ -576,7 +576,7 @@ class ScalingGroupPolicyView(BaseScalingGroupView):
             policy_form=self.policy_form,
             alarm_form=self.alarm_form,
             create_alarm_redirect=self.request.route_path('scalinggroup_policy_new', id=self.scaling_group.name),
-            metric_unit_mapping=json.dumps(self.get_metric_unit_mapping()),
+            metric_unit_mapping=self.get_metric_unit_mapping(),
             scale_down_text=_(u'Scale down by'),
             scale_up_text=_(u'Scale up by'),
         )

--- a/tests/scalinggroups/test_scalinggroups.py
+++ b/tests/scalinggroups/test_scalinggroups.py
@@ -30,6 +30,8 @@ Scaling Group tests
 See http://docs.pylonsproject.org/projects/pyramid/en/latest/narr/testing.html
 
 """
+import simplejson as json
+
 from pyramid import testing
 from pyramid.httpexceptions import HTTPNotFound
 
@@ -38,6 +40,7 @@ from eucaconsole.forms.scalinggroups import (
     ScalingGroupPolicyCreateForm, ScalingGroupPolicyDeleteForm,
     ScalingGroupInstancesMarkUnhealthyForm, ScalingGroupInstancesTerminateForm)
 from eucaconsole.i18n import _
+from eucaconsole.views.dialogs import create_alarm_dialog
 from eucaconsole.views.panels import form_field_row
 from eucaconsole.views.scalinggroups import ScalingGroupsView, BaseScalingGroupView, ScalingGroupView
 
@@ -182,6 +185,16 @@ class ScalingGroupPolicyCreateFormTestCase(BaseFormTestCase):
         self.assertTrue(hasattr(self.form.name.flags, 'required'))
         self.assertTrue('required' in fieldrow.get('html_attrs').keys())
         self.assertTrue(fieldrow.get('html_attrs').get('maxlength') is None)
+
+
+class CreateAlarmDialogTestCase(BaseViewTestCase):
+    request = testing.DummyRequest()
+
+    def test_create_alarm_dialog(self):
+        metric_unit_mapping = {'Latency': 'seconds'}
+        dialog = create_alarm_dialog(None, self.request, metric_unit_mapping=metric_unit_mapping)
+        controller_options = json.loads(dialog.get('controller_options_json'))
+        self.assertEqual(controller_options.get('metric_unit_mapping'), metric_unit_mapping)
 
 
 class ScalingGroupPolicyDeleteFormTestCase(BaseFormTestCase):


### PR DESCRIPTION
Fixes https://eucalyptus.atlassian.net/browse/GUI-2084

- Avoid stringifying metric-unit mapping twice, allowing relevant units to display when metric is selected in the Create Alarm dialog on the ASG scaling policy page;  
- Add unit test for create alarm dialog