### PR TITLE
DOC-2001: remove docs.hpcloud.com links from online help

### DIFF
--- a/eucaconsole/static/html/help/console_bucket_detail.html
+++ b/eucaconsole/static/html/help/console_bucket_detail.html
@@ -102,7 +102,7 @@
 
             <ol class="ol steps"><li class="li step stepexpand">
                     <span class="ph cmd">To edit the sharing settings associated with bucket Access Control Lists (ACLs):</span>
-                    <div class="itemgroup info"><div class="note note"><span class="notetitle">Note:</span> For more information about ACLs, see <a class="xref" href="http://docs.hpcloud.com/eucalyptus/4.3.0/#admin-guide/manage_resources_walrus.html" target="_blank">Manage Walrus Resources</a> in the <em class="ph i">Eucalyptus Administration Guide</em>.</div>
+                    <div class="itemgroup info"><div class="note note"><span class="notetitle">Note:</span> For more information about ACLs, see Manage Walrus Resources in the <em class="ph i">Eucalyptus Administration Guide</em>.</div>
 </div>
                     
                     <ol type="a" class="ol substeps">
@@ -160,7 +160,7 @@
 
                         <li class="li substep substepexpand">
                             <span class="ph cmd">Edit the values of the existing configuration, or create a new one.</span>
-                            <div class="itemgroup info"><div class="note note"><span class="notetitle">Note:</span> For more information about CORS, see <a class="xref" href="http://docs.hpcloud.com/eucalyptus/4.3.0/#shared/console_buckets_cors.html" target="_blank">Working with CORS</a> in the <em class="ph i">Eucalyptus Console Guide</em>.</div>
+                            <div class="itemgroup info"><div class="note note"><span class="notetitle">Note:</span> For more information about CORS, see Working with CORS in the <em class="ph i">Eucalyptus Console Guide</em>.</div>
 </div>
                         </li>
 

--- a/eucaconsole/static/html/help/console_instance_detail.html
+++ b/eucaconsole/static/html/help/console_instance_detail.html
@@ -64,7 +64,7 @@
                         used to define the parameters for new instances that are launched as part of your 
                         auto scaling group. Selecting this option displays the <span class="ph uicontrol">Create new launch
                             configuration</span> wizard. 
-                        <div class="note note"><span class="notetitle">Note:</span> For more information on Auto Scaling, see <a class="xref" href="http://docs.hpcloud.com/eucalyptus/4.3.0/#user-guide/autoscaling_intro.html" target="_blank">Using Auto Scaling</a> 
+                        <div class="note note"><span class="notetitle">Note:</span> For more information on Auto Scaling, see Using Auto Scaling 
                             in the <em class="ph i">Eucalyptus User Guide</em>.</div>
  </li>
 


### PR DESCRIPTION
docs.hpcloud.com links removed from 2 online help files. No new hyperlinks created at this time.