### PR TITLE
GUI-2839: Allow broken cookie to be cleared (following console restart) when GovCloud region is mistakenly enabled

### DIFF
--- a/eucaconsole/layout.py
+++ b/eucaconsole/layout.py
@@ -72,15 +72,10 @@ class MasterLayout(object):
         self.has_regions = True
         self.default_region = ''
         if self.cloud_type == 'aws':
-            self.regions = AWS_REGIONS
-            govcloud_region_option = dict(
-                name='us-gov-west-1',
-                label='US GovCloud',
-            )
-            if asbool(request.registry.settings.get('aws.govcloud.enabled', 'false')):
-                if govcloud_region_option not in self.regions:
-                    self.regions.append(govcloud_region_option)
             self.default_region = request.registry.settings.get('aws.default.region', 'us-east-1')
+            self.regions = list(AWS_REGIONS)
+            if asbool(request.registry.settings.get('aws.govcloud.enabled', 'false')):
+                self.regions.append(dict(name='us-gov-west-1', label='US GovCloud'))
         else:
             if self.access_id:
                 host = self.request.registry.settings.get('ufshost')

--- a/eucaconsole/layout.py
+++ b/eucaconsole/layout.py
@@ -73,11 +73,13 @@ class MasterLayout(object):
         self.default_region = ''
         if self.cloud_type == 'aws':
             self.regions = AWS_REGIONS
+            govcloud_region_option = dict(
+                name='us-gov-west-1',
+                label='US GovCloud',
+            )
             if asbool(request.registry.settings.get('aws.govcloud.enabled', 'false')):
-                self.regions.append(dict(
-                    name='us-gov-west-1',
-                    label='US GovCloud',
-                ))
+                if govcloud_region_option not in self.regions:
+                    self.regions.append(govcloud_region_option)
             self.default_region = request.registry.settings.get('aws.default.region', 'us-east-1')
         else:
             if self.access_id:

--- a/eucaconsole/views/dashboard.py
+++ b/eucaconsole/views/dashboard.py
@@ -30,6 +30,8 @@ Pyramid views for Dashboard
 """
 import simplejson as json
 
+from pyramid.httpexceptions import HTTPFound
+from pyramid.security import forget
 from pyramid.view import view_config
 from boto.exception import BotoServerError
 
@@ -69,6 +71,11 @@ class DashboardView(BaseView):
 
     @view_config(route_name='dashboard', request_method='GET', renderer='../templates/dashboard.pt')
     def dashboard_home(self):
+        if self.conn is None:
+            # Handle broken connection case (e.g. configured AWS GovCloud region without proper access)
+            forget(self.request)
+            self.request.session.delete()
+            return HTTPFound(location=self.request.route_path('login'))
         with boto_error_handler(self.request):
             availability_zones = ChoicesManager(self.conn).get_availability_zones(self.conn.host)
             alarms_triggered = self.get_connection(conn_type='cloudwatch').describe_alarms(state_value="ALARM")


### PR DESCRIPTION
Also, prevent duplicate "US GovCloud" entries from displaying in region choices.

https://eucalyptus.atlassian.net/browse/GUI-2839