### PR TITLE
GUI-2708:  Move nginx log files to /var/log/nginx

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -29,8 +29,8 @@ http {
     ### Logging Settings
     ##
 
-    access_log /var/log/eucaconsole_nginx_access.log;
-    error_log /var/log/eucaconsole_nginx_error.log;
+    access_log /var/log/nginx/eucaconsole_nginx_access.log;
+    error_log /var/log/nginx/eucaconsole_nginx_error.log;
 
     ### Gzip Settings
     ##


### PR DESCRIPTION
SELinux does not normally allow HTTP daemons to write logs outside of their own log directories.  While we could technically start allowing that for our purposes, it would be safer to simply move where we put our nginx log files.

This does not affect eucaconsole.log.

This fixes [GUI-2708](https://eucalyptus.atlassian.net/browse/GUI-2708).