### PR TITLE
GUI-2543: Avoid threshold/dimensions nowrap styling in scaling policies table to avoid breaking outside of container

### DIFF
--- a/eucaconsole/static/css/pages/scalinggroup.css
+++ b/eucaconsole/static/css/pages/scalinggroup.css
@@ -183,8 +183,6 @@ input[type="number"] { width: 3rem; }
 #availability_zones, #termination_policies { visibility: hidden; }
 
 table.table.scaling-policies hr { margin-top: 4px; margin-bottom: 4px; }
-table.table.scaling-policies .dimension-item { white-space: nowrap; }
-table.table.scaling-policies .threshold { white-space: nowrap; }
 
 .tile { background-color: white; border: 1px solid #cccccc; width: 190px; height: 160px; }
 .tile .footer { height: 24px; padding-top: 2px; }

--- a/eucaconsole/static/sass/pages/scalinggroup.scss
+++ b/eucaconsole/static/sass/pages/scalinggroup.scss
@@ -67,12 +67,6 @@ table.table.scaling-policies {
         margin-top: 4px;
         margin-bottom: 4px;
     }
-    .dimension-item {
-        white-space: nowrap;
-    }
-    .threshold {
-        white-space: nowrap;
-    }
 }
 
 // Scaling group instances page


### PR DESCRIPTION
Fixes cross-browser styling issue for https://eucalyptus.atlassian.net/browse/GUI-2543