### PR TITLE
GUI-2545: Fix CloudWatch route name references to avoid 500 error when switching regions

### DIFF
--- a/eucaconsole/constants/__init__.py
+++ b/eucaconsole/constants/__init__.py
@@ -86,6 +86,6 @@ AWS_REGIONS = (
 LANDINGPAGE_ROUTE_NAMES = [
     'buckets', 'groups', 'images', 'instances', 'ipaddresses', 'keypairs', 'launchconfigs',
     'scalinggroups', 'securitygroups', 'snapshots', 'users', 'volumes', 'elbs', 'stacks',
-    'alarms', 'metrics'
+    'cloudwatch_alarms', 'cloudwatch_metrics'
 ]
 


### PR DESCRIPTION
… on AWS and multi-region Eucalyptus clouds

Fixes https://eucalyptus.atlassian.net/browse/GUI-2545