### PR TITLE
GUI-2286 Complete integration of tag editor into scaling group view

### DIFF
--- a/eucaconsole/static/css/widgets/tag-editor.css
+++ b/eucaconsole/static/css/widgets/tag-editor.css
@@ -3,5 +3,6 @@
 .tag-editor .item-list .item .propagates { color: #777; }
 .tag-editor .item-list .item a.remove { color: #FFF; margin-left: 5px; }
 .tag-editor .add-label { color: #5A5A5A; margin-bottom: 6px; }
-.tag-editor.ng-invalid .button { background-color: #FFF; border-color: #B3B3B3; color: #B3B3B3; }
+.tag-editor .tag-entry-result { display: none; }
+.tag-editor.ng-pristine .button { background-color: #FFF; border-color: #B3B3B3; color: #B3B3B3; }
 .tag-editor input.ng-invalid.ng-touched ~ .error { display: block; }

--- a/eucaconsole/static/js/pages/scalinggroup.js
+++ b/eucaconsole/static/js/pages/scalinggroup.js
@@ -8,7 +8,11 @@
 angular.module('ScalingGroupPage', ['TagEditorModule', 'EucaConsoleUtils'])
     .directive('chosen', function () {
         return {
+            scope: {
+                model: '=ngModel'
+            },
             restrict: 'A',
+            require: 'ngModel',
             link: function (scope, element, attrs, ctrl) {
                 var chosenAttrs = JSON.parse(attrs.chosen || '{}');
                 for(var key in attrs) {
@@ -21,9 +25,8 @@ angular.module('ScalingGroupPage', ['TagEditorModule', 'EucaConsoleUtils'])
                 element.on('change', function () {
                     scope.validateField(this);
                 });
-                scope.validateField(element);
             },
-            controller: ['$scope', function ($scope) {
+            controller: ['$scope', '$element', function ($scope, $element) {
                 $scope.validateField = function (element) {
                     var isValid = element[0].selectedIndex > -1,
                         form = this.form && this.form.name,
@@ -33,6 +36,10 @@ angular.module('ScalingGroupPage', ['TagEditorModule', 'EucaConsoleUtils'])
                         $scope[form][field].$setValidity('required', isValid);
                     }
                 };
+
+                $scope.$watch('model', function () {
+                    $scope.validateField($element);
+                });
             }]
         };
     })
@@ -82,7 +89,9 @@ angular.module('ScalingGroupPage', ['TagEditorModule', 'EucaConsoleUtils'])
             // scalingGroupName, policiesCount
             $scope.scalingGroupName = options.scaling_group_name;
             $scope.policiesCount = options.policies_count;
+            $scope.terminationPoliciesUpdate = options.termination_policies;
             $scope.terminationPoliciesOrder = options.termination_policies;
+            $scope.availabilityZones = options.availability_zones;
             $scope.setInitialValues();
             $scope.initChosenSelectors();
             $scope.setWatch();
@@ -172,9 +181,6 @@ angular.module('ScalingGroupPage', ['TagEditorModule', 'EucaConsoleUtils'])
             // Stay button is clicked on the warning unsaved changes modal
             $(document).on('click', '#unsaved-changes-warning-modal-leave-link', function () {
                 $scope.openModalById($scope.pendingModalID);
-            });
-            $scope.$on('tagUpdate', function($event) {
-                $scope.isNotChanged = false;
             });
             $(document).on('submit', '[data-reveal] form', function () {
                 $(this).find('.dialog-submit-button').css('display', 'none');                

--- a/eucaconsole/static/js/pages/scalinggroup.js
+++ b/eucaconsole/static/js/pages/scalinggroup.js
@@ -6,6 +6,36 @@
 
 // Scaling Group page includes the AutoScale tag editor, so pull in that module as well.
 angular.module('ScalingGroupPage', ['TagEditorModule', 'EucaConsoleUtils'])
+    .directive('chosen', function () {
+        return {
+            restrict: 'A',
+            link: function (scope, element, attrs, ctrl) {
+                var chosenAttrs = JSON.parse(attrs.chosen || '{}');
+                for(var key in attrs) {
+                    if(/^chosen-.*/.test(key)) {
+                        chosenAttrs[key] = attrs[key];
+                    }
+                }
+                element.chosen(chosenAttrs);
+
+                element.on('change', function () {
+                    scope.validateField(this);
+                });
+                scope.validateField(element);
+            },
+            controller: ['$scope', function ($scope) {
+                $scope.validateField = function (element) {
+                    var isValid = element[0].selectedIndex > -1,
+                        form = this.form && this.form.name,
+                        field = this.name;
+
+                    if(form && field) {
+                        $scope[form][field].$setValidity('required', isValid);
+                    }
+                };
+            }]
+        };
+    })
     .controller('ScalingGroupPageCtrl', function ($scope, $timeout, eucaUnescapeJson, eucaNumbersOnly) {
         $scope.minSize = 1;
         $scope.desiredCapacity = 1;
@@ -19,6 +49,10 @@ angular.module('ScalingGroupPage', ['TagEditorModule', 'EucaConsoleUtils'])
         $scope.isSubmitted = false;
         $scope.pendingModalID = '';
 
+        $scope.isInvalid = function () {
+            return $scope.scalingGroupDetailForm.$invalid;
+        };
+
         $scope.initChosenSelectors = function () {
             $('#launch_config').chosen({'width': '80%', search_contains: true});
             // Remove the option if it has no vpc subnet ID associated
@@ -30,8 +64,8 @@ angular.module('ScalingGroupPage', ['TagEditorModule', 'EucaConsoleUtils'])
                 } 
             }
             $('#vpc_subnet').chosen({'width': '80%', search_contains: true});
-            $('#availability_zones').chosen({'width': '80%', search_contains: true});
-            $('#termination_policies').chosen({'width': '70%', search_contains: true});
+            //$('#availability_zones').chosen({'width': '80%', search_contains: true});
+            //$('#termination_policies').chosen({'width': '70%', search_contains: true});
         };
         $scope.setInitialValues = function () {
             $scope.minSize = parseInt($('#min_size').val(), 10);

--- a/eucaconsole/static/js/pages/scalinggroup.js
+++ b/eucaconsole/static/js/pages/scalinggroup.js
@@ -71,8 +71,6 @@ angular.module('ScalingGroupPage', ['TagEditorModule', 'EucaConsoleUtils'])
                 } 
             }
             $('#vpc_subnet').chosen({'width': '80%', search_contains: true});
-            //$('#availability_zones').chosen({'width': '80%', search_contains: true});
-            //$('#termination_policies').chosen({'width': '70%', search_contains: true});
         };
         $scope.setInitialValues = function () {
             $scope.minSize = parseInt($('#min_size').val(), 10);

--- a/eucaconsole/static/js/widgets/tag-editor/tag-editor.js
+++ b/eucaconsole/static/js/widgets/tag-editor/tag-editor.js
@@ -3,7 +3,8 @@ angular.module('TagEditorModule', ['EucaConsoleUtils'])
         return {
             scope: {
                 template: '@',
-                showNameTag: '@'
+                showNameTag: '@',
+                autoscale: '@'
             },
             transclude: true,
             restrict: 'E',
@@ -11,9 +12,9 @@ angular.module('TagEditorModule', ['EucaConsoleUtils'])
             templateUrl: function (element, attributes) {
                 return attributes.template;
             },
-            controller: ['$scope', function ($scope) {
+            controller: ['$scope', '$window', function ($scope, $window) {
                 $scope.addTag = function () {
-                    if(!$scope.tagForm.$valid) {
+                    if($scope.tagForm.$pristine) {
                         return
                     }
 
@@ -42,9 +43,8 @@ angular.module('TagEditorModule', ['EucaConsoleUtils'])
                 var content = transcludeContents();
                 scope.tags = JSON.parse(content.text() || '{}');
 
-                if(!attrs.showNameTag) {
-                    attrs.showNameTag = true;
-                }
+                attrs.showNameTag = !attrs.showNameTag; // default to true
+                attrs.autoscale = !!attrs.autoscale;    // default to false
 
                 scope.updateViewValue = function () {
                     ctrl.$setViewValue(scope.tags);

--- a/eucaconsole/static/js/widgets/tag-editor/tag-editor.js
+++ b/eucaconsole/static/js/widgets/tag-editor/tag-editor.js
@@ -14,10 +14,6 @@ angular.module('TagEditorModule', ['EucaConsoleUtils'])
             },
             controller: ['$scope', '$window', function ($scope, $window) {
                 $scope.addTag = function () {
-                    if($scope.tagForm.$pristine) {
-                        return
-                    }
-
                     $scope.tags.push({
                         name: $scope.newTagKey,
                         value: $scope.newTagValue,

--- a/eucaconsole/static/sass/widgets/tag-editor.scss
+++ b/eucaconsole/static/sass/widgets/tag-editor.scss
@@ -28,7 +28,11 @@
     margin-bottom: 6px;
   }
 
-  &.ng-invalid {
+  .tag-entry-result {
+    display: none;
+  }
+
+  &.ng-pristine {
     .button {
       background-color: #FFF;
       border-color: #B3B3B3;

--- a/eucaconsole/templates/scalinggroups/scalinggroup_view.pt
+++ b/eucaconsole/templates/scalinggroups/scalinggroup_view.pt
@@ -39,10 +39,12 @@
                 </metal:block>
                 <form id="scalinggroup-detail-form" action="${request.route_path('scalinggroup_update', id=scaling_group.name)}"
                       method="post" data-abide="" name="scalingGroupDetailForm" novalidate=""
-                      tal:define="avail_zone_html_attrs {'data-placeholder': avail_zone_placeholder_text};
+                      tal:define="avail_zone_html_attrs {'data-placeholder': avail_zone_placeholder_text, 'chosen': '{&quot;width&quot;: &quot;80%&quot;, &quot;search_contains&quot;: true}'};
                                   vpc_subnet_html_attrs {'data-placeholder': ' '};
                                   load_balancers_html_attrs {'data-placeholder': ' '};
-                                  term_policies_html_attrs {'data-placeholder': termination_policies_placeholder_text};">
+                                  term_policies_html_attrs {'data-placeholder': termination_policies_placeholder_text, 'chosen': '{&quot;width&quot;: &quot;70%&quot;, &quot;search_contains&quot;: true}'};">
+
+
                     ${structure:edit_form['csrf_token']}
                     <div id="capacity-section">
                         <h6 i18n:translate="">Capacity</h6>
@@ -105,7 +107,7 @@
                     </tag-editor>
                     <hr />
                     <div>
-                        <button type="submit" class="button" id="save-changes-btn" ng-disabled="scalingGroupDetailForm.$invalid">
+                        <button type="submit" class="button" id="save-changes-btn" ng-disabled="isInvalid()">
                             <span tal:condition="scaling_group" i18n:translate="">Save Changes</span>
                         </button>
                         <a href="${request.route_path('scalinggroups')}"

--- a/eucaconsole/templates/scalinggroups/scalinggroup_view.pt
+++ b/eucaconsole/templates/scalinggroups/scalinggroup_view.pt
@@ -72,7 +72,7 @@
                     </div>
                     <div tal:condition="not vpc_network">
                         <input type="hidden" name="vpc_subnet" value="None" />
-                        ${panel('form_field', field=edit_form['availability_zones'], leftcol_width_large=3, rightcol_width_large=9, **avail_zone_html_attrs)}
+                        ${panel('form_field', field=edit_form['availability_zones'], ng_attrs={'model': 'availabilityZones'}, leftcol_width_large=3, rightcol_width_large=9, **avail_zone_html_attrs)}
                     </div>
                     <div class="row controls-wrapper readonly" tal:condition="vpc_network">
                         <div class="large-3 small-4 columns">

--- a/eucaconsole/templates/scalinggroups/scalinggroup_view.pt
+++ b/eucaconsole/templates/scalinggroups/scalinggroup_view.pt
@@ -99,6 +99,7 @@
                     <hr />
                     <tag-editor
                             ng-model="tags"
+                            autoscale="1"
                             template="${request.route_path('tag_editor_template')}"
                             tal:content="tags | structure">
                     </tag-editor>

--- a/eucaconsole/templates/tag-editor/tag-editor.pt
+++ b/eucaconsole/templates/tag-editor/tag-editor.pt
@@ -21,19 +21,17 @@
 
         <div class="row tagentry controls-wrapper" ng-show="tags.length &lt; 10">
             <div class="tag-entry-fields">
-                <div id="propagate-wrapper" class="large-2 medium-3 small-3 columns">
+                <div id="propagate-wrapper" class="large-2 medium-3 small-3 columns" ng-show="autoscale">
                     <input id="propagate-checkbox" class="tag-input propagate" type="checkbox"
                            ng-model="newTagPropagate"/>
                     <label for="propagate-checkbox" i18n:translate="">Propagate</label>
                     <span class="helptext-icon" data-tooltop="" i18n:attributes="title"
                           title="Propagate to instances launched by this scaling group"></span>
                 </div>
-                <div id="autoscale-tag-name-input-div" class="large-2 medium-2 small-4 columns">
+                <div id="autoscale-tag-name-input-div" class="small-4 columns"
+                    ng-class="{'large-2 medium-2': autoscale, 'large-4 medium-4': !autoscale }">
                     <input class="key" type="text" placeholder="name..."
-                           ng-model="newTagKey" name="key" tag-name="" required=""/>
-                    <span class="error" ng-show="tagForm.key.$error.required" i18n:translate="">
-                        Tag name is required
-                    </span>
+                           ng-model="newTagKey" name="key" tag-name=""/>
                     <span class="error" ng-show="tagForm.key.$error.tagName" i18n:translate="">
                         Tag must not begin with "aws:" and its length may not be longer than 128 chars
                     </span>
@@ -52,7 +50,7 @@
                        id="add-tag-btn" title="Add tag" i18n:translate="">Add Tag</a>
                 </div>
             </div>
-            <div style="clear: both;">
+            <div class="tag-entry-result">
                 <textarea id="tags" name="tags" class="">{{ tags }}</textarea>
             </div>
         </div>

--- a/eucaconsole/views/scalinggroups.py
+++ b/eucaconsole/views/scalinggroups.py
@@ -448,6 +448,7 @@ class ScalingGroupView(BaseScalingGroupView, DeleteScalingGroupMixin):
         return BaseView.escape_json(json.dumps({
             'scaling_group_name': self.scaling_group.name,
             'policies_count': len(self.policies),
+            'availability_zones': self.scaling_group.availability_zones,
             'termination_policies': self.scaling_group.termination_policies,
         }))
 

--- a/eucaconsole/views/scalinggroups.py
+++ b/eucaconsole/views/scalinggroups.py
@@ -253,10 +253,15 @@ class BaseScalingGroupView(BaseView):
         tags_list = json.loads(tags_json) if tags_json else []
         tags = []
         for tag in tags_list:
+
+            value = tag.get('value')
+            if value is not None:
+                value = self.unescape_braces(value.strip())
+
             tags.append(Tag(
                 resource_id=scaling_group_name,
                 key=self.unescape_braces(tag.get('name', '').strip()),
-                value=self.unescape_braces(tag.get('value', '').strip()),
+                value=value,
                 propagate_at_launch=tag.get('propagate_at_launch', False),
             ))
         return tags


### PR DESCRIPTION
* Minor changes to tag-editor directive to better integrate into form-level validation.
* Parameterize tag-editor for autoscale.
* Create chosen directive to allow the chosen library to better integrate with angular and actually work with angular form validation.  This will move to it's own module in the next integration PR.
* Update template to inject form data into angular-land.