### PR TITLE
GUI-2024: Display warning dialog when ELB security group rules don't cover listener and health check ports

### DIFF
--- a/eucaconsole/static/js/pages/base_elb_wizard.js
+++ b/eucaconsole/static/js/pages/base_elb_wizard.js
@@ -4,7 +4,10 @@
  *
  */
 
-angular.module('BaseELBWizard', ['EucaConsoleUtils', 'CreateBucketDialog', 'MagicSearch', 'ELBSecurityPolicyEditor', 'TagEditor', 'ELBListenerEditor'])
+angular.module('BaseELBWizard', [
+    'EucaConsoleUtils', 'CreateBucketDialog', 'MagicSearch', 'ELBSecurityPolicyEditor',
+    'TagEditor', 'ELBListenerEditor', 'ELBSecurityGroupRulesWarning']
+)
     .controller('BaseELBWizardCtrl', function ($scope, $http, $timeout, eucaHandleError, eucaUnescapeJson) {
         $scope.thisForm = undefined;
         $scope.urlParams = undefined;

--- a/eucaconsole/static/js/pages/elb_view.js
+++ b/eucaconsole/static/js/pages/elb_view.js
@@ -15,8 +15,6 @@ angular.module('ELBPage', ['EucaConsoleUtils', 'ELBListenerEditor', 'ELBSecurity
         $scope.securityGroupChoices = {};  // id/name mapping of security group choices (e.g. {"sg-123": 'foo', ...})
         $scope.securityGroupCollection = [];  // Security group object choices
         $scope.selectedSecurityGroups = [];  // Selected security group objects
-        $scope.securityGroupInboundPorts = [];  // List of selected security group inbound ports to compare with ELB ports
-        $scope.securityGroupOutboundPorts = [];  // List of selected security group outbound ports to compare with ELB ports
         $scope.loadBalancerInboundPorts = [];
         $scope.loadBalancerOutboundPorts = [];
         $scope.pingPort = '';

--- a/eucaconsole/static/js/pages/elb_view.js
+++ b/eucaconsole/static/js/pages/elb_view.js
@@ -4,12 +4,22 @@
  *
  */
 
-angular.module('ELBPage', ['EucaConsoleUtils', 'ELBListenerEditor', 'ELBSecurityPolicyEditor', 'TagEditor', 'CreateBucketDialog'])
+angular.module('ELBPage', ['EucaConsoleUtils', 'ELBListenerEditor', 'ELBSecurityPolicyEditor', 'TagEditor',
+                           'CreateBucketDialog', 'ELBSecurityGroupRulesWarning'])
     .controller('ELBPageCtrl', function ($scope, $http, $timeout, eucaUnescapeJson, eucaHandleUnsavedChanges,
-                                         eucaHandleError, eucaFixHiddenTooltips) {
+                                         eucaHandleError, eucaFixHiddenTooltips, eucaCheckELBSecurityGroupRules) {
         $scope.elbForm = undefined;
         $scope.listenerArray = [];
-        $scope.securityGroups = [];
+        $scope.securityGroups = [];  // Selected security group ids (e.g. ["sg-123456", ...])
+        $scope.securityGroupNames = [];  // Selected security group names (e.g. ["sgroup-one", ...])
+        $scope.securityGroupChoices = {};  // id/name mapping of security group choices (e.g. {"sg-123": 'foo', ...})
+        $scope.securityGroupCollection = [];  // Security group object choices
+        $scope.selectedSecurityGroups = [];  // Selected security group objects
+        $scope.securityGroupInboundPorts = [];  // List of selected security group inbound ports to compare with ELB ports
+        $scope.securityGroupOutboundPorts = [];  // List of selected security group outbound ports to compare with ELB ports
+        $scope.loadBalancerInboundPorts = [];
+        $scope.loadBalancerOutboundPorts = [];
+        $scope.pingPort = '';
         $scope.certificateARN = '';
         $scope.certificateName = '';
         $scope.newCertificateName = '';
@@ -52,6 +62,8 @@ angular.module('ELBPage', ['EucaConsoleUtils', 'ELBListenerEditor', 'ELBSecurity
             if (elbForm.length > 0) {
                 $scope.elbForm = elbForm;
             }
+            $scope.securityGroupJsonEndpoint = options.securitygroups_json_endpoint;
+            $scope.pingPort = options.ping_port;
             $scope.bucketName = $scope.bucketNameField.val();
             $scope.bucketNameChoices = options.bucket_choices;
             $scope.loggingEnabled = options.logging_enabled;
@@ -90,6 +102,25 @@ angular.module('ELBPage', ['EucaConsoleUtils', 'ELBListenerEditor', 'ELBSecurity
         };
         $scope.initChosenSelectors = function () {
             $('#securitygroup').chosen({'width': '70%', search_contains: true});
+        };
+        $scope.getAllSecurityGroups = function (vpc) {
+            if (!vpc || vpc === 'None') {
+                return;
+            }
+            var csrf_token = $('#csrf_token').val();
+            var data = "csrf_token=" + csrf_token + "&vpc_id=" + vpc;
+            $http({
+                method:'POST', url:$scope.securityGroupJsonEndpoint, data:data,
+                headers: {'Content-Type': 'application/x-www-form-urlencoded'}
+            }).success(function(oData) {
+                var results = oData ? oData.results : [];
+                $scope.securityGroupCollection = results;
+                results.forEach(function (sGroup){
+                    $scope.securityGroupChoices[sGroup.id] = sGroup.name;
+                });
+            }).error(function (oData) {
+                eucaHandleError(oData, status);
+            });
         };
         $scope.setWatch = function () {
             eucaHandleUnsavedChanges($scope);
@@ -136,6 +167,9 @@ angular.module('ELBPage', ['EucaConsoleUtils', 'ELBListenerEditor', 'ELBSecurity
                     $scope.isNotChanged = false;
                 }
             }, true);
+            $scope.$watch('vpcNetwork', function () {
+                $scope.getAllSecurityGroups($scope.vpcNetwork);
+            });
             $scope.$on('eventUpdateListenerArray', function ($event, listenerArray) {
                 if ($scope.isInitComplete === true) {
                     $scope.isNotChanged = false;
@@ -432,6 +466,24 @@ angular.module('ELBPage', ['EucaConsoleUtils', 'ELBListenerEditor', 'ELBSecurity
             }
             $scope.accessLoggingConfirmed = true;
             $scope.accessLogConfirmationDialog.foundation('reveal', 'close');
+        };
+        $scope.updateELB = function ($event, confirmed) {
+            confirmed = confirmed || false;
+            $scope.checkSecurityGroupRules($event, confirmed);
+        };
+        $scope.checkSecurityGroupRules = function ($event, confirmed) {
+            var modal = $('#elb-security-group-rules-warning-modal');
+            var inboundOutboundPortChecksPass;
+            if (!$scope.vpcNetwork) {  // Bypass rules check on non-VPC clouds
+                $scope.elbForm.submit();
+            }
+            inboundOutboundPortChecksPass = eucaCheckELBSecurityGroupRules($scope);
+            if (!confirmed && !inboundOutboundPortChecksPass) {
+                modal.foundation('reveal', 'open');
+                $event.preventDefault();
+            } else {
+                $scope.elbForm.submit();
+            }
         };
     })
 ;

--- a/eucaconsole/static/js/pages/elb_wizard.js
+++ b/eucaconsole/static/js/pages/elb_wizard.js
@@ -7,7 +7,8 @@
  */
 
 angular.module('BaseELBWizard').controller('ELBWizardCtrl', function ($scope, $http, $timeout, eucaHandleError,
-                                                                      eucaUnescapeJson, eucaFixHiddenTooltips) {
+                                                                      eucaUnescapeJson, eucaFixHiddenTooltips,
+                                                                      eucaCheckELBSecurityGroupRules) {
     $scope.elbForm = undefined;
     $scope.urlParams = undefined;
     $scope.isNotValid = true;
@@ -708,75 +709,13 @@ angular.module('BaseELBWizard').controller('ELBWizardCtrl', function ($scope, $h
         }
     };
     $scope.checkSecurityGroupRules = function ($event, confirmed) {
-        var inboundChecksPass = true;
-        var outboundChecksPass = true;
         var modal = $('#elb-security-group-rules-warning-modal');
+        var inboundOutboundPortChecksPass;
         if (!$scope.vpcNetwork) {  // Bypass rules check on non-VPC clouds
             $scope.thisForm.submit();
         }
-        $scope.selectedSecurityGroups = $scope.securityGroupCollection.filter(function (group) {
-            if ($scope.securityGroups.indexOf(group.id) !== -1) {
-                return group;
-            }
-        });
-        // Collect inbound/outbound ports from security group rules
-        $scope.selectedSecurityGroups.forEach(function (sgroup) {
-            // Collect Inbound ports
-            sgroup.rules.forEach(function (rule) {
-                if (rule.from_port) {
-                    $scope.securityGroupInboundPorts.push(parseInt(rule.from_port, 10));
-                }
-                if (rule.to_port && rule.to_port !== rule.from_port) {
-                    $scope.securityGroupInboundPorts.push(parseInt(rule.to_port, 10));
-                }
-                if (rule.ip_protocol === '-1' && $scope.securityGroupInboundPorts.indexOf(-1) === -1) {
-                    $scope.securityGroupInboundPorts.push(-1);  // Add "all traffic" inbound rule
-                }
-            });
-            // Outbound ports
-            sgroup.rules_egress.forEach(function (rule) {
-                if (rule.from_port) {
-                    $scope.securityGroupOutboundPorts.push(parseInt(rule.from_port, 10));
-                }
-                if (rule.to_port && rule.to_port !== rule.from_port) {
-                    $scope.securityGroupOutboundPorts.push(parseInt(rule.to_port, 10));
-                }
-                if (rule.ip_protocol === '-1' && $scope.securityGroupOutboundPorts.indexOf(-1) === -1) {
-                    $scope.securityGroupOutboundPorts.push(-1);  // Add "all traffic" outbound rule
-                }
-            });
-        });
-        // Collect ports from configured listeners
-        $scope.listenerArray.forEach(function (listener) {
-            if ($scope.loadBalancerInboundPorts.indexOf(listener.fromPort) === -1) {
-                $scope.loadBalancerInboundPorts.push(listener.fromPort);
-            }
-            if ($scope.loadBalancerOutboundPorts.indexOf(listener.toPort) === -1) {
-                $scope.loadBalancerOutboundPorts.push(listener.toPort);
-            }
-        });
-        // Collect port from health check
-        if ($scope.loadBalancerOutboundPorts.indexOf($scope.pingPort) === -1) {
-            $scope.loadBalancerOutboundPorts.push($scope.pingPort);
-        }
-        // Compare listener and health check ports with selected security groups
-        $scope.loadBalancerInboundPorts.forEach(function (port) {
-            if ($scope.securityGroupInboundPorts.indexOf(port) === -1) {
-                inboundChecksPass = false;
-            }
-        });
-        $scope.loadBalancerOutboundPorts.forEach(function (port) {
-            if ($scope.securityGroupOutboundPorts.indexOf(port) === -1) {
-                outboundChecksPass = false;
-            }
-        });
-        if ($scope.securityGroupInboundPorts.indexOf(-1) !== -1) {
-            inboundChecksPass = true;  // Pass inbound check if "all traffic" rule
-        }
-        if ($scope.securityGroupOutboundPorts.indexOf(-1) !== -1) {
-            outboundChecksPass = true;  // Pass outbound check if "all traffic" rule
-        }
-        if (!confirmed && (!inboundChecksPass || !outboundChecksPass)) {
+        inboundOutboundPortChecksPass = eucaCheckELBSecurityGroupRules($scope);
+        if (!confirmed && !inboundOutboundPortChecksPass) {
             modal.foundation('reveal', 'open');
             $event.preventDefault();
         } else {

--- a/eucaconsole/static/js/pages/elb_wizard.js
+++ b/eucaconsole/static/js/pages/elb_wizard.js
@@ -712,14 +712,14 @@ angular.module('BaseELBWizard').controller('ELBWizardCtrl', function ($scope, $h
         var modal = $('#elb-security-group-rules-warning-modal');
         var inboundOutboundPortChecksPass;
         if (!$scope.vpcNetwork) {  // Bypass rules check on non-VPC clouds
-            $scope.thisForm.submit();
+            $scope.elbForm.submit();
         }
         inboundOutboundPortChecksPass = eucaCheckELBSecurityGroupRules($scope);
         if (!confirmed && !inboundOutboundPortChecksPass) {
             modal.foundation('reveal', 'open');
             $event.preventDefault();
         } else {
-            $scope.thisForm.submit();
+            $scope.elbForm.submit();
         }
     };
 })

--- a/eucaconsole/static/js/pages/elb_wizard.js
+++ b/eucaconsole/static/js/pages/elb_wizard.js
@@ -26,8 +26,6 @@ angular.module('BaseELBWizard').controller('ELBWizardCtrl', function ($scope, $h
     $scope.securityGroupChoices = {};  // id/name mapping of security group choices (e.g. {"sg-123": 'foo', ...})
     $scope.securityGroupCollection = [];  // Security group object choices
     $scope.selectedSecurityGroups = [];  // Selected security group objects
-    $scope.securityGroupInboundPorts = [];  // List of selected security group inbound ports to compare with ELB ports
-    $scope.securityGroupOutboundPorts = [];  // List of selected security group outbound ports to compare with ELB ports
     $scope.loadBalancerInboundPorts = [];
     $scope.loadBalancerOutboundPorts = [];
     $scope.availabilityZones = [];

--- a/eucaconsole/static/js/widgets/elb_security_group_warning_dialog.js
+++ b/eucaconsole/static/js/widgets/elb_security_group_warning_dialog.js
@@ -1,0 +1,79 @@
+/**
+ * @fileOverview ELB Security Group Rules Warning JS
+ * @requires AngularJS
+ *
+ */
+angular.module('ELBSecurityGroupRulesWarning', [])
+.service('eucaCheckELBSecurityGroupRules', function() {
+    /**
+     * Check security group rules to determine if inbound/outbound ports cover listener and health check ports
+     */
+    return function(scope) {
+        var inboundChecksPass = true;
+        var outboundChecksPass = true;
+        scope.selectedSecurityGroups = scope.securityGroupCollection.filter(function (group) {
+            if (scope.securityGroups.indexOf(group.id) !== -1) {
+                return group;
+            }
+        });
+        // Collect inbound/outbound ports from security group rules
+        scope.selectedSecurityGroups.forEach(function (sgroup) {
+            // Collect Inbound ports
+            sgroup.rules.forEach(function (rule) {
+                if (rule.from_port) {
+                    scope.securityGroupInboundPorts.push(parseInt(rule.from_port, 10));
+                }
+                if (rule.to_port && rule.to_port !== rule.from_port) {
+                    scope.securityGroupInboundPorts.push(parseInt(rule.to_port, 10));
+                }
+                if (rule.ip_protocol === '-1' && scope.securityGroupInboundPorts.indexOf(-1) === -1) {
+                    scope.securityGroupInboundPorts.push(-1);  // Add "all traffic" inbound rule
+                }
+            });
+            // Outbound ports
+            sgroup.rules_egress.forEach(function (rule) {
+                if (rule.from_port) {
+                    scope.securityGroupOutboundPorts.push(parseInt(rule.from_port, 10));
+                }
+                if (rule.to_port && rule.to_port !== rule.from_port) {
+                    scope.securityGroupOutboundPorts.push(parseInt(rule.to_port, 10));
+                }
+                if (rule.ip_protocol === '-1' && scope.securityGroupOutboundPorts.indexOf(-1) === -1) {
+                    scope.securityGroupOutboundPorts.push(-1);  // Add "all traffic" outbound rule
+                }
+            });
+        });
+        // Collect ports from configured listeners
+        scope.listenerArray.forEach(function (listener) {
+            if (scope.loadBalancerInboundPorts.indexOf(listener.fromPort) === -1) {
+                scope.loadBalancerInboundPorts.push(listener.fromPort);
+            }
+            if (scope.loadBalancerOutboundPorts.indexOf(listener.toPort) === -1) {
+                scope.loadBalancerOutboundPorts.push(listener.toPort);
+            }
+        });
+        // Collect port from health check
+        if (scope.pingPort && scope.loadBalancerOutboundPorts.indexOf(scope.pingPort) === -1) {
+            scope.loadBalancerOutboundPorts.push(scope.pingPort);
+        }
+        // Compare listener and health check ports with selected security groups
+        scope.loadBalancerInboundPorts.forEach(function (port) {
+            if (scope.securityGroupInboundPorts.indexOf(port) === -1) {
+                inboundChecksPass = false;
+            }
+        });
+        scope.loadBalancerOutboundPorts.forEach(function (port) {
+            if (scope.securityGroupOutboundPorts.indexOf(port) === -1) {
+                outboundChecksPass = false;
+            }
+        });
+        if (scope.securityGroupInboundPorts.indexOf(-1) !== -1) {
+            inboundChecksPass = true;  // Pass inbound check if "all traffic" rule
+        }
+        if (scope.securityGroupOutboundPorts.indexOf(-1) !== -1) {
+            outboundChecksPass = true;  // Pass outbound check if "all traffic" rule
+        }
+        return inboundChecksPass && outboundChecksPass;
+    };
+});
+

--- a/eucaconsole/static/js/widgets/elb_security_group_warning_dialog.js
+++ b/eucaconsole/static/js/widgets/elb_security_group_warning_dialog.js
@@ -11,6 +11,8 @@ angular.module('ELBSecurityGroupRulesWarning', [])
     return function(scope) {
         var inboundChecksPass = true;
         var outboundChecksPass = true;
+        var securityGroupInboundPorts = [];
+        var securityGroupOutboundPorts = [];
         scope.selectedSecurityGroups = scope.securityGroupCollection.filter(function (group) {
             if (scope.securityGroups.indexOf(group.id) !== -1) {
                 return group;
@@ -21,25 +23,25 @@ angular.module('ELBSecurityGroupRulesWarning', [])
             // Collect Inbound ports
             sgroup.rules.forEach(function (rule) {
                 if (rule.from_port) {
-                    scope.securityGroupInboundPorts.push(parseInt(rule.from_port, 10));
+                    securityGroupInboundPorts.push(parseInt(rule.from_port, 10));
                 }
                 if (rule.to_port && rule.to_port !== rule.from_port) {
-                    scope.securityGroupInboundPorts.push(parseInt(rule.to_port, 10));
+                    securityGroupInboundPorts.push(parseInt(rule.to_port, 10));
                 }
-                if (rule.ip_protocol === '-1' && scope.securityGroupInboundPorts.indexOf(-1) === -1) {
-                    scope.securityGroupInboundPorts.push(-1);  // Add "all traffic" inbound rule
+                if (rule.ip_protocol === '-1' && securityGroupInboundPorts.indexOf(-1) === -1) {
+                    securityGroupInboundPorts.push(-1);  // Add "all traffic" inbound rule
                 }
             });
             // Outbound ports
             sgroup.rules_egress.forEach(function (rule) {
                 if (rule.from_port) {
-                    scope.securityGroupOutboundPorts.push(parseInt(rule.from_port, 10));
+                    securityGroupOutboundPorts.push(parseInt(rule.from_port, 10));
                 }
                 if (rule.to_port && rule.to_port !== rule.from_port) {
-                    scope.securityGroupOutboundPorts.push(parseInt(rule.to_port, 10));
+                    securityGroupOutboundPorts.push(parseInt(rule.to_port, 10));
                 }
-                if (rule.ip_protocol === '-1' && scope.securityGroupOutboundPorts.indexOf(-1) === -1) {
-                    scope.securityGroupOutboundPorts.push(-1);  // Add "all traffic" outbound rule
+                if (rule.ip_protocol === '-1' && securityGroupOutboundPorts.indexOf(-1) === -1) {
+                    securityGroupOutboundPorts.push(-1);  // Add "all traffic" outbound rule
                 }
             });
         });
@@ -58,19 +60,19 @@ angular.module('ELBSecurityGroupRulesWarning', [])
         }
         // Compare listener and health check ports with selected security groups
         scope.loadBalancerInboundPorts.forEach(function (port) {
-            if (scope.securityGroupInboundPorts.indexOf(port) === -1) {
+            if (securityGroupInboundPorts.indexOf(port) === -1) {
                 inboundChecksPass = false;
             }
         });
         scope.loadBalancerOutboundPorts.forEach(function (port) {
-            if (scope.securityGroupOutboundPorts.indexOf(port) === -1) {
+            if (securityGroupOutboundPorts.indexOf(port) === -1) {
                 outboundChecksPass = false;
             }
         });
-        if (scope.securityGroupInboundPorts.indexOf(-1) !== -1) {
+        if (securityGroupInboundPorts.indexOf(-1) !== -1) {
             inboundChecksPass = true;  // Pass inbound check if "all traffic" rule
         }
-        if (scope.securityGroupOutboundPorts.indexOf(-1) !== -1) {
+        if (securityGroupOutboundPorts.indexOf(-1) !== -1) {
             outboundChecksPass = true;  // Pass outbound check if "all traffic" rule
         }
         return inboundChecksPass && outboundChecksPass;

--- a/eucaconsole/templates/dialogs/elb_security_group_warning_dialog.pt
+++ b/eucaconsole/templates/dialogs/elb_security_group_warning_dialog.pt
@@ -31,4 +31,5 @@
         </button>
         <a href="#" class="close-reveal-modal">&#215;</a>
     </div>
+    <script src="${request.static_path('eucaconsole:static/js/widgets/elb_security_group_warning_dialog.js')}"></script>
 </div>

--- a/eucaconsole/templates/dialogs/elb_security_group_warning_dialog.pt
+++ b/eucaconsole/templates/dialogs/elb_security_group_warning_dialog.pt
@@ -1,0 +1,34 @@
+<!--! ELB Security Group rules warning dialog -->
+<div i18n:domain="eucaconsole">
+    <div id="elb-security-group-rules-warning-modal" class="reveal-modal medium" data-reveal="">
+        <h3 i18n:translate="">WARNING: Additional security group rules needed</h3>
+        <p i18n:translate="">
+            Your load balancer will be inaccessible until you open all traffic to the ports you
+            specified in your listeners and health check.
+        </p>
+        <p i18n:translate="">
+            Please update your selected security group(s) after your load balancer is created to
+            add rules that open all traffic to the following ports.
+        </p>
+        <div class="row" ng-repeat="(sgroupId, sgroupName) in securityGroupChoices">
+            <div class="large-4 small-4 columns">
+                <div i18n:translate="">SECURITY GROUP</div>
+                {{ sgroupName }}
+            </div>
+            <div class="large-4 small-4 columns">
+                <div i18n:translate="">INBOUND PORTS</div>
+                <span ng-repeat="port in loadBalancerInboundPorts">{{ port }}<span ng-if="!$last">, </span></span>
+            </div>
+            <div class="large-4 small-4 columns">
+                <div i18n:translate="">OUTBOUND PORTS</div>
+                <span ng-repeat="port in loadBalancerOutboundPorts">{{ port }}<span ng-if="!$last">, </span></span>
+            </div>
+            <div class="row"><div class="columns">&nbsp;</div></div>
+        </div>
+        <div>&nbsp;</div>
+        <button class="expand" i18n:translate="" tal:condition="create" ng-click="createELB($event, true)">
+            I Understand, Create Load Balancer
+        </button>
+        <a href="#" class="close-reveal-modal">&#215;</a>
+    </div>
+</div>

--- a/eucaconsole/templates/dialogs/elb_security_group_warning_dialog.pt
+++ b/eucaconsole/templates/dialogs/elb_security_group_warning_dialog.pt
@@ -10,10 +10,10 @@
             Please update your selected security group(s) after your load balancer is created to
             add rules that open all traffic to the following ports.
         </p>
-        <div class="row" ng-repeat="(sgroupId, sgroupName) in securityGroupChoices">
+        <div class="row" ng-repeat="sgroup in selectedSecurityGroups track by $index">
             <div class="large-4 small-4 columns">
                 <div i18n:translate="">SECURITY GROUP</div>
-                {{ sgroupName }}
+                {{ sgroup.name }}
             </div>
             <div class="large-4 small-4 columns">
                 <div i18n:translate="">INBOUND PORTS</div>

--- a/eucaconsole/templates/dialogs/elb_security_group_warning_dialog.pt
+++ b/eucaconsole/templates/dialogs/elb_security_group_warning_dialog.pt
@@ -29,6 +29,9 @@
         <button class="expand" i18n:translate="" tal:condition="create" ng-click="createELB($event, true)">
             I Understand, Create Load Balancer
         </button>
+        <button class="expand" i18n:translate="" tal:condition="not: create" ng-click="updateELB($event, true)">
+            I Understand, Update Load Balancer
+        </button>
         <a href="#" class="close-reveal-modal">&#215;</a>
     </div>
     <script src="${request.static_path('eucaconsole:static/js/widgets/elb_security_group_warning_dialog.js')}"></script>

--- a/eucaconsole/templates/elbs/elb_view.pt
+++ b/eucaconsole/templates/elbs/elb_view.pt
@@ -118,7 +118,7 @@
                     <hr />
                     <div class="save-changes-button">
                         <button type="submit" class="button" id="save-changes-btn-general"
-                            ng-click="submitSaveChanges($event, 'general-tab')"
+                            ng-click="updateELB($event)"
                             ng-disabled="isNotChanged || listenerArray.length === 0">
                             <span i18n:translate="">Save Changes</span>
                         </button>
@@ -143,6 +143,7 @@
         ${panel('elb_security_policy_dialog', security_policy_form=security_policy_form, latest_predefined_policy=latest_predefined_policy)}
         ${panel('create_bucket_dialog', create_bucket_form=create_bucket_form)}
         ${panel('elb_bucket_access_log_dialog')}
+        ${panel('elb_security_group_warning_dialog', create=False)}
     </div>
 </div>
 

--- a/eucaconsole/templates/elbs/elb_wizard.pt
+++ b/eucaconsole/templates/elbs/elb_wizard.pt
@@ -246,7 +246,7 @@
                             <div class="row">
                                 <div class="small-3 columns">&nbsp;</div>
                                 <div class="small-9 columns field inline">
-                                    <button type="submit" class="button" ng-click="createELB()" id="create-elb-btn-step4" ng-disabled="isValidationError">
+                                    <button type="submit" class="button" ng-click="createELB($event)" id="create-elb-btn-step4" ng-disabled="isValidationError">
                                         <span i18n:translate="">Create Load Balancer</span>
                                     </button>
                                     <a href="${request.route_path('elbs')}"
@@ -367,6 +367,7 @@
         ${panel('select_certificate_dialog', can_list_certificates=can_list_certificates, certificate_form=certificate_form, backend_certificate_form=backend_certificate_form)}
         ${panel('elb_security_policy_dialog', security_policy_form=security_policy_form, latest_predefined_policy=latest_predefined_policy)}
         ${panel('elb_bucket_access_log_dialog')}
+        ${panel('elb_security_group_warning_dialog', create=True)}
         ${panel('create_bucket_dialog', create_bucket_form=create_bucket_form)}
     </div>
 </div>

--- a/eucaconsole/views/dialogs.py
+++ b/eucaconsole/views/dialogs.py
@@ -355,6 +355,14 @@ def elb_bucket_access_log_dialog(context, request):
     return dict()
 
 
+@panel_config('elb_security_group_warning_dialog', renderer='../templates/dialogs/elb_security_group_warning_dialog.pt')
+def elb_security_group_warning_dialog(context, request, create=False):
+    """ Modal confirmation when the security group rules for an ELB don't cover the listener and health check ports"""
+    return dict(
+        create=create
+    )
+
+
 @panel_config('cloudwatch_chart_dialog', renderer='../templates/dialogs/cloudwatch_chart_dialog.pt')
 def cloudwatch_chart_dialog(context, request, duration_choices=None, statistic_choices=None):
     """ Modal dialog for large CloudWatch chart"""

--- a/tests/elbs/test_elbs.py
+++ b/tests/elbs/test_elbs.py
@@ -39,9 +39,10 @@ from moto import mock_elb, mock_cloudwatch
 
 
 from eucaconsole.constants.elbs import ELB_EMPTY_DATA_MESSAGE
+from eucaconsole.forms.elbs import ELBForm, ELBHealthChecksForm
 from eucaconsole.views.elbs import ELBsJsonView, ELBView, ELBMonitoringView, ELBInstancesView, ELBHealthChecksView
 
-from tests import BaseViewTestCase, Mock
+from tests import BaseViewTestCase, BaseFormTestCase, Mock
 
 
 class MockELBMixin(object):
@@ -133,3 +134,40 @@ class ELBHealthChecksViewTests(BaseViewTestCase, MockELBMixin):
         self.assertEqual(form.ping_path.data, 'index.html')
         self.assertEqual(form.passes_until_healthy.data, '3')
         self.assertEqual(form.failures_until_unhealthy.data, '5')
+
+
+class ELBDetailPageFormTests(BaseFormTestCase, BaseViewTestCase, MockELBMixin):
+    @mock_elb
+    def test_elb_detail_page_form(self):
+        request = self.create_request()
+        elb_conn, elb = self.make_elb()
+        elb.idle_timeout = 30
+        form = ELBForm(request, elb_conn=elb_conn, elb=elb)
+        self.assertEqual(form.get_idle_timeout(elb), 30)
+        self.assertEqual(form.idle_timeout.data, 30)
+        self.assertEqual(form.logging_enabled.data, False)
+        self.assertEqual(form.bucket_name.data, None)
+        self.assertEqual(form.bucket_prefix.data, None)
+        self.assertEqual(form.collection_interval.data, '60')
+
+
+class ELBHealthChecksFormTests(BaseFormTestCase, BaseViewTestCase, MockELBMixin):
+    @mock_elb
+    def test_elb_health_checks_form(self):
+        request = self.create_request()
+        elb_conn, elb = self.make_elb()
+        elb.health_check = Mock(
+            interval=30,
+            timeout=30,
+            healthy_threshold=3,
+            unhealthy_threshold=2,
+            target='HTTP:80/index.html',
+        )
+        form = ELBHealthChecksForm(request, elb_conn=elb_conn, elb=elb)
+        self.assertEqual(form.ping_protocol.data, 'HTTP')
+        self.assertEqual(form.ping_port.data, 80)
+        self.assertEqual(form.ping_path.data, 'index.html')
+        self.assertEqual(form.time_between_pings.data, '30')
+        self.assertEqual(form.response_timeout.data, 30)
+        self.assertEqual(form.failures_until_unhealthy.data, '2')
+        self.assertEqual(form.passes_until_healthy.data, '3')


### PR DESCRIPTION
Implements the following for https://eucalyptus.atlassian.net/browse/GUI-2024 (for VPC clouds)...
- If the selected security groups don't contain rules that open required ports for the listeners or health check when creating an ELB, display a warning dialog notifying the user to open the relevant ports in the listed security group(s).  The modal dialog is displayed when clicking the "Create Load Balancer" button.
- The ELB detail page (General tab) also implements the above when the "Save Changes" button is clicked.