### PR TITLE
GUI-2777: Fix VPC subnet choices in scaling group wizard for Angular 1.5 compatibility

### DIFF
--- a/eucaconsole/static/js/pages/scalinggroup_wizard.js
+++ b/eucaconsole/static/js/pages/scalinggroup_wizard.js
@@ -21,9 +21,8 @@ angular.module('ScalingGroupWizard', ['AutoScaleTagEditor','EucaConsoleUtils', '
         $scope.vpcNetwork = '';
         $scope.vpcNetworkName = '';
         $scope.vpcSubnets = [];
-        $scope.vpcSubnetNames = '';
         $scope.vpcSubnetList = {};
-        $scope.vpcSubnetChoices = {};
+        $scope.vpcSubnetChoices = [];
         $scope.vpcSubnetZonesMap = {};
         $scope.availZones = '';
         $scope.loadBalancers = '';
@@ -127,11 +126,7 @@ angular.module('ScalingGroupWizard', ['AutoScaleTagEditor','EucaConsoleUtils', '
                 $scope.checkRequiredInput();
             });
             $scope.$watch('vpcSubnets', function (newVal) {
-                if (typeof newVal === 'undefined') {
-                    $scope.subnets = [];
-                }
                 $scope.disableVPCSubnetOptions();
-                $scope.updateSelectedVPCSubnetNames();
                 $scope.checkRequiredInput();
             }, true);
         };
@@ -161,21 +156,30 @@ angular.module('ScalingGroupWizard', ['AutoScaleTagEditor','EucaConsoleUtils', '
         };
         $scope.updateVPCSubnetChoices = function () {
             var foundVPCSubnets = false;
-            $scope.vpcSubnetChoices = {};
+            $scope.vpcSubnetChoices = [];
             $scope.vpcSubnets = [];
-            angular.forEach($scope.vpcSubnetList, function (subnet) {
-                if (subnet.vpc_id === $scope.vpcNetwork) {
-                    $scope.vpcSubnetChoices[subnet.id] = 
-                        subnet.cidr_block + ' (' + subnet.id + ') | ' + subnet.availability_zone;
+            var emptySubnetChoice;
+            angular.forEach($scope.vpcSubnetList, function (vpcSubnet) {
+                var subnetChoice;
+                if (vpcSubnet.vpc_id === $scope.vpcNetwork) {
+                    subnetChoice = {
+                        'id': vpcSubnet.id,
+                        'label': vpcSubnet.cidr_block + ' (' + vpcSubnet.id + ') | ' + vpcSubnet.availability_zone
+                    };
+                    $scope.vpcSubnetChoices.push(subnetChoice);
                     foundVPCSubnets = true;
                 }
                 // Create vpc subnet zone map to use later for disabling options
-                $scope.vpcSubnetZonesMap[subnet.id] = subnet.availability_zone;
+                $scope.vpcSubnetZonesMap[vpcSubnet.id] = vpcSubnet.availability_zone;
             }); 
             if (!foundVPCSubnets) {
                 // Case of No VPC or no existing subnets, set the default to 'None'
-                $scope.vpcSubnetChoices.None = $('#vpc_subnet_empty_option').text();
-                $scope.vpcSubnets.push('None');
+                emptySubnetChoice = {
+                    'id': 'None',
+                    'label': $('#vpc_subnet_empty_option').text()
+                };
+                $scope.vpcSubnetChoices.push(emptySubnetChoice);
+                $scope.vpcSubnets.push(emptySubnetChoice);
             }
             // Timeout is need for the chosen widget to react after Angular has updated the option list
             $timeout(function() {
@@ -218,17 +222,6 @@ angular.module('ScalingGroupWizard', ['AutoScaleTagEditor','EucaConsoleUtils', '
                 } 
             });
         };
-        $scope.updateSelectedVPCSubnetNames = function () {
-            var foundVPCSubnets = false;
-            $scope.vpcSubnetNames = [];
-            angular.forEach($scope.vpcSubnets, function (subnetID) {
-                angular.forEach($scope.vpcSubnetList, function (subnet) {
-                    if (subnetID === subnet.id) {
-                       $scope.vpcSubnetNames.push(subnet.cidr_block);
-                    }
-                });
-            });
-        }; 
         $scope.setWizardFocus = function (stepIdx) {
             var modal = $('div').filter("#step" + stepIdx);
             var inputElement = modal.find('input[type!=hidden]').get(0);

--- a/eucaconsole/templates/instances/instance_launch.pt
+++ b/eucaconsole/templates/instances/instance_launch.pt
@@ -295,11 +295,11 @@
                 <div class="section step3 hide">
                     <div class="row" ng-show="instanceVPC != ''">
                         <label i18n:translate="">Network</label>
-                        <div class="columns value">{{ instanceVPCName }}</div>
+                        <div class="columns value">{{ instanceVPC }}</div>
                     </div>
                     <div class="row" ng-show="instanceVPC != ''">
                         <label i18n:translate="">Subnet</label>
-                        <div class="columns value">{{ vpcSubnetChoices[subnetVPC] }}</div>
+                        <div class="columns value">{{ subnetVPC.label }}</div>
                     </div>
                     <div class="row">
                         <label i18n:translate="">Key</label>

--- a/eucaconsole/templates/scalinggroups/scalinggroup_wizard.pt
+++ b/eucaconsole/templates/scalinggroups/scalinggroup_wizard.pt
@@ -56,7 +56,7 @@
                             <div tal:condition="is_vpc_supported">
                                 ${panel('form_field', field=create_form['vpc_network'], leftcol_width_large=3, rightcol_width_large=9, ng_attrs={'model': 'vpcNetwork'}, leftcol_width=4, rightcol_width=8)}
                                 <div ng-show="vpcNetwork != '' &amp;&amp; vpcNetwork != 'None'">
-                                    ${panel('form_field', field=create_form['vpc_subnet'], leftcol_width=4, rightcol_width=8, leftcol_width_large=3, rightcol_width_large=9, ng_attrs={'model': 'vpcSubnets', 'options': 'k as v for (k, v) in vpcSubnetChoices'}, **vpc_subnet_html_attrs)}
+                                    ${panel('form_field', field=create_form['vpc_subnet'], leftcol_width=4, rightcol_width=8, leftcol_width_large=3, rightcol_width_large=9, ng_attrs={'model': 'vpcSubnets', 'options': 'item as item.label for item in vpcSubnetChoices track by item.id'}, **vpc_subnet_html_attrs)}
                                     <span id="vpc_subnet_empty_option" class="hide" i18n:translate="">No subnets found</span>
                                 </div>
                             </div>
@@ -157,10 +157,10 @@
                         <label i18n:translate="">VPC network:</label>
                         <div class="columns value">{{ vpcNetworkName }}</div>
                     </div>
-                    <div tal:condition="is_vpc_supported" class="row" ng-show="vpcSubnetNames.length">
+                    <div tal:condition="is_vpc_supported" class="row" ng-show="vpcSubnets.length">
                         <label i18n:translate="">VPC subnet:</label>
                         <div class="columns value">
-                            <div ng-repeat="vpcSubnetName in vpcSubnetNames">{{ vpcSubnetName }}</div>
+                            <div ng-repeat="subnet in vpcSubnets">{{ subnet.label }}</div>
                         </div>
                     </div>
                     <div class="row">


### PR DESCRIPTION
Also, fix display of VPC network/subnet choices in summary area of launch instance wizard.

https://eucalyptus.atlassian.net/browse/GUI-2777