### PR TITLE
GUI-2420: Hide errant "Monitor" action in volume tile on instance-volumes page

### DIFF
--- a/eucaconsole/templates/instances/instance_volumes.pt
+++ b/eucaconsole/templates/instances/instance_volumes.pt
@@ -39,14 +39,14 @@
                 <div class="tile item" ng-repeat="volume in volumes | orderBy: -attach_time" ng-cloak="">
                     <div class="header">
                         <strong><a ng-href="/volumes/{{ volume.id }}">{{ volume.name || volume.id }}</a></strong>
-                        <span id="tile-item-dropdown_{{ volume.id }}" class="tiny secondary button dropdown" data-dropdown="item-dropdown_{{ volume.id }}"><i class="grid-action"></i></span>
-                        <ul id="item-dropdown_{{ volume.id }}" class="f-dropdown" data-dropdown-content="">
-                            <li ng-show="volume.attach_status == 'attached'">
+                        <span id="tile-item-dropdown_{{ volume.id }}" class="tiny secondary button dropdown"
+                              ng-show="volume.attach_status == 'attached'"
+                              data-dropdown="item-dropdown_{{ volume.id }}"><i class="grid-action"></i></span>
+                        <ul id="item-dropdown_{{ volume.id }}" class="f-dropdown" data-dropdown-content=""
+                            ng-show="volume.attach_status == 'attached'">
+                            <li>
                                 <a ng-click="detachModal(volume.id, volume.device, '${request.route_path('instance_json', id=instance.id)}', volume.detach_form_action)"
                                     i18n:translate="">Detach volume</a>
-                            </li>
-                            <li>
-                                <a ng-href="/volumes/{{ volume.id }}/monitoring" i18n:translate="">Monitor</a>
                             </li>
                         </ul>
                     </div>


### PR DESCRIPTION
…also hide "Detach" action if volume is still in attaching state.

Fixes https://eucalyptus.atlassian.net/browse/GUI-2420