### PR TITLE
GUI-2572: Ensure an alarm with statistic = SampleCount displays the proper statistic on the alarm details page

### DIFF
--- a/eucaconsole/templates/cloudwatch/alarms_detail.pt
+++ b/eucaconsole/templates/cloudwatch/alarms_detail.pt
@@ -98,11 +98,11 @@
                                 </div>
                                 <div class="large-3 small-4 columns value">
                                     <select ng-model="alarm.statistic">
-                                        <option i18n:translate="" value="Average">Average</option>
-                                        <option i18n:translate="" value="Minimum">Minimum</option>
-                                        <option i18n:translate="" value="Maximum">Maximum</option>
-                                        <option i18n:translate="" value="Sum">Sum</option>
-                                        <option i18n:translate="" value="SampleCount">Sample Count</option>
+                                        <option value="Average" i18n:translate="">Average</option>
+                                        <option value="Minimum" i18n:translate="">Minimum</option>
+                                        <option value="Maximum" i18n:translate="">Maximum</option>
+                                        <option value="Sum" i18n:translate="">Sum</option>
+                                        <option value="SampleCount" i18n:translate="">Data samples</option>
                                     </select>
                                 </div>
                                 <div class="large-6 small-4 columns">

--- a/eucaconsole/templates/cloudwatch/alarms_detail.pt
+++ b/eucaconsole/templates/cloudwatch/alarms_detail.pt
@@ -98,11 +98,11 @@
                                 </div>
                                 <div class="large-3 small-4 columns value">
                                     <select ng-model="alarm.statistic">
-                                        <option i18n:translate="">Average</option>
-                                        <option i18n:translate="">Minimum</option>
-                                        <option i18n:translate="">Maximum</option>
-                                        <option i18n:translate="">Sum</option>
-                                        <option i18n:translate="">Sample Count</option>
+                                        <option i18n:translate="" value="Average">Average</option>
+                                        <option i18n:translate="" value="Minimum">Minimum</option>
+                                        <option i18n:translate="" value="Maximum">Maximum</option>
+                                        <option i18n:translate="" value="Sum">Sum</option>
+                                        <option i18n:translate="" value="SampleCount">Sample Count</option>
                                     </select>
                                 </div>
                                 <div class="large-6 small-4 columns">


### PR DESCRIPTION
...also avoids breaking statistic selection on non-English console deployments.

Fixes https://eucalyptus.atlassian.net/browse/GUI-2572