### PR TITLE
GUI-2415: Revert to passing volume ids via filters to prevent errors w.r.t. missing volumes

### DIFF
--- a/eucaconsole/views/snapshots.py
+++ b/eucaconsole/views/snapshots.py
@@ -202,7 +202,8 @@ class SnapshotsJsonView(LandingPageView):
         else:
             filtered_snapshots = self.get_items()
         volume_ids = list(set([snapshot.volume_id for snapshot in filtered_snapshots]))
-        volumes = self.conn.get_all_volumes(volume_ids=volume_ids) if self.conn else []
+        # NOTE: Do not pass volume_ids directly to conn.get_all_volumes(), see GUI-2415
+        volumes = self.conn.get_all_volumes(filters={'volume_id': volume_ids}) if self.conn else []
         for snapshot in filtered_snapshots:
             volume = [volume for volume in volumes if volume.id == snapshot.volume_id]
             volume_name = ''

--- a/tests/snapshots/test_snapshots.py
+++ b/tests/snapshots/test_snapshots.py
@@ -129,25 +129,6 @@ class SnapshotDeleteFormTestCase(BaseFormTestCase):
         self.assertTrue(issubclass(self.form_class, BaseSecureForm))
 
 
-class MockSnapshotsJsonViewTestCase(BaseViewTestCase, MockSnapshotMixin):
-
-    @mock_ec2
-    def test_snapshots_json_view(self):
-        request = self.create_request()
-        request.path = '/snapshots/json'
-        request.params['csrf_token'] = request.session.get_csrf_token()
-        snapshot, conn = self.make_snapshot()
-        snapshot.add_tag('Name', 'snapshot_one')
-        view = SnapshotsJsonView(request, conn=conn, enable_filters=False).snapshots_json()
-        results = view.get('results')
-        self.assertEqual(len(results), 1)
-        snapshot = results[0]
-        self.assertEqual(snapshot.get('name'), u'{0} ({1})'.format('snapshot_one', snapshot.get('id')))
-        self.assertEqual(snapshot.get('description'), u'test snapshot description')
-        self.assertEqual(snapshot.get('exists_volume'), True)
-        self.assertEqual(snapshot.get('volume_size'), 1)
-
-
 class MockSnapshotViewTestCase(BaseViewTestCase, MockSnapshotMixin):
 
     @mock_ec2


### PR DESCRIPTION
… also remove problematic unit test.

Fixes https://eucalyptus.atlassian.net/browse/GUI-2415