### PR TITLE
GUI-2635 removed NetworkInterfaceAttachment from unsupported list

### DIFF
--- a/eucaconsole/views/stacks.py
+++ b/eucaconsole/views/stacks.py
@@ -928,7 +928,6 @@ class StackWizardView(BaseView, StackMixin):
             'AWS::CloudFront',
             'AWS::CloudTrail',
             'AWS::DynamoDB',
-            'AWS::EC2::NetworkInterfaceAttachment',
             'AWS::EC2::VPCPeeringConnection',
             'AWS::EC2::VPCConnection',
             'AWS::EC2::VPCConnectionRoute',


### PR DESCRIPTION
https://eucalyptus.atlassian.net/browse/GUI-2635