### PR TITLE
GUI-2745: Disable EC2 image cache by default on Eucalyptus clouds

### DIFF
--- a/conf/console.default.ini
+++ b/conf/console.default.ini
@@ -93,6 +93,7 @@ session.cookie_expires = 43200
 # configuration of regions for dogpile.cache
 cache.memory = dogpile.cache.pylibmc
 cache.memory.url = /var/run/eucaconsole/memcached.sock
+# cache durations are in seconds
 cache.short_term.expire = 60
 cache.default_term.expire = 300
 cache.long_term.expire = 3600
@@ -100,8 +101,8 @@ cache.extra_long_term.expire = 43200
 # for configuring SASL PLAIN auth
 #cache.username =
 #cache.password =
-# disable image caching on Eucalyptus if users frequently change images outside of console
-cache.images.disable = false
+# If true, disable EC2 image cache on Eucalyptus. If false, EC2 image API fetches will be cached for cache.long_term.expire duration
+cache.images.disable = true
 
 ###########################
 # WSGI server configuration

--- a/eucaconsole/views/__init__.py
+++ b/eucaconsole/views/__init__.py
@@ -253,7 +253,7 @@ class BaseView(object):
             acct = ''
         ufshost = self.get_connection().host if self.cloud_type == 'euca' else ''
         try:
-            if self.cloud_type == 'euca' and asbool(self.request.registry.settings.get('cache.images.disable', False)):
+            if self.cloud_type == 'euca' and asbool(self.request.registry.settings.get('cache.images.disable', True)):
                 return self._get_images_(owners, executors, ec2_region)
             else:
                 return self._get_images_cached_(owners, executors, ec2_region, acct, ufshost)

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+# Copyright 2013-2016 Hewlett Packard Enterprise Development LP
+#
+# Redistribution and use of this software in source and binary forms,
+# with or without modification, are permitted provided that the following
+# conditions are met:
+#
+# Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# Redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""
+Pyramid configuration tests
+
+"""
+from pyramid.paster import get_appsettings
+from pyramid.settings import asbool
+
+from tests import BaseTestCase
+
+SETTINGS = get_appsettings('conf/console.default.ini', name='main')
+
+
+class CacheImagesSettingTestCase(BaseTestCase):
+
+    def test_images_cache_is_disabled_by_default(self):
+        cache_setting = SETTINGS.get('cache.images.disable')
+        self.assertEqual(asbool(cache_setting), True)


### PR DESCRIPTION
Implements https://eucalyptus.atlassian.net/browse/GUI-2745 (for 4.4)