### PR TITLE
GUI-2257: Prevent validation error for unit field when creating alarms for ASG metrics

### DIFF
--- a/eucaconsole/constants/cloudwatch.py
+++ b/eucaconsole/constants/cloudwatch.py
@@ -32,6 +32,7 @@ from ..i18n import _
 
 
 METRIC_TYPES = [
+    # NOTE: AWS/AutoScaling metrics expect 'None' (not 'Count' or None) as the unit
     {'namespace': 'AWS/AutoScaling', 'name': 'GroupDesiredCapacity', 'unit': 'None'},
     {'namespace': 'AWS/AutoScaling', 'name': 'GroupInServiceInstances', 'unit': 'None'},
     {'namespace': 'AWS/AutoScaling', 'name': 'GroupMaxSize', 'unit': 'None'},

--- a/eucaconsole/forms/alarms.py
+++ b/eucaconsole/forms/alarms.py
@@ -187,7 +187,7 @@ class CloudWatchAlarmCreateForm(BaseSecureForm):
 
     @staticmethod
     def get_unit_choices():
-        choices = [BLANK_CHOICE]
+        choices = [BLANK_CHOICE, ('None', 'None')]
         for choice in Metric.Units:
             if choice is not None:
                 choices.append((choice, choice))


### PR DESCRIPTION
Fixes https://eucalyptus.atlassian.net/browse/GUI-2257 (for 4.2.2)