### PR TITLE
GUI-2875: Fix policy preview area position only when viewport height is tall enough to display Create Policy button

### DIFF
--- a/eucaconsole/static/css/pages/iam_policy_wizard.css
+++ b/eucaconsole/static/css/pages/iam_policy_wizard.css
@@ -26,7 +26,7 @@
 #policy-preview { background-color: white; padding: 1rem; margin-top: 40px; }
 #policy-preview input[type=text], #policy-preview textarea { background-color: white; }
 
-@media only screen and (min-width: 64.063em) { #policy-preview { position: fixed; min-width: 26rem; } }
+@media only screen and (min-width: 64.063em) and (min-height: 52rem) { #policy-preview { position: fixed; min-width: 26rem; } }
 #policy-generator { border-color: #cccccc; border-left: none; border-right: none; width: 100%; }
 #policy-generator tr.namespace { border-top: 1px solid #cccccc; background-color: white; }
 #policy-generator tr.namespace td { font-size: 1rem; }

--- a/eucaconsole/static/sass/pages/iam_policy_wizard.scss
+++ b/eucaconsole/static/sass/pages/iam_policy_wizard.scss
@@ -57,8 +57,9 @@
     }
 }
 
-@media only screen and (min-width: 64.063em) {  // 64.063em = large screen width
-    // Fix position of policy editor textarea to keep it visible when page scrolls
+@media only screen and (min-width: 64.063em) and (min-height: 52rem) {  // 64.063em = large screen width
+    // Fix position of policy editor textarea to keep it visible when page scrolls,
+    // and only fix position if the viewport height is tall enough to display the Create Policy button
     #policy-preview {
         position: fixed;
         min-width: 26rem;


### PR DESCRIPTION
Follow-up fix for https://eucalyptus.atlassian.net/browse/GUI-2875

Note that with the additional media query, GUI-2875 is addressed only when the viewport is tall enough to display the entire policy editor preview area.