### PR TITLE
GUI-2257: Prevent validation error for unit field when creating alarms for ASG metrics

### DIFF
--- a/eucaconsole/constants/cloudwatch.py
+++ b/eucaconsole/constants/cloudwatch.py
@@ -32,13 +32,14 @@ from ..i18n import _
 
 
 METRIC_TYPES = [
-    {'namespace': 'AWS/AutoScaling', 'name': 'GroupDesiredCapacity', 'unit': 'Count'},
-    {'namespace': 'AWS/AutoScaling', 'name': 'GroupInServiceInstances', 'unit': 'Count'},
-    {'namespace': 'AWS/AutoScaling', 'name': 'GroupMaxSize', 'unit': 'Count'},
-    {'namespace': 'AWS/AutoScaling', 'name': 'GroupMinSize', 'unit': 'Count'},
-    {'namespace': 'AWS/AutoScaling', 'name': 'GroupPendingInstances', 'unit': 'Count'},
-    {'namespace': 'AWS/AutoScaling', 'name': 'GroupTerminatingInstances', 'unit': 'Count'},
-    {'namespace': 'AWS/AutoScaling', 'name': 'GroupTotalInstances', 'unit': 'Count'},
+    # NOTE: AWS/AutoScaling metrics expect 'None' (not 'Count' or None) as the unit
+    {'namespace': 'AWS/AutoScaling', 'name': 'GroupDesiredCapacity', 'unit': 'None'},
+    {'namespace': 'AWS/AutoScaling', 'name': 'GroupInServiceInstances', 'unit': 'None'},
+    {'namespace': 'AWS/AutoScaling', 'name': 'GroupMaxSize', 'unit': 'None'},
+    {'namespace': 'AWS/AutoScaling', 'name': 'GroupMinSize', 'unit': 'None'},
+    {'namespace': 'AWS/AutoScaling', 'name': 'GroupPendingInstances', 'unit': 'None'},
+    {'namespace': 'AWS/AutoScaling', 'name': 'GroupTerminatingInstances', 'unit': 'None'},
+    {'namespace': 'AWS/AutoScaling', 'name': 'GroupTotalInstances', 'unit': 'None'},
     {'namespace': 'AWS/EBS', 'name': 'VolumeIdleTime', 'unit': 'Seconds'},
     {'namespace': 'AWS/EBS', 'name': 'VolumeQueueLength', 'unit': 'Count'},
     {'namespace': 'AWS/EBS', 'name': 'VolumeReadBytes', 'unit': 'Bytes'},

--- a/eucaconsole/constants/cloudwatch.py
+++ b/eucaconsole/constants/cloudwatch.py
@@ -32,13 +32,13 @@ from ..i18n import _
 
 
 METRIC_TYPES = [
-    {'namespace': 'AWS/AutoScaling', 'name': 'GroupDesiredCapacity', 'unit': 'None'},
-    {'namespace': 'AWS/AutoScaling', 'name': 'GroupInServiceInstances', 'unit': 'None'},
-    {'namespace': 'AWS/AutoScaling', 'name': 'GroupMaxSize', 'unit': 'None'},
-    {'namespace': 'AWS/AutoScaling', 'name': 'GroupMinSize', 'unit': 'None'},
-    {'namespace': 'AWS/AutoScaling', 'name': 'GroupPendingInstances', 'unit': 'None'},
-    {'namespace': 'AWS/AutoScaling', 'name': 'GroupTerminatingInstances', 'unit': 'None'},
-    {'namespace': 'AWS/AutoScaling', 'name': 'GroupTotalInstances', 'unit': 'None'},
+    {'namespace': 'AWS/AutoScaling', 'name': 'GroupDesiredCapacity', 'unit': 'Count'},
+    {'namespace': 'AWS/AutoScaling', 'name': 'GroupInServiceInstances', 'unit': 'Count'},
+    {'namespace': 'AWS/AutoScaling', 'name': 'GroupMaxSize', 'unit': 'Count'},
+    {'namespace': 'AWS/AutoScaling', 'name': 'GroupMinSize', 'unit': 'Count'},
+    {'namespace': 'AWS/AutoScaling', 'name': 'GroupPendingInstances', 'unit': 'Count'},
+    {'namespace': 'AWS/AutoScaling', 'name': 'GroupTerminatingInstances', 'unit': 'Count'},
+    {'namespace': 'AWS/AutoScaling', 'name': 'GroupTotalInstances', 'unit': 'Count'},
     {'namespace': 'AWS/EBS', 'name': 'VolumeIdleTime', 'unit': 'Seconds'},
     {'namespace': 'AWS/EBS', 'name': 'VolumeQueueLength', 'unit': 'Count'},
     {'namespace': 'AWS/EBS', 'name': 'VolumeReadBytes', 'unit': 'Bytes'},

--- a/eucaconsole/forms/alarms.py
+++ b/eucaconsole/forms/alarms.py
@@ -186,7 +186,7 @@ class CloudWatchAlarmCreateForm(BaseSecureForm):
 
     @staticmethod
     def get_unit_choices():
-        choices = [BLANK_CHOICE]
+        choices = [BLANK_CHOICE, ('None', 'None')]
         for choice in Metric.Units:
             if choice is not None:
                 choices.append((choice, choice))


### PR DESCRIPTION
https://eucalyptus.atlassian.net/browse/GUI-2257
The affected alarms require a "Count" unit to create the alarm.  Added this value to the constants for AWS/Autoscaling alarm types.