### PR TITLE
GUI-2626: Avoid 500 error when manually selecting zero non-ASG instances on ELB instances page

### DIFF
--- a/eucaconsole/views/elbs.py
+++ b/eucaconsole/views/elbs.py
@@ -867,6 +867,7 @@ class ELBInstancesView(BaseELBView):
             if not self.elb:
                 raise HTTPNotFound()
             self.cross_zone_enabled = self.is_cross_zone_enabled(elb_attrs=elb_attrs)
+            self.scaling_groups = self.autoscale_conn.get_all_groups()
         self.elb_form = ELBInstancesForm(
             self.request, elb=self.elb, cross_zone_enabled=self.cross_zone_enabled,
             formdata=self.request.params or None)
@@ -876,7 +877,6 @@ class ELBInstancesView(BaseELBView):
             cloud_type=self.cloud_type, formdata=self.request.params or None)
         search_facets = filters_form.facets
         filter_keys = ['id', 'name', 'placement', 'state', 'tags', 'vpc_subnet_display', 'vpc_name']
-        self.scaling_groups = self.autoscale_conn.get_all_groups()
         self.elb_scaling_group_names = [
             asg.name for asg in self.scaling_groups if self.elb.name in asg.load_balancers]
         self.render_dict = dict(
@@ -901,7 +901,7 @@ class ELBInstancesView(BaseELBView):
             vpc_subnets = self.request.params.getall('vpc_subnet') or []
             zones = self.request.params.getall('zone') or []
             cross_zone_enabled = self.request.params.get('cross_zone_enabled') == 'y'
-            instances = self.request.params.getall('instances') or None
+            instances = self.request.params.getall('instances') or []
             for scaling_group_name in self.elb_scaling_group_names:
                 # NOTE: Disabled checkboxes don't populate request.params.getall('instances')
                 #       So ensure ASG instances aren't de-registered when updating ELB instances list
@@ -929,12 +929,11 @@ class ELBInstancesView(BaseELBView):
         return self.render_dict
 
     def get_scaling_group_instance_ids(self, scaling_group_name):
-        with boto_error_handler(self.request):
-            scaling_groups = [asg for asg in self.scaling_groups if asg.name == scaling_group_name]
-            if scaling_groups:
-                instances = scaling_groups[0].instances or []
-                return [instance.instance_id for instance in instances]
-            return []
+        scaling_groups = [asg for asg in self.scaling_groups if asg.name == scaling_group_name]
+        if scaling_groups:
+            instances = scaling_groups[0].instances or []
+            return [instance.instance_id for instance in instances]
+        return []
 
     def is_cross_zone_enabled(self, elb_attrs=None):
         attrs = elb_attrs or self.elb.get_attributes()


### PR DESCRIPTION
…also move scaling groups API call within boto error handler.

Fixes https://eucalyptus.atlassian.net/browse/GUI-2626