### PR TITLE
GUI-2305: Implement multi-select operations on the volumes landing page

### DIFF
--- a/eucaconsole/routes.py
+++ b/eucaconsole/routes.py
@@ -83,7 +83,6 @@ urls = [
     Route(name='instance_create', pattern='/instances/new'),
     Route(name='instance_launch', pattern='/instances/launch'),
     Route(name='instance_view', pattern='/instances/{id}'),
-    Route(name='instance_json', pattern='/instances/{id}/json'),
     Route(name='instance_userdata_json', pattern='/instances/{id}/userdata'),
     Route(name='instance_more', pattern='/instances/{id}/more'),
     Route(name='instance_more_launch', pattern='/instances/{id}/more/launch'),

--- a/eucaconsole/static/css/pages/accounts.css
+++ b/eucaconsole/static/css/pages/accounts.css
@@ -45,8 +45,9 @@
 .tile .header { position: relative; height: 24px; }
 .tile .header a { overflow: hidden; white-space: nowrap; text-overflow: ellipsis; display: block; padding: 6px 30px 4px 10px; color: #5a5a5a; font-weight: bold; }
 .tile .header a:hover { color: #007dba; }
+.tile .header a.has-checkbox { padding-left: 24px; }
 .tile .header strong { font-weight: normal; }
-.tile .header .item-checkbox { position: relative; left: -2px; margin-right: 2px; }
+.tile .header .item-checkbox { position: absolute; top: 10px; left: 7px; }
 .tile .header .f-dropdown a { color: #444; font-weight: normal; overflow: visible; white-space: normal; text-overflow: inherit; }
 .tile .content { padding: 8px; font-size: 0.9em; }
 .tile .content a { color: #007dba; }

--- a/eucaconsole/static/css/pages/alarms.css
+++ b/eucaconsole/static/css/pages/alarms.css
@@ -45,8 +45,9 @@
 .tile .header { position: relative; height: 24px; }
 .tile .header a { overflow: hidden; white-space: nowrap; text-overflow: ellipsis; display: block; padding: 6px 30px 4px 10px; color: #5a5a5a; font-weight: bold; }
 .tile .header a:hover { color: #007dba; }
+.tile .header a.has-checkbox { padding-left: 24px; }
 .tile .header strong { font-weight: normal; }
-.tile .header .item-checkbox { position: relative; left: -2px; margin-right: 2px; }
+.tile .header .item-checkbox { position: absolute; top: 10px; left: 7px; }
 .tile .header .f-dropdown a { color: #444; font-weight: normal; overflow: visible; white-space: normal; text-overflow: inherit; }
 .tile .content { padding: 8px; font-size: 0.9em; }
 .tile .content a { color: #007dba; }

--- a/eucaconsole/static/css/pages/bucket_contents.css
+++ b/eucaconsole/static/css/pages/bucket_contents.css
@@ -45,8 +45,9 @@
 .tile .header { position: relative; height: 24px; }
 .tile .header a { overflow: hidden; white-space: nowrap; text-overflow: ellipsis; display: block; padding: 6px 30px 4px 10px; color: #5a5a5a; font-weight: bold; }
 .tile .header a:hover { color: #007dba; }
+.tile .header a.has-checkbox { padding-left: 24px; }
 .tile .header strong { font-weight: normal; }
-.tile .header .item-checkbox { position: relative; left: -2px; margin-right: 2px; }
+.tile .header .item-checkbox { position: absolute; top: 10px; left: 7px; }
 .tile .header .f-dropdown a { color: #444; font-weight: normal; overflow: visible; white-space: normal; text-overflow: inherit; }
 .tile .content { padding: 8px; font-size: 0.9em; }
 .tile .content a { color: #007dba; }

--- a/eucaconsole/static/css/pages/buckets.css
+++ b/eucaconsole/static/css/pages/buckets.css
@@ -45,8 +45,9 @@
 .tile .header { position: relative; height: 24px; }
 .tile .header a { overflow: hidden; white-space: nowrap; text-overflow: ellipsis; display: block; padding: 6px 30px 4px 10px; color: #5a5a5a; font-weight: bold; }
 .tile .header a:hover { color: #007dba; }
+.tile .header a.has-checkbox { padding-left: 24px; }
 .tile .header strong { font-weight: normal; }
-.tile .header .item-checkbox { position: relative; left: -2px; margin-right: 2px; }
+.tile .header .item-checkbox { position: absolute; top: 10px; left: 7px; }
 .tile .header .f-dropdown a { color: #444; font-weight: normal; overflow: visible; white-space: normal; text-overflow: inherit; }
 .tile .content { padding: 8px; font-size: 0.9em; }
 .tile .content a { color: #007dba; }

--- a/eucaconsole/static/css/pages/elb.css
+++ b/eucaconsole/static/css/pages/elb.css
@@ -45,8 +45,9 @@
 .tile .header { position: relative; height: 24px; }
 .tile .header a { overflow: hidden; white-space: nowrap; text-overflow: ellipsis; display: block; padding: 6px 30px 4px 10px; color: #5a5a5a; font-weight: bold; }
 .tile .header a:hover { color: #007dba; }
+.tile .header a.has-checkbox { padding-left: 24px; }
 .tile .header strong { font-weight: normal; }
-.tile .header .item-checkbox { position: relative; left: -2px; margin-right: 2px; }
+.tile .header .item-checkbox { position: absolute; top: 10px; left: 7px; }
 .tile .header .f-dropdown a { color: #444; font-weight: normal; overflow: visible; white-space: normal; text-overflow: inherit; }
 .tile .content { padding: 8px; font-size: 0.9em; }
 .tile .content a { color: #007dba; }

--- a/eucaconsole/static/css/pages/elbs.css
+++ b/eucaconsole/static/css/pages/elbs.css
@@ -41,8 +41,9 @@
 .tile .header { position: relative; height: 24px; }
 .tile .header a { overflow: hidden; white-space: nowrap; text-overflow: ellipsis; display: block; padding: 6px 30px 4px 10px; color: #5a5a5a; font-weight: bold; }
 .tile .header a:hover { color: #007dba; }
+.tile .header a.has-checkbox { padding-left: 24px; }
 .tile .header strong { font-weight: normal; }
-.tile .header .item-checkbox { position: relative; left: -2px; margin-right: 2px; }
+.tile .header .item-checkbox { position: absolute; top: 10px; left: 7px; }
 .tile .header .f-dropdown a { color: #444; font-weight: normal; overflow: visible; white-space: normal; text-overflow: inherit; }
 .tile .content { padding: 8px; font-size: 0.9em; }
 .tile .content a { color: #007dba; }

--- a/eucaconsole/static/css/pages/groups.css
+++ b/eucaconsole/static/css/pages/groups.css
@@ -45,8 +45,9 @@
 .tile .header { position: relative; height: 24px; }
 .tile .header a { overflow: hidden; white-space: nowrap; text-overflow: ellipsis; display: block; padding: 6px 30px 4px 10px; color: #5a5a5a; font-weight: bold; }
 .tile .header a:hover { color: #007dba; }
+.tile .header a.has-checkbox { padding-left: 24px; }
 .tile .header strong { font-weight: normal; }
-.tile .header .item-checkbox { position: relative; left: -2px; margin-right: 2px; }
+.tile .header .item-checkbox { position: absolute; top: 10px; left: 7px; }
 .tile .header .f-dropdown a { color: #444; font-weight: normal; overflow: visible; white-space: normal; text-overflow: inherit; }
 .tile .content { padding: 8px; font-size: 0.9em; }
 .tile .content a { color: #007dba; }

--- a/eucaconsole/static/css/pages/images.css
+++ b/eucaconsole/static/css/pages/images.css
@@ -45,8 +45,9 @@
 .tile .header { position: relative; height: 24px; }
 .tile .header a { overflow: hidden; white-space: nowrap; text-overflow: ellipsis; display: block; padding: 6px 30px 4px 10px; color: #5a5a5a; font-weight: bold; }
 .tile .header a:hover { color: #007dba; }
+.tile .header a.has-checkbox { padding-left: 24px; }
 .tile .header strong { font-weight: normal; }
-.tile .header .item-checkbox { position: relative; left: -2px; margin-right: 2px; }
+.tile .header .item-checkbox { position: absolute; top: 10px; left: 7px; }
 .tile .header .f-dropdown a { color: #444; font-weight: normal; overflow: visible; white-space: normal; text-overflow: inherit; }
 .tile .content { padding: 8px; font-size: 0.9em; }
 .tile .content a { color: #007dba; }

--- a/eucaconsole/static/css/pages/instance.css
+++ b/eucaconsole/static/css/pages/instance.css
@@ -45,8 +45,9 @@
 .tile .header { position: relative; height: 24px; }
 .tile .header a { overflow: hidden; white-space: nowrap; text-overflow: ellipsis; display: block; padding: 6px 30px 4px 10px; color: #5a5a5a; font-weight: bold; }
 .tile .header a:hover { color: #007dba; }
+.tile .header a.has-checkbox { padding-left: 24px; }
 .tile .header strong { font-weight: normal; }
-.tile .header .item-checkbox { position: relative; left: -2px; margin-right: 2px; }
+.tile .header .item-checkbox { position: absolute; top: 10px; left: 7px; }
 .tile .header .f-dropdown a { color: #444; font-weight: normal; overflow: visible; white-space: normal; text-overflow: inherit; }
 .tile .content { padding: 8px; font-size: 0.9em; }
 .tile .content a { color: #007dba; }

--- a/eucaconsole/static/css/pages/instance_types.css
+++ b/eucaconsole/static/css/pages/instance_types.css
@@ -45,8 +45,9 @@
 .tile .header { position: relative; height: 24px; }
 .tile .header a { overflow: hidden; white-space: nowrap; text-overflow: ellipsis; display: block; padding: 6px 30px 4px 10px; color: #5a5a5a; font-weight: bold; }
 .tile .header a:hover { color: #007dba; }
+.tile .header a.has-checkbox { padding-left: 24px; }
 .tile .header strong { font-weight: normal; }
-.tile .header .item-checkbox { position: relative; left: -2px; margin-right: 2px; }
+.tile .header .item-checkbox { position: absolute; top: 10px; left: 7px; }
 .tile .header .f-dropdown a { color: #444; font-weight: normal; overflow: visible; white-space: normal; text-overflow: inherit; }
 .tile .content { padding: 8px; font-size: 0.9em; }
 .tile .content a { color: #007dba; }

--- a/eucaconsole/static/css/pages/instances.css
+++ b/eucaconsole/static/css/pages/instances.css
@@ -45,8 +45,9 @@
 .tile .header { position: relative; height: 24px; }
 .tile .header a { overflow: hidden; white-space: nowrap; text-overflow: ellipsis; display: block; padding: 6px 30px 4px 10px; color: #5a5a5a; font-weight: bold; }
 .tile .header a:hover { color: #007dba; }
+.tile .header a.has-checkbox { padding-left: 24px; }
 .tile .header strong { font-weight: normal; }
-.tile .header .item-checkbox { position: relative; left: -2px; margin-right: 2px; }
+.tile .header .item-checkbox { position: absolute; top: 10px; left: 7px; }
 .tile .header .f-dropdown a { color: #444; font-weight: normal; overflow: visible; white-space: normal; text-overflow: inherit; }
 .tile .content { padding: 8px; font-size: 0.9em; }
 .tile .content a { color: #007dba; }

--- a/eucaconsole/static/css/pages/ipaddresses.css
+++ b/eucaconsole/static/css/pages/ipaddresses.css
@@ -41,8 +41,9 @@
 .tile .header { position: relative; height: 24px; }
 .tile .header a { overflow: hidden; white-space: nowrap; text-overflow: ellipsis; display: block; padding: 6px 30px 4px 10px; color: #5a5a5a; font-weight: bold; }
 .tile .header a:hover { color: #007dba; }
+.tile .header a.has-checkbox { padding-left: 24px; }
 .tile .header strong { font-weight: normal; }
-.tile .header .item-checkbox { position: relative; left: -2px; margin-right: 2px; }
+.tile .header .item-checkbox { position: absolute; top: 10px; left: 7px; }
 .tile .header .f-dropdown a { color: #444; font-weight: normal; overflow: visible; white-space: normal; text-overflow: inherit; }
 .tile .content { padding: 8px; font-size: 0.9em; }
 .tile .content a { color: #007dba; }

--- a/eucaconsole/static/css/pages/keypairs.css
+++ b/eucaconsole/static/css/pages/keypairs.css
@@ -41,8 +41,9 @@
 .tile .header { position: relative; height: 24px; }
 .tile .header a { overflow: hidden; white-space: nowrap; text-overflow: ellipsis; display: block; padding: 6px 30px 4px 10px; color: #5a5a5a; font-weight: bold; }
 .tile .header a:hover { color: #007dba; }
+.tile .header a.has-checkbox { padding-left: 24px; }
 .tile .header strong { font-weight: normal; }
-.tile .header .item-checkbox { position: relative; left: -2px; margin-right: 2px; }
+.tile .header .item-checkbox { position: absolute; top: 10px; left: 7px; }
 .tile .header .f-dropdown a { color: #444; font-weight: normal; overflow: visible; white-space: normal; text-overflow: inherit; }
 .tile .content { padding: 8px; font-size: 0.9em; }
 .tile .content a { color: #007dba; }

--- a/eucaconsole/static/css/pages/launchconfigs.css
+++ b/eucaconsole/static/css/pages/launchconfigs.css
@@ -41,8 +41,9 @@
 .tile .header { position: relative; height: 24px; }
 .tile .header a { overflow: hidden; white-space: nowrap; text-overflow: ellipsis; display: block; padding: 6px 30px 4px 10px; color: #5a5a5a; font-weight: bold; }
 .tile .header a:hover { color: #007dba; }
+.tile .header a.has-checkbox { padding-left: 24px; }
 .tile .header strong { font-weight: normal; }
-.tile .header .item-checkbox { position: relative; left: -2px; margin-right: 2px; }
+.tile .header .item-checkbox { position: absolute; top: 10px; left: 7px; }
 .tile .header .f-dropdown a { color: #444; font-weight: normal; overflow: visible; white-space: normal; text-overflow: inherit; }
 .tile .content { padding: 8px; font-size: 0.9em; }
 .tile .content a { color: #007dba; }

--- a/eucaconsole/static/css/pages/metrics.css
+++ b/eucaconsole/static/css/pages/metrics.css
@@ -45,8 +45,9 @@
 .tile .header { position: relative; height: 24px; }
 .tile .header a { overflow: hidden; white-space: nowrap; text-overflow: ellipsis; display: block; padding: 6px 30px 4px 10px; color: #5a5a5a; font-weight: bold; }
 .tile .header a:hover { color: #007dba; }
+.tile .header a.has-checkbox { padding-left: 24px; }
 .tile .header strong { font-weight: normal; }
-.tile .header .item-checkbox { position: relative; left: -2px; margin-right: 2px; }
+.tile .header .item-checkbox { position: absolute; top: 10px; left: 7px; }
 .tile .header .f-dropdown a { color: #444; font-weight: normal; overflow: visible; white-space: normal; text-overflow: inherit; }
 .tile .content { padding: 8px; font-size: 0.9em; }
 .tile .content a { color: #007dba; }

--- a/eucaconsole/static/css/pages/roles.css
+++ b/eucaconsole/static/css/pages/roles.css
@@ -45,8 +45,9 @@
 .tile .header { position: relative; height: 24px; }
 .tile .header a { overflow: hidden; white-space: nowrap; text-overflow: ellipsis; display: block; padding: 6px 30px 4px 10px; color: #5a5a5a; font-weight: bold; }
 .tile .header a:hover { color: #007dba; }
+.tile .header a.has-checkbox { padding-left: 24px; }
 .tile .header strong { font-weight: normal; }
-.tile .header .item-checkbox { position: relative; left: -2px; margin-right: 2px; }
+.tile .header .item-checkbox { position: absolute; top: 10px; left: 7px; }
 .tile .header .f-dropdown a { color: #444; font-weight: normal; overflow: visible; white-space: normal; text-overflow: inherit; }
 .tile .content { padding: 8px; font-size: 0.9em; }
 .tile .content a { color: #007dba; }

--- a/eucaconsole/static/css/pages/scalinggroup.css
+++ b/eucaconsole/static/css/pages/scalinggroup.css
@@ -45,8 +45,9 @@
 .tile .header { position: relative; height: 24px; }
 .tile .header a { overflow: hidden; white-space: nowrap; text-overflow: ellipsis; display: block; padding: 6px 30px 4px 10px; color: #5a5a5a; font-weight: bold; }
 .tile .header a:hover { color: #007dba; }
+.tile .header a.has-checkbox { padding-left: 24px; }
 .tile .header strong { font-weight: normal; }
-.tile .header .item-checkbox { position: relative; left: -2px; margin-right: 2px; }
+.tile .header .item-checkbox { position: absolute; top: 10px; left: 7px; }
 .tile .header .f-dropdown a { color: #444; font-weight: normal; overflow: visible; white-space: normal; text-overflow: inherit; }
 .tile .content { padding: 8px; font-size: 0.9em; }
 .tile .content a { color: #007dba; }

--- a/eucaconsole/static/css/pages/scalinggroups.css
+++ b/eucaconsole/static/css/pages/scalinggroups.css
@@ -45,8 +45,9 @@
 .tile .header { position: relative; height: 24px; }
 .tile .header a { overflow: hidden; white-space: nowrap; text-overflow: ellipsis; display: block; padding: 6px 30px 4px 10px; color: #5a5a5a; font-weight: bold; }
 .tile .header a:hover { color: #007dba; }
+.tile .header a.has-checkbox { padding-left: 24px; }
 .tile .header strong { font-weight: normal; }
-.tile .header .item-checkbox { position: relative; left: -2px; margin-right: 2px; }
+.tile .header .item-checkbox { position: absolute; top: 10px; left: 7px; }
 .tile .header .f-dropdown a { color: #444; font-weight: normal; overflow: visible; white-space: normal; text-overflow: inherit; }
 .tile .content { padding: 8px; font-size: 0.9em; }
 .tile .content a { color: #007dba; }

--- a/eucaconsole/static/css/pages/securitygroups.css
+++ b/eucaconsole/static/css/pages/securitygroups.css
@@ -41,8 +41,9 @@
 .tile .header { position: relative; height: 24px; }
 .tile .header a { overflow: hidden; white-space: nowrap; text-overflow: ellipsis; display: block; padding: 6px 30px 4px 10px; color: #5a5a5a; font-weight: bold; }
 .tile .header a:hover { color: #007dba; }
+.tile .header a.has-checkbox { padding-left: 24px; }
 .tile .header strong { font-weight: normal; }
-.tile .header .item-checkbox { position: relative; left: -2px; margin-right: 2px; }
+.tile .header .item-checkbox { position: absolute; top: 10px; left: 7px; }
 .tile .header .f-dropdown a { color: #444; font-weight: normal; overflow: visible; white-space: normal; text-overflow: inherit; }
 .tile .content { padding: 8px; font-size: 0.9em; }
 .tile .content a { color: #007dba; }

--- a/eucaconsole/static/css/pages/snapshots.css
+++ b/eucaconsole/static/css/pages/snapshots.css
@@ -45,8 +45,9 @@
 .tile .header { position: relative; height: 24px; }
 .tile .header a { overflow: hidden; white-space: nowrap; text-overflow: ellipsis; display: block; padding: 6px 30px 4px 10px; color: #5a5a5a; font-weight: bold; }
 .tile .header a:hover { color: #007dba; }
+.tile .header a.has-checkbox { padding-left: 24px; }
 .tile .header strong { font-weight: normal; }
-.tile .header .item-checkbox { position: relative; left: -2px; margin-right: 2px; }
+.tile .header .item-checkbox { position: absolute; top: 10px; left: 7px; }
 .tile .header .f-dropdown a { color: #444; font-weight: normal; overflow: visible; white-space: normal; text-overflow: inherit; }
 .tile .content { padding: 8px; font-size: 0.9em; }
 .tile .content a { color: #007dba; }

--- a/eucaconsole/static/css/pages/stack.css
+++ b/eucaconsole/static/css/pages/stack.css
@@ -41,8 +41,9 @@
 .tile .header { position: relative; height: 24px; }
 .tile .header a { overflow: hidden; white-space: nowrap; text-overflow: ellipsis; display: block; padding: 6px 30px 4px 10px; color: #5a5a5a; font-weight: bold; }
 .tile .header a:hover { color: #007dba; }
+.tile .header a.has-checkbox { padding-left: 24px; }
 .tile .header strong { font-weight: normal; }
-.tile .header .item-checkbox { position: relative; left: -2px; margin-right: 2px; }
+.tile .header .item-checkbox { position: absolute; top: 10px; left: 7px; }
 .tile .header .f-dropdown a { color: #444; font-weight: normal; overflow: visible; white-space: normal; text-overflow: inherit; }
 .tile .content { padding: 8px; font-size: 0.9em; }
 .tile .content a { color: #007dba; }

--- a/eucaconsole/static/css/pages/stacks.css
+++ b/eucaconsole/static/css/pages/stacks.css
@@ -41,8 +41,9 @@
 .tile .header { position: relative; height: 24px; }
 .tile .header a { overflow: hidden; white-space: nowrap; text-overflow: ellipsis; display: block; padding: 6px 30px 4px 10px; color: #5a5a5a; font-weight: bold; }
 .tile .header a:hover { color: #007dba; }
+.tile .header a.has-checkbox { padding-left: 24px; }
 .tile .header strong { font-weight: normal; }
-.tile .header .item-checkbox { position: relative; left: -2px; margin-right: 2px; }
+.tile .header .item-checkbox { position: absolute; top: 10px; left: 7px; }
 .tile .header .f-dropdown a { color: #444; font-weight: normal; overflow: visible; white-space: normal; text-overflow: inherit; }
 .tile .content { padding: 8px; font-size: 0.9em; }
 .tile .content a { color: #007dba; }

--- a/eucaconsole/static/css/pages/user.css
+++ b/eucaconsole/static/css/pages/user.css
@@ -45,8 +45,9 @@
 .tile .header { position: relative; height: 24px; }
 .tile .header a { overflow: hidden; white-space: nowrap; text-overflow: ellipsis; display: block; padding: 6px 30px 4px 10px; color: #5a5a5a; font-weight: bold; }
 .tile .header a:hover { color: #007dba; }
+.tile .header a.has-checkbox { padding-left: 24px; }
 .tile .header strong { font-weight: normal; }
-.tile .header .item-checkbox { position: relative; left: -2px; margin-right: 2px; }
+.tile .header .item-checkbox { position: absolute; top: 10px; left: 7px; }
 .tile .header .f-dropdown a { color: #444; font-weight: normal; overflow: visible; white-space: normal; text-overflow: inherit; }
 .tile .content { padding: 8px; font-size: 0.9em; }
 .tile .content a { color: #007dba; }

--- a/eucaconsole/static/css/pages/users.css
+++ b/eucaconsole/static/css/pages/users.css
@@ -45,8 +45,9 @@
 .tile .header { position: relative; height: 24px; }
 .tile .header a { overflow: hidden; white-space: nowrap; text-overflow: ellipsis; display: block; padding: 6px 30px 4px 10px; color: #5a5a5a; font-weight: bold; }
 .tile .header a:hover { color: #007dba; }
+.tile .header a.has-checkbox { padding-left: 24px; }
 .tile .header strong { font-weight: normal; }
-.tile .header .item-checkbox { position: relative; left: -2px; margin-right: 2px; }
+.tile .header .item-checkbox { position: absolute; top: 10px; left: 7px; }
 .tile .header .f-dropdown a { color: #444; font-weight: normal; overflow: visible; white-space: normal; text-overflow: inherit; }
 .tile .content { padding: 8px; font-size: 0.9em; }
 .tile .content a { color: #007dba; }

--- a/eucaconsole/static/css/pages/volume.css
+++ b/eucaconsole/static/css/pages/volume.css
@@ -45,8 +45,9 @@
 .tile .header { position: relative; height: 24px; }
 .tile .header a { overflow: hidden; white-space: nowrap; text-overflow: ellipsis; display: block; padding: 6px 30px 4px 10px; color: #5a5a5a; font-weight: bold; }
 .tile .header a:hover { color: #007dba; }
+.tile .header a.has-checkbox { padding-left: 24px; }
 .tile .header strong { font-weight: normal; }
-.tile .header .item-checkbox { position: relative; left: -2px; margin-right: 2px; }
+.tile .header .item-checkbox { position: absolute; top: 10px; left: 7px; }
 .tile .header .f-dropdown a { color: #444; font-weight: normal; overflow: visible; white-space: normal; text-overflow: inherit; }
 .tile .content { padding: 8px; font-size: 0.9em; }
 .tile .content a { color: #007dba; }

--- a/eucaconsole/static/css/pages/volumes.css
+++ b/eucaconsole/static/css/pages/volumes.css
@@ -45,8 +45,9 @@
 .tile .header { position: relative; height: 24px; }
 .tile .header a { overflow: hidden; white-space: nowrap; text-overflow: ellipsis; display: block; padding: 6px 30px 4px 10px; color: #5a5a5a; font-weight: bold; }
 .tile .header a:hover { color: #007dba; }
+.tile .header a.has-checkbox { padding-left: 24px; }
 .tile .header strong { font-weight: normal; }
-.tile .header .item-checkbox { position: relative; left: -2px; margin-right: 2px; }
+.tile .header .item-checkbox { position: absolute; top: 10px; left: 7px; }
 .tile .header .f-dropdown a { color: #444; font-weight: normal; overflow: visible; white-space: normal; text-overflow: inherit; }
 .tile .content { padding: 8px; font-size: 0.9em; }
 .tile .content a { color: #007dba; }

--- a/eucaconsole/static/js/jasmine-spec/spec_volumes.js
+++ b/eucaconsole/static/js/jasmine-spec/spec_volumes.js
@@ -70,11 +70,6 @@ describe("VolumesPage", function() {
             scope.revealModal('a', {name: "vol"});
             expect(scope.volumeName).toEqual('vol');
         });
-
-        it("Should set instanceName when revealModal() is called and action is detach", function() {
-            scope.revealModal('detach', {instance_name: "inst"});
-            expect(scope.instanceName).toEqual('inst');
-        });
     });
 
     describe("Function detachModal() Test", function() {

--- a/eucaconsole/static/js/jasmine-spec/spec_volumes.js
+++ b/eucaconsole/static/js/jasmine-spec/spec_volumes.js
@@ -51,10 +51,10 @@ describe("VolumesPage", function() {
         });
     });
 
-    describe("Function initPage() Test", function() {
+    describe("Function initController() Test", function() {
 
-        it("Should set instanceByZone when initPage() is called", function() {
-            scope.initPage('{"zone": "zone"}');
+        it("Should set instanceByZone when initcontroller() is called", function() {
+            scope.initController('{"instances_by_zone": {"zone": "zone"}}');
             expect(scope.instancesByZone.zone).toEqual('zone');
         });
     });
@@ -80,12 +80,12 @@ describe("VolumesPage", function() {
     describe("Function detachModal() Test", function() {
 
         it("Should set volumeID when detachModal() is called", function() {
-            scope.detachModal({id: "v-12345678"}, 'url');
+            scope.detachModal({id: "v-12345678"});
             expect(scope.volumeID).toEqual('v-12345678');
         });
 
         it("Should set instanceName when revealModal() is called", function() {
-            scope.detachModal({instance_name: "inst"}, 'url');
+            scope.detachModal({instance_name: "inst"});
             expect(scope.instanceName).toEqual('inst');
         });
     });

--- a/eucaconsole/static/js/pages/instance_volumes.js
+++ b/eucaconsole/static/js/pages/instance_volumes.js
@@ -88,19 +88,14 @@ angular.module('InstanceVolumes', ['EucaConsoleUtils'])
             $scope.detachFormAction = action;
             modal.foundation('reveal', 'open');
         };
-        $scope.detachModal = function (volume, device_name, url, action) {
+        $scope.detachModal = function (volume, isRootVolume, action) {
             $scope.detachVolumeName = volume;
             $scope.detachFormAction = action;
-            $http.get(url).success(function(oData) {
-                var results = oData ? oData.results : '';
-                if (results) {
-                    if (results.root_device_name == device_name) {
-                        $('#detach-volume-warn-modal').foundation('reveal', 'open');
-                    } else {
-                        $('#detach-volume-modal').foundation('reveal', 'open');
-                    }
-                }
-            });
+            if (isRootVolume) {
+                $('#detach-volume-warn-modal').foundation('reveal', 'open');
+            } else {
+                $('#detach-volume-modal').foundation('reveal', 'open');
+            }
         };
     })
 ;

--- a/eucaconsole/static/js/pages/volume.js
+++ b/eucaconsole/static/js/pages/volume.js
@@ -231,25 +231,19 @@ angular.module('VolumePage', ['TagEditor', 'EucaConsoleUtils'])
                }
             });
         };
-        $scope.detachModal = function (device_name, url) {
+        $scope.detachModal = function (isRootVolume) {
             var warnModalID = 'detach-volume-warn-modal',
                 detachModalID = 'detach-volume-modal';
-
-            $http.get(url).success(function(oData) {
-                var results = oData ? oData.results : '';
-                if (results) {
-                    if (results.root_device_name === device_name) {
-                        $scope.pendingModalID = warnModalID;
-                    } else {
-                        $scope.pendingModalID = detachModalID;
-                    }
-                    if ($scope.existsUnsavedTag() || $scope.isNotChanged === false) {
-                        $scope.openModalById('unsaved-changes-warning-modal');
-                        return;
-                    } 
-                    $scope.openModalById($scope.pendingModalID);
-                }
-            });
+            if (isRootVolume === 'True') {
+                $scope.pendingModalID = warnModalID;
+            } else {
+                $scope.pendingModalID = detachModalID;
+            }
+            if ($scope.existsUnsavedTag() || $scope.isNotChanged === false) {
+                $scope.openModalById('unsaved-changes-warning-modal');
+                return;
+            }
+            $scope.openModalById($scope.pendingModalID);
         };
     })
 ;

--- a/eucaconsole/static/js/pages/volumes.js
+++ b/eucaconsole/static/js/pages/volumes.js
@@ -12,6 +12,7 @@ angular.module('VolumesPage', ['LandingPage', 'EucaConsoleUtils', 'smart-table']
         $scope.instanceName = '';
         $scope.instancesByZone = '';
         $scope.instanceChoices = {};
+        $scope.instanceJsonUrl = '';
         $scope.multipleItemsSelected = false;
         $scope.initController = function (optionsJson) {
             var options = JSON.parse(eucaUnescapeJson(optionsJson));

--- a/eucaconsole/static/js/pages/volumes.js
+++ b/eucaconsole/static/js/pages/volumes.js
@@ -51,17 +51,23 @@ angular.module('VolumesPage', ['LandingPage', 'EucaConsoleUtils', 'smart-table']
             var modal = $('#' + action + '-volume-modal');
             var itemIDs = [];
             var itemNames = [];
+            var instanceNames = [];
             selectedItems.forEach(function (item) {
                 itemIDs.push(item.id);
                 itemNames.push(item.name || item.id);
+                if (action === 'detach') {
+                    instanceNames.push(item.instance_name);
+                }
             });
             $scope.multipleItemsSelected = itemIDs.length > 1;
             $scope.volumeID = itemIDs.join(', ');
             $scope.volumeName = itemNames.join(', ');
+            $scope.instanceName = instanceNames.join(', ');
             modal.foundation('reveal', 'open');
         };
         $scope.detachModal = function (item) {
             $scope.volumeID = item.id;
+            $scope.volumeName = item.name;
             $scope.instanceName = item.instance_name;
             var url = $scope.instanceJsonUrl;
             url = url.replace('_id_', item.instance);

--- a/eucaconsole/static/js/pages/volumes.js
+++ b/eucaconsole/static/js/pages/volumes.js
@@ -13,8 +13,10 @@ angular.module('VolumesPage', ['LandingPage', 'EucaConsoleUtils', 'smart-table']
         $scope.instancesByZone = '';
         $scope.instanceChoices = {};
         $scope.multipleItemsSelected = false;
-        $scope.initPage = function (instancesByZone) {
-            $scope.instancesByZone = JSON.parse(eucaUnescapeJson(instancesByZone));
+        $scope.initController = function (optionsJson) {
+            var options = JSON.parse(eucaUnescapeJson(optionsJson));
+            $scope.instancesByZone = options.instances_by_zone;
+            $scope.instanceJsonUrl = options.instance_json_url;
         };
         $scope.revealModal = function (action, volume) {
             var modal = $('#' + action + '-volume-modal'),
@@ -58,14 +60,15 @@ angular.module('VolumesPage', ['LandingPage', 'EucaConsoleUtils', 'smart-table']
             $scope.volumeName = itemNames.join(', ');
             modal.foundation('reveal', 'open');
         };
-        $scope.detachModal = function (item, url) {
+        $scope.detachModal = function (item) {
             $scope.volumeID = item.id;
             $scope.instanceName = item.instance_name;
+            var url = $scope.instanceJsonUrl;
             url = url.replace('_id_', item.instance);
             $http.get(url).success(function(oData) {
                 var results = oData ? oData.results : '';
                 if (results) {
-                    if (results.root_device_name == item.device) {
+                    if (results.root_device_name === item.device) {
                         $('#detach-volume-warn-modal').foundation('reveal', 'open');
                     } else {
                         $('#detach-volume-modal').foundation('reveal', 'open');

--- a/eucaconsole/static/js/pages/volumes.js
+++ b/eucaconsole/static/js/pages/volumes.js
@@ -12,6 +12,7 @@ angular.module('VolumesPage', ['LandingPage', 'EucaConsoleUtils', 'smart-table']
         $scope.instanceName = '';
         $scope.instancesByZone = '';
         $scope.instanceChoices = {};
+        $scope.multipleItemsSelected = false;
         $scope.initPage = function (instancesByZone) {
             $scope.instancesByZone = JSON.parse(eucaUnescapeJson(instancesByZone));
         };
@@ -42,6 +43,19 @@ angular.module('VolumesPage', ['LandingPage', 'EucaConsoleUtils', 'smart-table']
                     }, 50);
                 });
             }
+            modal.foundation('reveal', 'open');
+        };
+        $scope.revealMultiSelectModal = function (action, selectedItems) {
+            var modal = $('#' + action + '-volume-modal');
+            var itemIDs = [];
+            var itemNames = [];
+            selectedItems.forEach(function (item) {
+                itemIDs.push(item.id);
+                itemNames.push(item.name || item.id);
+            });
+            $scope.multipleItemsSelected = itemIDs.length > 1;
+            $scope.volumeID = itemIDs.join(', ');
+            $scope.volumeName = itemNames.join(', ');
             modal.foundation('reveal', 'open');
         };
         $scope.detachModal = function (item, url) {

--- a/eucaconsole/static/js/pages/volumes.js
+++ b/eucaconsole/static/js/pages/volumes.js
@@ -12,21 +12,17 @@ angular.module('VolumesPage', ['LandingPage', 'EucaConsoleUtils', 'smart-table']
         $scope.instanceName = '';
         $scope.instancesByZone = '';
         $scope.instanceChoices = {};
-        $scope.instanceJsonUrl = '';
         $scope.multipleItemsSelected = false;
+        $scope.rootVolumes = [];
         $scope.initController = function (optionsJson) {
             var options = JSON.parse(eucaUnescapeJson(optionsJson));
             $scope.instancesByZone = options.instances_by_zone;
-            $scope.instanceJsonUrl = options.instance_json_url;
         };
         $scope.revealModal = function (action, volume) {
             var modal = $('#' + action + '-volume-modal'),
                 volumeZone = volume.zone;
             $scope.volumeID = volume.id;
             $scope.volumeName = volume.name;
-            if (action === 'detach') {
-                $scope.instanceName = volume.instance_name;
-            }
             if (action === 'attach') {
                 // Set instance choices for attach to instance widget
                 modal.on('open.fndtn.reveal', function() {
@@ -56,9 +52,6 @@ angular.module('VolumesPage', ['LandingPage', 'EucaConsoleUtils', 'smart-table']
             selectedItems.forEach(function (item) {
                 itemIDs.push(item.id);
                 itemNames.push(item.name || item.id);
-                if (action === 'detach') {
-                    instanceNames.push(item.instance_name);
-                }
             });
             $scope.multipleItemsSelected = itemIDs.length > 1;
             $scope.volumeID = itemIDs.join(', ');
@@ -66,22 +59,42 @@ angular.module('VolumesPage', ['LandingPage', 'EucaConsoleUtils', 'smart-table']
             $scope.instanceName = instanceNames.join(', ');
             modal.foundation('reveal', 'open');
         };
+        $scope.revealMultiSelectDetachModal = function (selectedItems) {
+            // Multi-select Detach operation requires special handling of root volumes in EBS-backed instances
+            var modal = $('#detach-volume-modal');
+            var itemIDs = [];
+            var itemNames = [];
+            var instanceNames = [];
+            var rootVolumes = [];
+            selectedItems.forEach(function (item) {
+                if (item.is_root_volume) {
+                    rootVolumes.push({
+                        volume: item.name,
+                        instance: item.instance_name
+                    });
+                } else {
+                    itemIDs.push(item.id);
+                    itemNames.push(item.name || item.id);
+                    instanceNames.push(item.instance_name);
+                }
+            });
+            $scope.multipleItemsSelected = selectedItems.length > 1;
+            $scope.volumeID = itemIDs.join(', ');
+            $scope.volumeName = itemNames.join(', ');
+            $scope.instanceName = instanceNames.join(', ');
+            $scope.rootVolumes = rootVolumes;
+            modal.foundation('reveal', 'open');
+        };
         $scope.detachModal = function (item) {
+            // Handles Detach action from single item actions menu
             $scope.volumeID = item.id;
             $scope.volumeName = item.name;
             $scope.instanceName = item.instance_name;
-            var url = $scope.instanceJsonUrl;
-            url = url.replace('_id_', item.instance);
-            $http.get(url).success(function(oData) {
-                var results = oData ? oData.results : '';
-                if (results) {
-                    if (results.root_device_name === item.device) {
-                        $('#detach-volume-warn-modal').foundation('reveal', 'open');
-                    } else {
-                        $('#detach-volume-modal').foundation('reveal', 'open');
-                    }
-                }
-            });
+            if (item.is_root_volume) {
+                $('#detach-volume-warn-modal').foundation('reveal', 'open');
+            } else {
+                $('#detach-volume-modal').foundation('reveal', 'open');
+            }
         };
         $scope.getDeviceSuggestion = function () {
             // TODO: the url shouldn't be built by hand, pass value from request.route_path!

--- a/eucaconsole/static/sass/includes/_landingpage.scss
+++ b/eucaconsole/static/sass/includes/_landingpage.scss
@@ -186,14 +186,17 @@ $dropdown-border-color: $hp-gray-65;
             &:hover {
                 color: $hp-accessible-blue;
             }
+            &.has-checkbox {
+                padding-left: 24px;
+            }
         }
         strong {
             font-weight: normal;
         }
         .item-checkbox {
-            position: relative;
-            left: -2px;
-            margin-right: 2px;
+            position: absolute;
+            top: 10px;
+            left: 7px;
         }
         .f-dropdown a {
             color: $euca-darkgrey;

--- a/eucaconsole/templates/dialogs/volume_dialogs.pt
+++ b/eucaconsole/templates/dialogs/volume_dialogs.pt
@@ -46,17 +46,29 @@
          tal:define="landingpage_action request.route_path('volumes_detach') + layout.querystring;
                      detailpage_action request.route_path('volume_detach', id=volume.id) if volume else '';
                      action landingpage_action if landingpage else detailpage_action;">
-        <h3 i18n:translate="">Detach volume</h3>
+        <h3>
+            <span i18n:translate="" ng-if="!multipleItemsSelected">Detach volume</span>
+            <span i18n:translate="" ng-if="multipleItemsSelected">Detach volumes</span>
+        </h3>
         <p>
             <span i18n:translate="">If you detach a volume, the instance can no longer read or write to it.</span>
         </p>
         <p>
             <span i18n:translate="">Are you sure you want to detach volume</span>
-            <span tal:condition="volume"><b>${volume_name}</b></span>
-            <span tal:condition="not volume"><b>{{ volumeID }}</b></span>
-            <span i18n:translate="">from instance</span>
-            <strong tal:condition="not landingpage">${instance_name}</strong>
-            <strong tal:condition="landingpage">{{ instanceName }}</strong>?
+            <span ng-if="!multipleItemsSelected">
+                <span tal:condition="volume"><b>${volume_name}</b></span>
+                <span tal:condition="not volume"><b>{{ volumeName }}</b></span>
+                <span i18n:translate="">from instance</span>
+                <strong tal:condition="not landingpage">${instance_name}</strong>
+                <strong tal:condition="landingpage">{{ instanceName }}</strong>?
+            </span>
+            <span ng-if="multipleItemsSelected">
+                <span ng-repeat="vol in volumeName.split(', ')">
+                    <strong>{{ vol }}</strong>
+                    <span i18n:translate="">from instance</span>
+                    <strong>{{ instanceName.split(', ')[$index] }}</strong><span ng-hide="$last">, </span><span i18n:translate="" ng-show="$last">?</span>
+                </span>
+            </span>
         </p>
         <form method="post" id="detach-form" data-abide="" action="${action}">
             ${structure:detach_form['csrf_token']}
@@ -64,7 +76,10 @@
                 <input type="hidden" name="volume_id" value="{{ volumeID }}" />
             </div>
             <div class="dialog-submit-button">
-                <button type="submit" id="detach_volume_submit_button" class="button expand" i18n:translate="">Yes, Detach Volume</button>
+                <button type="submit" id="detach_volume_submit_button" class="button expand">
+                    <span i18n:translate="" ng-if="!multipleItemsSelected">Yes, Detach Volume</span>
+                    <span i18n:translate="" ng-if="multipleItemsSelected">Yes, Detach Volumes</span>
+                </button>
             </div>
             <div class="dialog-progress-display hide">
                 <span i18n:translate="">Sending request </span>&nbsp;<i class="busy"></i>

--- a/eucaconsole/templates/dialogs/volume_dialogs.pt
+++ b/eucaconsole/templates/dialogs/volume_dialogs.pt
@@ -50,10 +50,34 @@
             <span i18n:translate="" ng-if="!multipleItemsSelected">Detach volume</span>
             <span i18n:translate="" ng-if="multipleItemsSelected">Detach volumes</span>
         </h3>
-        <p>
+        <div ng-if="rootVolumes.length" tal:condition="landingpage">
+            <p i18n:translate="">
+                The volume(s) below are the root volume of an EBS-backed instance and cannot be detached.
+                To delete the volume(s), terminate the respective instance.
+            </p>
+            <table class="table">
+                <thead>
+                    <tr>
+                        <th i18n:translate="">Volume</th>
+                        <th i18n:translate="">Instance</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr ng-repeat="vol in rootVolumes">
+                        <td><strong>{{ vol.volume }}</strong></td>
+                        <td><strong>{{ vol.instance }}</strong></td>
+                    </tr>
+                </tbody>
+            </table>
+            <hr />
+        </div>
+        <!-- The ng-if here and elsewhere is to handle multi-select detach operations where some of the volumes
+             are root volumes for EBS-backed instances.  The first condition handles the landing page case,
+             while the remainder is for the detail page !-->
+        <p ng-if="volumeName || volumeAttachStatus &amp;&amp; volumeAttachStatus === 'attached'">
             <span i18n:translate="">If you detach a volume, the instance can no longer read or write to it.</span>
         </p>
-        <p>
+        <p ng-if="volumeName || volumeAttachStatus &amp;&amp; volumeAttachStatus === 'attached'">
             <span i18n:translate="">Are you sure you want to detach volume</span>
             <span ng-if="!multipleItemsSelected">
                 <span tal:condition="volume"><b>${volume_name}</b></span>
@@ -70,15 +94,15 @@
                 </span>
             </span>
         </p>
-        <form method="post" id="detach-form" data-abide="" action="${action}">
+        <form method="post" id="detach-form" data-abide="" action="${action}"
+              ng-if="volumeName || volumeAttachStatus &amp;&amp; volumeAttachStatus === 'attached'">
             ${structure:detach_form['csrf_token']}
             <div tal:condition="landingpage" tal:omit-tag="">
                 <input type="hidden" name="volume_id" value="{{ volumeID }}" />
             </div>
             <div class="dialog-submit-button">
                 <button type="submit" id="detach_volume_submit_button" class="button expand">
-                    <span i18n:translate="" ng-if="!multipleItemsSelected">Yes, Detach Volume</span>
-                    <span i18n:translate="" ng-if="multipleItemsSelected">Yes, Detach Volumes</span>
+                    <span i18n:translate="">Yes, Detach</span>
                 </button>
             </div>
             <div class="dialog-progress-display hide">

--- a/eucaconsole/templates/dialogs/volume_dialogs.pt
+++ b/eucaconsole/templates/dialogs/volume_dialogs.pt
@@ -88,11 +88,14 @@
          tal:define="landingpage_action request.route_path('volumes_delete') + layout.querystring;
                      detailpage_action request.route_path('volume_delete', id=volume.id) if volume else '';
                      action landingpage_action if landingpage else detailpage_action;">
-        <h3 i18n:translate="">Delete volume</h3>
+        <h3>
+            <span i18n:translate="" ng-if="!multipleItemsSelected">Delete volume</span>
+            <span i18n:translate="" ng-if="multipleItemsSelected">Delete volumes</span>
+        </h3>
         <p><span i18n:translate="">All data on the volumes will be destroyed.</span></p>
         <p><span i18n:translate="">Are you sure you want to delete volume</span>
            <span tal:condition="volume"><b>${volume_name}</b></span>
-           <span tal:condition="not volume"><b>{{ volumeID }}</b></span> 
+           <span tal:condition="not volume"><b>{{ volumeName }}</b></span>
            ?</p>
         <form action="${action}" method="post">
             ${structure:delete_form['csrf_token']}

--- a/eucaconsole/templates/instances/instance_volumes.pt
+++ b/eucaconsole/templates/instances/instance_volumes.pt
@@ -45,7 +45,7 @@
                         <ul id="item-dropdown_{{ volume.id }}" class="f-dropdown" data-dropdown-content=""
                             ng-show="volume.attach_status == 'attached'">
                             <li>
-                                <a ng-click="detachModal(volume.id, volume.device, '${request.route_path('instance_json', id=instance.id)}', volume.detach_form_action)"
+                                <a ng-click="detachModal(volume.id, volume.is_root_volume, volume.detach_form_action)"
                                     i18n:translate="">Detach volume</a>
                             </li>
                         </ul>

--- a/eucaconsole/templates/instances/instances.pt
+++ b/eucaconsole/templates/instances/instances.pt
@@ -114,8 +114,8 @@
                 <metal:block metal:use-macro="layout.global_macros['selectall_items_checkbox']" />
             </div>
             <div metal:fill-slot="tile_header">
-                <a ng-href="${prefix}/{{ item.id }}">
-                    <span metal:use-macro="layout.global_macros['select_item_checkbox']"></span>
+                <span metal:use-macro="layout.global_macros['select_item_checkbox']"></span>
+                <a ng-href="${prefix}/{{ item.id }}" class="has-checkbox">
                     {{ item.name }}
                 </a>
             </div>

--- a/eucaconsole/templates/ipaddresses/ipaddresses.pt
+++ b/eucaconsole/templates/ipaddresses/ipaddresses.pt
@@ -39,8 +39,8 @@
                 <metal:block metal:use-macro="layout.global_macros['selectall_items_checkbox']" />
             </div>
             <div metal:fill-slot="tile_header">
-                <a ng-href="${prefix}/{{ item.public_ip }}">
-                    <span metal:use-macro="layout.global_macros['select_item_checkbox']"></span>
+                <span metal:use-macro="layout.global_macros['select_item_checkbox']"></span>
+                <a ng-href="${prefix}/{{ item.public_ip }}" class="has-checkbox">
                     {{ item.public_ip }}
                 </a>
             </div>

--- a/eucaconsole/templates/volumes/volume_view.pt
+++ b/eucaconsole/templates/volumes/volume_view.pt
@@ -43,7 +43,7 @@
                             <a href="#" id="attach-volume-action" i18n:translate="">Attach to instance</a>
                         </li>
                         <li ng-show="volumeStatus == 'in-use' &amp;&amp; volumeAttachStatus != 'detaching'">
-                            <a ng-click="detachModal('${device_name}', '${request.route_path('instance_json', id=instance_id)}')"
+                            <a ng-click="detachModal('${is_root_volume}')"
                                id="detach-volume-action" i18n:translate="">Detach from instance</a>
                         </li>
                         <li ng-show="volumeStatus === 'available' || volumeStatus === 'failed'">

--- a/eucaconsole/templates/volumes/volumes.pt
+++ b/eucaconsole/templates/volumes/volumes.pt
@@ -39,7 +39,7 @@
                         </li>
                         <li ng-class="{'disabled': (items | filter: {selected: true, attach_status: 'attached'}).length &lt; 1}">
                             <a i18n:translate="" class="more-actions-detach"
-                               ng-click="revealMultiSelectModal('detach', (items | filter:{selected: true, attach_status: 'attached'}))">
+                               ng-click="revealMultiSelectDetachModal((items | filter:{selected: true, attach_status: 'attached'}))">
                                 Detach from instance
                             </a>
                         </li>

--- a/eucaconsole/templates/volumes/volumes.pt
+++ b/eucaconsole/templates/volumes/volumes.pt
@@ -30,7 +30,19 @@
                                 View details
                             </a>
                         </li>
+                        <li ng-class="{'disabled': (items | filter: {selected: true, status: 'available'}).length !== 1}">
+                            <a i18n:translate="" class="more-actions-attach"
+                               ng-click="revealModal('attach', (items | filter:{selected: true, status: 'available'})[0])">
+                                Attach to instance
+                            </a>
+                        </li>
                         <hr />
+                        <li ng-class="{'disabled': (items | filter: {selected: true}).length !== 1}">
+                            <a i18n:translate="" class="more-actions-snapshots"
+                               ng-href="${prefix}/{{ (items | filter: {selected: true})[0].id }}/snapshots">
+                                Manage snapshots
+                            </a>
+                        </li>
                         <li ng-class="{'disabled': (items | filter: {selected: true}).length !== 1}">
                             <a i18n:translate="" class="more-actions-monitoring"
                                ng-href="${prefix}/{{ (items | filter: {selected: true})[0].id }}/monitoring">

--- a/eucaconsole/templates/volumes/volumes.pt
+++ b/eucaconsole/templates/volumes/volumes.pt
@@ -4,7 +4,8 @@
     <link rel="stylesheet" type="text/css" href="${request.static_path('eucaconsole:static/css/pages/volumes.css')}" />
 </head>
 
-<div metal:fill-slot="main_content" ng-app="VolumesPage" ng-controller="VolumesCtrl" ng-init="initPage('${instances_by_zone}')"
+<div metal:fill-slot="main_content" ng-app="VolumesPage" ng-controller="VolumesCtrl"
+     ng-init="initController('${controller_options_json}')"
     tal:define="using_expando False;
                 expando_data_url request.route_path('volumes_expando_details', id='__id__');
                 expando_data_id '{{item.id}}'">
@@ -34,6 +35,12 @@
                             <a i18n:translate="" class="more-actions-attach"
                                ng-click="revealModal('attach', (items | filter:{selected: true, status: 'available'})[0])">
                                 Attach to instance
+                            </a>
+                        </li>
+                        <li ng-class="{'disabled': (items | filter: {selected: true, attach_status: 'attached'}).length &lt; 1}">
+                            <a i18n:translate="" class="more-actions-detach"
+                               ng-click="revealMultiSelectModal('detach', (items | filter:{selected: true, attach_status: 'attached'}))">
+                                Detach from instance
                             </a>
                         </li>
                         <hr />
@@ -84,8 +91,8 @@
                         </a>
                     </li>
                     <li ng-show="item.attach_status === 'attached' &amp;&amp; item.attach_status !== 'detaching'">
-                        <a ng-click="detachModal(item, '${request.route_path('instance_json', id='_id_')}')"
-                               class="detach-volume-action" i18n:translate="">Detach from instance</a>
+                        <a ng-click="detachModal(item)"
+                           class="detach-volume-action" i18n:translate="">Detach from instance</a>
                     </li>
                     <li ng-show="item.status === 'available' || item.status === 'failed'">
                         <a i18n:translate="" ng-click="revealModal('delete', item)" class="delete-volume-action">
@@ -188,7 +195,7 @@
                                 </a>
                             </li>
                             <li ng-show="item.attach_status === 'attached' &amp;&amp; item.attach_status !== 'detaching'">
-                                <a ng-click="detachModal(item, '${request.route_path('instance_json', id='_id_')}')"
+                                <a ng-click="detachModal(item)"
                                    class="detach-volume-action" i18n:translate="">Detach from instance</a>
                             </li>
                             <li ng-show="item.status === 'available' || item.status === 'failed'">

--- a/eucaconsole/templates/volumes/volumes.pt
+++ b/eucaconsole/templates/volumes/volumes.pt
@@ -68,8 +68,8 @@
                 <metal:block metal:use-macro="layout.global_macros['selectall_items_checkbox']" />
             </div>
             <div metal:fill-slot="tile_header">
-                <a ng-href="${prefix}/{{ item.id }}">
-                    <span metal:use-macro="layout.global_macros['select_item_checkbox']"></span>
+                <span metal:use-macro="layout.global_macros['select_item_checkbox']"></span>
+                <a ng-href="${prefix}/{{ item.id }}" class="has-checkbox">
                     {{ item.name }}
                 </a>
             </div>

--- a/eucaconsole/templates/volumes/volumes.pt
+++ b/eucaconsole/templates/volumes/volumes.pt
@@ -22,6 +22,37 @@
             <div metal:fill-slot="new_button">
                 <a class="button" i18n:translate="" id="create-volume-btn"
                    href="${request.route_path('volume_view', id='new')}">Create New Volume</a>
+                <metal:block metal:use-macro="layout.global_macros['more_actions']">
+                    <div metal:fill-slot="menu_items" tal:omit-tag="">
+                        <li ng-class="{'disabled': (items | filter: {selected: true}).length !== 1}">
+                            <a i18n:translate="" class="more-actions-details"
+                               ng-href="${prefix}/{{ (items | filter: {selected: true})[0].id }}">
+                                View details
+                            </a>
+                        </li>
+                        <hr />
+                        <li ng-class="{'disabled': (items | filter: {selected: true}).length !== 1}">
+                            <a i18n:translate="" class="more-actions-monitoring"
+                               ng-href="${prefix}/{{ (items | filter: {selected: true})[0].id }}/monitoring">
+                                View monitoring
+                            </a>
+                        </li>
+                        <hr />
+                        <li ng-class="{'disabled': (items | filter: {selected: true, status: 'available'}).length &lt; 1}">
+                            <a i18n:translate="" class="more-actions-delete"
+                               ng-click="revealMultiSelectModal('delete', (items | filter:{selected: true, status: 'available'}))">
+                                Delete
+                            </a>
+                        </li>
+                    </div>
+                </metal:block>
+                <metal:block metal:use-macro="layout.global_macros['selectall_items_checkbox']" />
+            </div>
+            <div metal:fill-slot="tile_header">
+                <a ng-href="${prefix}/{{ item.id }}">
+                    <span metal:use-macro="layout.global_macros['select_item_checkbox']"></span>
+                    {{ item.name }}
+                </a>
             </div>
             <div metal:fill-slot="tile_dropdown_button" tal:omit-tag="">
                 <a id="tile-item-dropdown_{{ item.id }}" class="tiny secondary button dropdown right" data-dropdown="item-dropdown_{{ item.id }}"><i class="grid-action"></i></a>
@@ -89,6 +120,7 @@
                 </div>
             </metal:block>
             <metal:block metal:fill-slot="tableview_headers">
+                <th metal:use-macro="layout.global_macros['selectall_header_checkbox']"></th>
                 <th i18n:translate="" st-skip-natural="true" st-sort="name">Name (ID)</th>
                 <th i18n:translate="" st-skip-natural="true" st-sort="status">Status</th>
                 <th i18n:translate="" st-skip-natural="true" st-sort="size">Size</th>
@@ -100,6 +132,7 @@
                 <th class="actions" i18n:translate="">Actions</th>
             </metal:block>
             <metal:block metal:fill-slot="tableview_columns">
+                <td><metal:block metal:use-macro="layout.global_macros['select_item_checkbox']" /></td>
                 <td class="breakword" id="table-id-column-{{item.id}}">
                     <span ng-show="item.status === 'deleting'">{{ item.name || item.id | ellipsis: 30 }}</span>
                     <a ng-show="item.status !== 'deleting'" ng-href="${prefix}/{{ item.id }}">{{ item.name || item.id | ellipsis: 30 }}</a>

--- a/eucaconsole/views/volumes.py
+++ b/eucaconsole/views/volumes.py
@@ -254,7 +254,7 @@ class VolumesJsonView(LandingPageView):
                     instance = [inst for inst in instances if inst.id == volume.attach_data.instance_id][0]
                     instance_name = TaggedItemView.get_display_name(instance, escapebraces=False)
                     if instance.root_device_type == 'ebs' and volume.attach_data.device == instance.root_device_name:
-                        is_root_volume = True
+                        is_root_volume = True  # Note: Check for 'True' when passed to JS via Chameleon template
                 if status != 'deleted':
                     snapshot_name = [snap.tags.get('Name') for snap in snapshots if snap.id == volume.snapshot_id]
                     if len(snapshot_name) == 0:
@@ -322,14 +322,18 @@ class VolumeView(TaggedItemView, BaseVolumeView):
         self.attach_data = self.volume.attach_data if self.volume else None
         self.volume_name = self.get_volume_name()
         self.instance_name = None
+        is_root_volume = False
         if self.attach_data is not None and self.attach_data.instance_id is not None:
             instance = self.get_instance(self.attach_data.instance_id)
             self.instance_name = TaggedItemView.get_display_name(instance)
+            if instance.root_device_type == 'ebs' and self.volume.attach_data.device == instance.root_device_name:
+                is_root_volume = True
         self.render_dict = dict(
             volume=self.volume,
             volume_name=self.volume_name,
             instance_name=self.instance_name,
             device_name=self.attach_data.device if self.attach_data else None,
+            is_root_volume=is_root_volume,
             attachment_time=self.get_attachment_time(),
             volume_form=self.volume_form,
             delete_form=self.delete_form,


### PR DESCRIPTION
#### Implements the following for https://eucalyptus.atlassian.net/browse/GUI-2305:
- Support the following actions in the More Actions menu when selecting a single item:  View details, Attach to instance, Manage snapshots, View Monitoring
- Allow one or more attached volumes to be detached from an instance, with a warning and list of volume/instance pairs displayed when the volume is root volume of an EBS-backed instance
- Allow one or more available volumes to be deleted

#### Refactoring for performance improvements:
- Refactors the Detach Volume dialog on the volumes landing page, volume detail page, and the instance volumes page to not require an additional XHR fetch to determine if the volume is a root volume of an EBS-backed instance